### PR TITLE
Light curve fixes

### DIFF
--- a/src/tdastro/opsim/opsim.py
+++ b/src/tdastro/opsim/opsim.py
@@ -161,6 +161,13 @@ class OpSim:
         """Get the column names."""
         return self.table.columns
 
+    def get_filters(self):
+        """Get the unique filters in the OpSim table."""
+        colname = self.colmap.get("filter", "filter")
+        if colname not in self.table.columns:
+            raise KeyError(f"No filters column found in OpSim table. Expected column: {colname}")
+        return np.unique(self.table[colname])
+
     def has_columns(self, columns):
         """Checks whether OpSim has a column or columns while accounting
         for the colmap.

--- a/src/tdastro/utils/io_utils.py
+++ b/src/tdastro/utils/io_utils.py
@@ -161,7 +161,7 @@ def _read_lclib_data_from_open_file(input_file):
                 raise ValueError(f"Expected {len(colnames)} values on line={l_num}: {col_vals}")
             for col_idx, col in enumerate(colnames):
                 current_model[col].append(float(col_vals[col_idx]))
-        elif key == "MODEL_PARNAMES":
+        elif key == "MODEL_PARNAMES" or key == "MODEL_PARAMETERS":
             parnames = value.split(",")
         elif key == "PARVAL":
             if "," in value:

--- a/tests/tdastro/opsim/test_opsim.py
+++ b/tests/tdastro/opsim/test_opsim.py
@@ -56,6 +56,10 @@ def test_create_opsim():
     assert np.allclose(ops_data["fieldDec"], values["fieldDec"])
     assert np.allclose(ops_data["observationStartMJD"], values["observationStartMJD"])
 
+    # Without a filters column we cannot access the filters.
+    with pytest.raises(KeyError):
+        _ = ops_data.get_filters()
+
     # We can create an OpSim directly from the dictionary as well.
     ops_data2 = OpSim(pdf)
     assert len(ops_data2) == 5
@@ -77,6 +81,7 @@ def test_create_opsim_override():
         "fieldRA": np.array([15.0, 30.0, 15.0, 0.0, 60.0]),
         "fieldDec": np.array([-10.0, -5.0, 0.0, 5.0, 10.0]),
         "zp_nJy": np.ones(5),
+        "filter": np.array(["r", "g", "r", "i", "g"]),
     }
     ops_data = OpSim(
         values,
@@ -95,6 +100,10 @@ def test_create_opsim_override():
     assert ops_data.radius == 1.0
     assert ops_data.read_noise == 5.0
     assert ops_data.zp_per_sec == {"u": 25.0, "g": 26.0, "r": 27.0, "i": 28.0, "z": 29.0, "y": 30.0}
+
+    # We can access the filters.
+    filters = ops_data.get_filters()
+    assert set(filters) == {"r", "g", "i"}
 
 
 def test_create_opsim_no_zp():


### PR DESCRIPTION
Small fixes and helper functions that came up when testing with a real LCLIB file:
- Add a helper function to get the list of used filters from an OpSim
- Allow the code to load only a subset of the LCLIB bands. This is important when we only want to simulate the bands in an OpSim and the code will currently crash if we do not have a passband for each row in the LCLIB (this fixes that).
- Allow the code to work on passbands with small transmission values
- Accept "MODEL_PARAMETERS" as a header (not just "MODEL_PARNAMES")