### PR TITLE
Conda installation instructions for optional dependencies

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -51,39 +51,55 @@ Getting Started
 You can install TDAstro from PyPI with pip or from conda-forge with conda. We recommend using a dedicated environment.
 
 .. tab-set::
+   :sync-group: packagemanager
 
-    .. tab-item:: pip
+   .. tab-item:: pip
+      :sync: pip
 
-        .. code-block:: bash
+      .. code-block:: bash
 
-           >> # Create a virtual environment
-           >> python3 -m venv ~/envs/tdastro
-           >> # Activate it
-           >> source ~/envs/tdastro/bin/activate
-           >> # Install from PyPI
-           >> python -m pip install tdastro
+         # Create a virtual environment
+         python3 -m venv ~/envs/tdastro
+         # Activate it
+         source ~/envs/tdastro/bin/activate
+         # Install from PyPI
+         python -m pip install tdastro
 
-    .. tab-item:: conda
+   .. tab-item:: conda
+      :sync: conda
 
-        .. code-block:: bash
+      .. code-block:: bash
 
-          >> # Create a virtual environment
-          >> conda create -p tdastro python=3.12
-          >> # Activate it
-          >> conda activate tdastro
-          >> # Install from conda-forge channel
-          >> conda install conda-forge::tdastro
+         # Create a virtual environment
+         conda create -p tdastro python=3.12
+         # Activate it
+         conda activate tdastro
+         # Install from conda-forge channel
+         conda install conda-forge::tdastro
 
 Since TDAstro relies on a large number of existing packages, not all of the packages
 are installed in the default configuration. For example the microlensing (`VBMicrolensing`),
 pzflow (`pzflow`), and sncosmo (`sncosmo`) packages are not included by default. If you try to
-import a module that is not installed, TDAstro will raise an ImportError with information on which
+import a module that is not installed, TDAstro will raise an `ImportError` with information on which
 packages you need to install. You will need to install these manually. You can also install all
 optional dependencies with:
 
-.. code-block:: bash
+.. tab-set::
+   :sync-group: packagemanager
 
-   >> python -m pip install 'tdastro[all]'
+   .. tab-item:: pip
+      :sync: pip
+
+      .. code-block:: bash
+
+         python -m pip install 'tdastro[all]'
+
+   .. tab-item:: conda
+      :sync: conda
+
+      .. code-block:: bash
+
+         conda install conda-forge::tdastro conda-forge::pzflow conda-forge::sncosmo
 
 See our selection of :doc:`tutorial notebooks <notebooks>` for usage examples.
 We recommend starting with the :doc:`introduction notebook <notebooks/introduction>`

--- a/src/tdastro/astro_utils/dustmap.py
+++ b/src/tdastro/astro_utils/dustmap.py
@@ -6,7 +6,8 @@ https://github.com/gregreen/dustmaps
 
 Note that the dustmaps package is not included by default, because it uses
 dependencies that may not be compatible with all systems. Users can manually
-install dustmaps in their environment with “pip install dustmaps”.
+install dustmaps in their environment with “pip install dustmaps” or
+“conda install conda-forge::dustmaps”.
 """
 
 import importlib

--- a/src/tdastro/astro_utils/passbands.py
+++ b/src/tdastro/astro_utils/passbands.py
@@ -747,7 +747,7 @@ class Passband:
             except ImportError as err:
                 raise ImportError(
                     "sncosmo package is not installed be default. You can install it with "
-                    "`pip install sncosmo`."
+                    "`pip install sncosmo` or `conda install conda-forge::sncosmo`."
                 ) from err
             bandpass = get_bandpass(bandpass)
 

--- a/src/tdastro/astro_utils/pzflow_node.py
+++ b/src/tdastro/astro_utils/pzflow_node.py
@@ -65,7 +65,8 @@ class PZFlowNode(FunctionNode, CiteClass):
             from pzflow import Flow
         except ImportError as err:
             raise ImportError(
-                "pzflow package is not installed be default. You can install it with `pip install pzflow`."
+                "pzflow package is not installed be default. You can install it with "
+                "`pip install pzflow` or `conda install conda-forge::pzflow`."
             ) from err
 
         flow_to_use = Flow(file=filename)

--- a/src/tdastro/sources/sncomso_models.py
+++ b/src/tdastro/sources/sncomso_models.py
@@ -68,7 +68,8 @@ class SncosmoWrapperModel(PhysicalModel, CiteClass):
         except ImportError as err:
             raise ImportError(
                 "sncosmo package is not installed be default. To use the SncosmoWrapperModel, "
-                "please install sncosmo. For example, you can install it with `pip install sncosmo`."
+                "please install sncosmo. For example, you can install it with "
+                "`pip install sncosmo` or `conda install conda-forge::sncosmo`."
             ) from err
 
         # We explicitly ask for and pass along the PhysicalModel parameters such


### PR DESCRIPTION
Adds more instructions about installing optional dependencies with conda, in both docs and error messages