### PR TITLE
Fix small bug in OpSim Notebook

### DIFF
--- a/docs/notebooks/opsim_notebook.ipynb
+++ b/docs/notebooks/opsim_notebook.ipynb
@@ -314,7 +314,7 @@
    "source": [
     "## Sampling\n",
     "\n",
-    "We can sample RA, Dec, and time from an `OpSim` object using the `ObsTableUniformRADECSampler` node. This will select a random observation from the OpSim and then create a random (RA, Dec) from near the center of that observation.\n",
+    "We can sample RA, Dec, and time from an `OpSim` object using the `ObsTableRADECSampler` node. This will select a random observation from the OpSim and then create a random (RA, Dec) from near the center of that observation.\n",
     "\n",
     "This allows us to generate fake query locations for testing that are compatible with arbitrary OpSims as opposed to generating a large number of fake locations and then filtering only those that match the opsim. The distribution will be weighted by the opsim's pointing. If it points at region A 90% of time time and region B 10% of the time, then 90% of the resulting points will be from region A and 10% from region B."
    ]
@@ -325,9 +325,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from tdastro.math_nodes.ra_dec_sampler import ObsTableUniformRADECSampler\n",
+    "from tdastro.math_nodes.ra_dec_sampler import ObsTableRADECSampler\n",
     "\n",
-    "sampler_node = ObsTableUniformRADECSampler(ops_data, in_order=True)\n",
+    "sampler_node = ObsTableRADECSampler(ops_data, in_order=True)\n",
     "\n",
     "# Test we can generate a single value.\n",
     "(ra, dec, time) = sampler_node.generate(num_samples=10)\n",


### PR DESCRIPTION
The notebook cell describes the behavior of the `ObsTableRADECSampler` node, but uses the `ObsTableUniformRADECSampler` (which crashes because it does not produce time).