### PR TITLE
Adopt nJy in blackbody model and eclipsing binaries

### DIFF
--- a/src/tdastro/astro_utils/black_body.py
+++ b/src/tdastro/astro_utils/black_body.py
@@ -13,20 +13,28 @@ def black_body_luminosity_density_per_solid(temperature, radius, wavelengths):
     temperature : `float`
         The effective temperature of the star, in kelvins.
     radius : `float`
-        The radius of the star, in solar radii.
+        The radius of the star, in cm.
     wavelengths : `numpy.ndarray`
-        A length N array of wavelengths.
+        A length N array of wavelengths, in cm.
 
     Returns
     -------
     luminosity_density : `numpy.ndarray`
         A length N array of luminosity density values.
+        Output is in CGS units of erg/s/Hz/steradian.
+
+    Notes
+    -----
+    tdastro adopts nJy as the unit of flux density, so the output of this
+    function may need to be converted to compatible units,
+    e.g. multiply by 10^32.
     """
     black_body = BlackBody(temperature * u.K)
-    intensity_per_freq = black_body(wavelengths * u.cm).to_value(
-        u.erg * u.cm**-2 * u.s**-1 * u.steradian**-1 * u.Hz**-1
-    )
+    # Convert intensity to units compatible with nJy flux density
+    intensity_per_freq = black_body(wavelengths * u.cm).to_value(u.erg / u.s / u.cm**2 / u.Hz / u.steradian)
+    # Integral over solid angle, on surface of sphere
     surface_flux = intensity_per_freq * np.pi
-    # 4pi r^2 over 4pi
+    # Multiply to total area (4pi r^2) and divide by 4pi steradians,
+    # e.g. multiply by r^2.
     surface_area_per_solid_angle = radius**2
     return surface_flux * surface_area_per_solid_angle

--- a/src/tdastro/consts.py
+++ b/src/tdastro/consts.py
@@ -20,3 +20,10 @@ This is derived from two facts for a symmetric 2D Gaussian:
    where
    g(x,y) = 1 / (2π sigma²) exp(-(x²+y²)/2/sigma²).
 """
+
+ANGSTROM_TO_CM = (1.0 * u.AA).to_value(u.cm)
+"""Conversion factor from Angstrom to cm, 1e-8"""
+
+
+CGS_FNU_UNIT_TO_NJY = (1.0 * u.erg / u.second / u.cm**2 / u.Hz).to_value(u.nJy)
+"""Conversion factor from erg/s/cm²/Hz to nJy, 1e23"""

--- a/src/tdastro/consts.py
+++ b/src/tdastro/consts.py
@@ -26,4 +26,4 @@ ANGSTROM_TO_CM = (1.0 * u.AA).to_value(u.cm)
 
 
 CGS_FNU_UNIT_TO_NJY = (1.0 * u.erg / u.second / u.cm**2 / u.Hz).to_value(u.nJy)
-"""Conversion factor from erg/s/cm²/Hz to nJy, 1e23"""
+"""Conversion factor from erg/s/cm²/Hz to nJy, 1e32"""

--- a/tests/tdastro/astro_utils/test_black_body.py
+++ b/tests/tdastro/astro_utils/test_black_body.py
@@ -11,8 +11,8 @@ def test_bolometric_luminosity():
     radius = const.R_sun.cgs.value
     teff = (bolometric_luminosity / (4 * np.pi * radius**2 * const.sigma_sb.cgs.value)) ** 0.25
 
-    # From 10 to 100,000 Angstroms
-    wavelengths = np.logspace(5, 1, 1001) * 1e-8
+    # From 10 to 100,000 Angstroms, in cm
+    wavelengths = np.geomspace(100_000, 10, 1001) * 1e-8
     frequencies = speed_of_light / wavelengths
 
     # Multiply dL_nu / d nu / d Omega by 4pi and integrate over frequency

--- a/tests/tdastro/astro_utils/test_noise_model.py
+++ b/tests/tdastro/astro_utils/test_noise_model.py
@@ -1,7 +1,6 @@
 import numpy as np
 from numpy.testing import assert_allclose
 from tdastro.astro_utils.noise_model import poisson_flux_std
-from tdastro.consts import GAUSS_EFF_AREA2FWHM_SQ
 
 
 def test_poisson_flux_std_flux():
@@ -109,12 +108,3 @@ def test_poisson_flux_std_dark():
     )
 
     assert_allclose(flux_err, expected_flux_err, rtol=1e-10)
-
-
-def test_gauss_eff_area2fwhm_sq():
-    """Test GAUSS_EFF_AREA2FWHM_SQ to be close to 2.266
-
-    Find 2.266 here:
-    https://smtn-002.lsst.io/v/OPSIM-1171/index.html
-    """
-    assert_allclose(GAUSS_EFF_AREA2FWHM_SQ, 2.266, atol=1e-3)

--- a/tests/tdastro/sources/test_periodic_variable_star.py
+++ b/tests/tdastro/sources/test_periodic_variable_star.py
@@ -156,9 +156,9 @@ def test_eclipsing_binary_star():
     # Times in days
     times = np.linspace(0, 2.0 * period.to_value(u.day), 2 * points_per_period + 1)
     # Wavelengths in cm
-    wavelengths = np.array([4500, 6000]) * 1e-8
+    wavelengths_aa = np.array([4500, 6000])
 
-    fluxes = source.evaluate(times, wavelengths)
+    fluxes = source.evaluate(times, wavelengths_aa)
 
     # Check the fluxes are positive
     assert np.all(fluxes >= 0)

--- a/tests/tdastro/test_consts.py
+++ b/tests/tdastro/test_consts.py
@@ -1,0 +1,26 @@
+from numpy.testing import assert_allclose
+from tdastro import consts
+
+
+def test_parsec_to_cm():
+    """Check PARSEC_TO_CM constant"""
+    assert_allclose(consts.PARSEC_TO_CM, 3.08567758149137e18)
+
+
+def test_gauss_eff_area2fwhm_sq():
+    """Test GAUSS_EFF_AREA2FWHM_SQ to be close to 2.266
+
+    Find 2.266 here:
+    https://smtn-002.lsst.io/v/OPSIM-1171/index.html
+    """
+    assert_allclose(consts.GAUSS_EFF_AREA2FWHM_SQ, 2.266, atol=1e-3)
+
+
+def test_angstrom_to_cm():
+    """Check ANGSTROM_TO_CM constant"""
+    assert_allclose(consts.ANGSTROM_TO_CM, 1e-8)
+
+
+def test_cgs_fnu_unit_to_njy():
+    """Check CGS_FNU_UNIT_TO_NJY constant"""
+    assert_allclose(consts.CGS_FNU_UNIT_TO_NJY, 1e32)


### PR DESCRIPTION
This fixes periodic model to return values in nJy, and adds some comments to black-body model to highlight that it has CGS inputs and outputs.