### PR TITLE
Provide the foundation for manual surveys

### DIFF
--- a/src/lightcurvelynx/obstable/custom_survey_table.py
+++ b/src/lightcurvelynx/obstable/custom_survey_table.py
@@ -49,7 +49,7 @@ class CustomSurveyTable(ObsTable):
             # (with constant values per filter).
             if isinstance(fluxerr, list):
                 fluxerr = np.array(fluxerr)
-            elif isinstance(fluxerr, float):
+            elif isinstance(fluxerr, float) or isinstance(fluxerr, int):
                 fluxerr = np.full(len(self._table), fluxerr)
             elif fluxerr is None:
                 fluxerr = np.zeros(len(self._table))
@@ -63,8 +63,9 @@ class CustomSurveyTable(ObsTable):
                 fluxerr_array = np.zeros(len(self._table))
                 for filt, err in fluxerr.items():
                     if not isinstance(err, (float, int)):
-                        raise ValueError(
-                            "When providing a dictionary of flux errors, the values must be constants (float or int)."
+                        raise TypeError(
+                            "When providing a dictionary of flux errors, the values must be "
+                            f"constants (float or int). Found {type(err)} for filter {filt}."
                         )
                     fluxerr_array[self._table["filter"] == filt] = err
                 fluxerr = fluxerr_array
@@ -77,7 +78,10 @@ class CustomSurveyTable(ObsTable):
                 if np.any(fluxerr < 0.0):
                     raise ValueError("Flux error must be non-negative.")
             else:
-                raise ValueError("fluxerr must be a callable, np.array, float, str, list, or None.")
+                raise TypeError(
+                    "fluxerr must be a callable, np.array, float, str, list, or None. "
+                    f"Found type = {type(fluxerr)}."
+                )
         self.fluxerr = fluxerr
 
     def bandflux_error_point_source(self, bandflux, index):

--- a/src/lightcurvelynx/obstable/custom_survey_table.py
+++ b/src/lightcurvelynx/obstable/custom_survey_table.py
@@ -1,0 +1,104 @@
+import numpy as np
+
+from lightcurvelynx.obstable.obs_table import ObsTable
+
+
+class CustomSurveyTable(ObsTable):
+    """A subclass for a completely custom survey. This can be fake data,
+    ToS observations, etc.
+
+    Parameters
+    ----------
+    table : dict or pandas.core.frame.DataFrame
+        The table with all the ObsTable information.  Must have columns
+        "time", "ra", "dec", and "filter".
+    fluxerr: callable, np.array, float, dict, or str, optional
+        The information needed to compute the flux error. This can be:
+        - A function that takes in the bandflux (and the pandas table) and returns the flux error.
+        - An array or list of flux errors that is the same length as the number of observations.
+        - A constant flux error (float).
+        - The column name (str) in the table that contains the flux errors.
+        - A dictionary mapping filter names to a constant flux error (float).
+        - None, in which case the flux error will be zero.
+    colmap : dict, optional
+        A mapping of standard column names to their names in the input table.
+        For example, in Rubin's OpSim we might have the column "observationStartMJD"
+        which maps to "time". In that case we would have an entry with key="time"
+        and value="observationStartMJD".
+    **kwargs : dict
+        Additional keyword arguments to pass to the ObsTable constructor.  This includes overrides
+        for survey parameters such as:
+        - pixel_scale: The pixel scale for the camera in arcseconds per pixel.
+        - radius: The angular radius of the observations (in degrees).
+        - read_noise: The readout noise for the camera in electrons per pixel.
+    """
+
+    def __init__(self, table, fluxerr=None, colmap=None, **kwargs):
+        super().__init__(table, colmap=colmap, **kwargs)
+
+        # Do some basic checks on how the error is specified and extract it into a numpy array.
+        if not callable(fluxerr):
+            # Handle table column name.
+            if isinstance(fluxerr, str):
+                if fluxerr not in self._table.columns:
+                    raise ValueError(f"Column {fluxerr} not found in observations table.")
+                else:
+                    fluxerr = self._table[fluxerr].values
+
+            # Handle lists, arrays, constants (including None), and dictionaries
+            # (with constant values per filter).
+            if isinstance(fluxerr, list):
+                fluxerr = np.array(fluxerr)
+            elif isinstance(fluxerr, float):
+                fluxerr = np.full(len(self._table), fluxerr)
+            elif fluxerr is None:
+                fluxerr = np.zeros(len(self._table))
+            elif isinstance(fluxerr, dict):
+                # Create an array of flux errors based on the filter column.
+                all_filters = np.unique(self._table["filter"])
+                for filt in all_filters:
+                    if filt not in fluxerr:
+                        raise ValueError(f"Flux error dictionary is missing an entry for filter {filt}.")
+
+                fluxerr_array = np.zeros(len(self._table))
+                for filt, err in fluxerr.items():
+                    if not isinstance(err, (float, int)):
+                        raise ValueError(
+                            "When providing a dictionary of flux errors, the values must be constants (float or int)."
+                        )
+                    fluxerr_array[self._table["filter"] == filt] = err
+                fluxerr = fluxerr_array
+
+            # At this point the data should be in a numpy array. Check that it is the
+            # correct length and has valid values.
+            if isinstance(fluxerr, np.ndarray):
+                if len(fluxerr) != len(self._table):
+                    raise ValueError("Flux error array must be the same length as the observations table.")
+                if np.any(fluxerr < 0.0):
+                    raise ValueError("Flux error must be non-negative.")
+            else:
+                raise ValueError("fluxerr must be a callable, np.array, float, str, list, or None.")
+        self.fluxerr = fluxerr
+
+    def bandflux_error_point_source(self, bandflux, index):
+        """Compute observational bandflux error for a point source
+
+        Parameters
+        ----------
+        bandflux : array_like of float
+            Band bandflux of the point source in nJy.
+        index : array_like of int
+            The index of the observation in the table.
+
+        Returns
+        -------
+        flux_err : array_like of float
+            Simulated bandflux noise in nJy.
+        """
+        # If we have precompute the flux errors into an array, use those.
+        if isinstance(self.fluxerr, np.ndarray):
+            return self.fluxerr[index]
+
+        # Treat the flux error as a callable function.
+        observations = self._table.iloc[index]
+        return self.fluxerr(bandflux, observations)

--- a/src/lightcurvelynx/obstable/custom_survey_table.py
+++ b/src/lightcurvelynx/obstable/custom_survey_table.py
@@ -49,7 +49,7 @@ class CustomSurveyTable(ObsTable):
             # (with constant values per filter).
             if isinstance(fluxerr, list):
                 fluxerr = np.array(fluxerr)
-            elif isinstance(fluxerr, float) or isinstance(fluxerr, int):
+            elif isinstance(fluxerr, float | int):
                 fluxerr = np.full(len(self._table), fluxerr)
             elif fluxerr is None:
                 fluxerr = np.zeros(len(self._table))
@@ -62,7 +62,7 @@ class CustomSurveyTable(ObsTable):
 
                 fluxerr_array = np.zeros(len(self._table))
                 for filt, err in fluxerr.items():
-                    if not isinstance(err, (float, int)):
+                    if not isinstance(err, float | int):
                         raise TypeError(
                             "When providing a dictionary of flux errors, the values must be "
                             f"constants (float or int). Found {type(err)} for filter {filt}."

--- a/tests/lightcurvelynx/obstable/test_custom_survey.py
+++ b/tests/lightcurvelynx/obstable/test_custom_survey.py
@@ -1,0 +1,126 @@
+import tempfile
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+from lightcurvelynx.astro_utils.mag_flux import mag2flux
+
+from lightcurvelynx.obstable.custom_survey_table import CustomSurveyTable
+
+
+def test_create_custom_survey_table_given():
+    """Create a minimal CustomSurveyTable object with given noise data."""
+    values = {
+        "time": np.array([0.0, 1.0, 2.0, 3.0, 4.0, 5.0]),
+        "ra": np.array([15.0, 30.0, 15.0, 0.0, 60.0, 45.0]),
+        "dec": np.array([-10.0, -5.0, 0.0, 5.0, 10.0, 15.0]),
+        "filter": np.array(["r", "g", "r", "g", "r", "g"]),
+        "noise": np.array([0.1, 0.2, 0.3, 0.4, 0.5, 0.6]),
+    }
+    pdf = pd.DataFrame(values)
+    inds = np.arange(6)
+
+    # Try the survey with a constant flux error for all bands.
+    survey_data = CustomSurveyTable(pdf, fluxerr=0.1)
+    assert np.allclose(survey_data.fluxerr, np.full(6, 0.1))
+    band_flux_err = survey_data.bandflux_error_point_source(np.ones(6), inds)
+    assert np.allclose(band_flux_err, np.full(6, 0.1))
+
+    # We fail with a negative constant error.
+    with pytest.raises(ValueError):
+        _ = CustomSurveyTable(pdf, fluxerr=-0.1)
+
+    # Try the survey with a list of flux errors.
+    survey_data = CustomSurveyTable(pdf, fluxerr=[0.2, 0.4, 0.6, 0.8, 1.0, 1.2])
+    assert np.allclose(survey_data.fluxerr, np.array([0.2, 0.4, 0.6, 0.8, 1.0, 1.2]))
+    band_flux_err = survey_data.bandflux_error_point_source(np.ones(6), inds)
+    assert np.allclose(band_flux_err, np.array([0.2, 0.4, 0.6, 0.8, 1.0, 1.2]))
+
+    # We fail if the list is the wrong size.
+    with pytest.raises(ValueError):
+        _ = CustomSurveyTable(pdf, fluxerr=[0.2, 0.4, 0.6])
+
+    # Try the survey with a column name for the flux errors.
+    survey_data = CustomSurveyTable(pdf, fluxerr="noise")
+    assert np.allclose(survey_data.fluxerr, values["noise"])
+    band_flux_err = survey_data.bandflux_error_point_source(np.ones(6), inds)
+    assert np.allclose(band_flux_err, values["noise"])
+
+    # We fail if the column name does not exist.
+    with pytest.raises(ValueError):
+        _ = CustomSurveyTable(pdf, fluxerr="something_random")
+
+    # Try with an np array of flux errors.
+    survey_data = CustomSurveyTable(pdf, fluxerr=np.array([0.3, 0.6, 0.9, 1.2, 1.5, 1.8]))
+    assert np.allclose(survey_data.fluxerr, np.array([0.3, 0.6, 0.9, 1.2, 1.5, 1.8]))
+    band_flux_err = survey_data.bandflux_error_point_source(np.ones(6), inds)
+    assert np.allclose(band_flux_err, np.array([0.3, 0.6, 0.9, 1.2, 1.5, 1.8]))
+
+    # We can use a limited set of indices.
+    limited_inds = np.array([0, 2, 4])
+    band_flux_err = survey_data.bandflux_error_point_source(np.ones(6), limited_inds)
+    assert np.allclose(band_flux_err, np.array([0.3, 0.9, 1.5]))
+
+    # Try with None (zero error for each point).
+    survey_data = CustomSurveyTable(pdf, fluxerr=None)
+    assert np.allclose(survey_data.fluxerr, np.zeros(6))
+    band_flux_err = survey_data.bandflux_error_point_source(np.ones(6), inds)
+    assert np.allclose(band_flux_err, np.zeros(6))
+
+    # Try with a dictionary of constant errors per filter.
+    survey_data = CustomSurveyTable(pdf, fluxerr={"r": 0.1, "g": 0.2})
+    assert np.allclose(survey_data.fluxerr, [0.1, 0.2, 0.1, 0.2, 0.1, 0.2])
+    band_flux_err = survey_data.bandflux_error_point_source(np.ones(6), inds)
+    assert np.allclose(band_flux_err, [0.1, 0.2, 0.1, 0.2, 0.1, 0.2])
+
+    # We fail if a filter in the table is not in the dictionary.
+    with pytest.raises(ValueError):
+        _ = CustomSurveyTable(pdf, fluxerr={"r": 0.1, "i": 0.2})
+
+
+def _calling_fun(bandflux, table):
+    """Compute the noise from the a given bandfluxes and table.
+
+    Parameters
+    ----------
+    bandflux : array_like of float
+        The band bandflux of the point source in nJy.
+    table : pandas.core.frame.DataFrame
+        The table with all the ObsTable information.
+
+    Returns
+    -------
+    flux_err : array_like of float
+        Simulated bandflux noise in nJy.
+    """
+    # Simple example: noise is 10% of the flux plus whatever is in the "noise" column.
+    return 0.1 * bandflux + table["noise"].values
+
+
+def test_create_custom_survey_table_callable():
+    """Create a minimal CustomSurveyTable object with given noise data."""
+    values = {
+        "time": np.array([0.0, 1.0, 2.0, 3.0, 4.0, 5.0]),
+        "ra": np.array([15.0, 30.0, 15.0, 0.0, 60.0, 45.0]),
+        "dec": np.array([-10.0, -5.0, 0.0, 5.0, 10.0, 15.0]),
+        "filter": np.array(["r", "g", "r", "g", "r", "g"]),
+        "noise": np.array([0.1, 0.2, 0.3, 0.4, 0.5, 0.6]),
+    }
+    pdf = pd.DataFrame(values)
+
+    # Try the survey with a callable function.
+    survey_data = CustomSurveyTable(pdf, fluxerr=_calling_fun)
+    band_flux_err = survey_data.bandflux_error_point_source(
+        np.array([10.0, 20.0, 10.0, 20.0, 10.0, 20.0]),
+        np.arange(6),
+    )
+    assert np.allclose(band_flux_err, [1.1, 2.2, 1.3, 2.4, 1.5, 2.6])
+
+    # Use the same callable function with a subset of indices.
+    inds = np.array([0, 2, 3, 5])
+    band_flux_err = survey_data.bandflux_error_point_source(
+        np.array([10.0, 20.0, 10.0, 20.0]),
+        inds,
+    )
+    assert np.allclose(band_flux_err, [1.1, 2.3, 1.4, 2.6])

--- a/tests/lightcurvelynx/obstable/test_custom_survey.py
+++ b/tests/lightcurvelynx/obstable/test_custom_survey.py
@@ -1,7 +1,6 @@
 import numpy as np
 import pandas as pd
 import pytest
-
 from lightcurvelynx.obstable.custom_survey_table import CustomSurveyTable
 
 


### PR DESCRIPTION
Provide a survey class that takes in basic pointing data specified as a table or dictionary. Instead of using instrument-specific details to generate the noise, we provide a bunch of options for manually specifying noise, including:
  * Constant
  * Constant per-band
  * Given (list or numpy array)
  * A function
 
This class will serve as the basis for randomly generated surveys, such as uniform cadence,  poisson cadence, etc.