### PR TITLE
Reduce the memory requirements for the test_snia.py

### DIFF
--- a/tests/tdastro/conftest.py
+++ b/tests/tdastro/conftest.py
@@ -48,7 +48,7 @@ def test_conditional_flow_filename(test_data_dir):
 
 @pytest.fixture
 def oversampled_observations(opsim_shorten):
-    """Return an OpSim object with 0.01 day cadence spanning year 2027."""
+    """Return an OpSim object with 0.05 day cadence spanning year 2027."""
     from tdastro.opsim.opsim import OpSim, oversample_opsim
 
     base_opsim = OpSim.from_db(opsim_shorten)
@@ -56,7 +56,7 @@ def oversampled_observations(opsim_shorten):
         base_opsim,
         pointing=(0.0, 0.0),
         search_radius=180.0,
-        delta_t=0.01,
+        delta_t=0.05,
         time_range=(61406.0, 61771.0),
         bands=None,
         strategy="darkest_sky",

--- a/tests/tdastro/opsim/test_opsim.py
+++ b/tests/tdastro/opsim/test_opsim.py
@@ -488,7 +488,7 @@ def test_oversample_opsim(opsim_shorten):
 
 def test_fixture_oversampled_observations(oversampled_observations):
     """Test the fixture oversampled_observations."""
-    assert len(oversampled_observations) == 36_500
+    assert len(oversampled_observations) == 7_300
     assert set(oversampled_observations["filter"]) == {"g", "r"}
     assert oversampled_observations["skyBrightness"].isna().sum() == 0
     assert oversampled_observations["skyBrightness"].unique().size >= 2
@@ -496,4 +496,4 @@ def test_fixture_oversampled_observations(oversampled_observations):
     assert np.all(oversampled_observations["observationStartMJD"] <= 61771.0)
     np.testing.assert_allclose(oversampled_observations["fieldRA"], 0.0)
     np.testing.assert_allclose(oversampled_observations["fieldDec"], 0.0)
-    np.testing.assert_allclose(np.diff(oversampled_observations["observationStartMJD"]), 0.01)
+    np.testing.assert_allclose(np.diff(oversampled_observations["observationStartMJD"]), 0.05)

--- a/tests/tdastro/sources/test_snia.py
+++ b/tests/tdastro/sources/test_snia.py
@@ -11,8 +11,7 @@ def test_snia_end2end(oversampled_observations, passbands_dir):
         oversampled_observations,
         passbands_dir,
         solid_angle=solid_angle,
-        nsample=None,
-        check_sncosmo=True,
+        nsample=4,
         rng_info=rng,
     )
     assert len(passbands) == 2
@@ -24,7 +23,6 @@ def test_snia_end2end(oversampled_observations, passbands_dir):
         passbands_dir,
         solid_angle=solid_angle,
         nsample=num_samples,
-        check_sncosmo=True,
         rng_info=rng,
     )
     assert len(res_list) == num_samples


### PR DESCRIPTION
Reduce the resources needed for the snia test by using a more coarsely oversampled OpSim. Instead of sampling every 0.01 day, sample every 0.05 days.

This also turns off the sncosmo check, which loads in the sncosmo model and reruns each simulation.