### PR TITLE
Allow surveys to use custom footprints

### DIFF
--- a/docs/notebooks.rst
+++ b/docs/notebooks.rst
@@ -33,6 +33,7 @@ features and models of the LightCurveLynx package.
     Lightcurve Template Model Demo <notebooks/lightcurve_source_demo>
     Advanced Sampling Techniques <notebooks/advanced_sampling>
     Simulating Multiple Surveys <notebooks/multiple_surveys>
+    Survey Footprints <notebooks/survey_footprints>
 
 
 Citations

--- a/docs/notebooks/survey_footprint.ipynb
+++ b/docs/notebooks/survey_footprint.ipynb
@@ -21,7 +21,7 @@
    "source": [
     "import numpy as np\n",
     "\n",
-    "from lightcurvelynx.astro_utils.survey_footprint import RectangularFootprint"
+    "from lightcurvelynx.astro_utils.survey_footprint import CircularFootprint, RectangularFootprint"
    ]
   },
   {
@@ -151,6 +151,34 @@
    "metadata": {},
    "source": [
     "As we see the first point falls within the footprint, but the remaining points do not."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "714333ef",
+   "metadata": {},
+   "source": [
+    "## Circular Footprints\n",
+    "\n",
+    "By default the `ObsTable` class does an initial filtering based on a circular radius. However in some cases we might want to later use a tighter circular radius.  We can do this with the `CircularFootprint` class.\n",
+    "\n",
+    "Here we create a circular footprint with a 1 degree radius."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0838d7f4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fp2 = CircularFootprint(1.0)\n",
+    "ax = fp2.plot(\n",
+    "    center_ra=20.0,\n",
+    "    center_dec=10.0,\n",
+    "    point_ra=ra_points,\n",
+    "    point_dec=dec_points,\n",
+    ")"
    ]
   }
  ],

--- a/docs/notebooks/survey_footprint.ipynb
+++ b/docs/notebooks/survey_footprint.ipynb
@@ -1,0 +1,178 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "b93e472d",
+   "metadata": {},
+   "source": [
+    "# Survey Footprints\n",
+    "\n",
+    "In this tutorial we look at the basics of specifying survey footprints. Survey footprints provide templates for filtering which objects are seen in a given pointing. As such we will need to provide both the information about the query point and the survey pointing itself.\n",
+    "\n",
+    "It is **important** to note that we currently use small angle approximations to perform translations, rotations, and bounds checks. These are approximate only. We can add more exact computations if needed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "652fdc71",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "\n",
+    "from lightcurvelynx.astro_utils.survey_footprint import RectangularFootprint"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8dd0a2ee",
+   "metadata": {},
+   "source": [
+    "## SurveyFootprint Class\n",
+    "\n",
+    "The `SurveyFootprint` class is a base class to represent a range of survey footprints. It has two basic functions for users: `contains` and `plot`. Let's start with a rectangular footprint with a width of 2.0 degrees and a height of 1 degree."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9310e49a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fp = RectangularFootprint(2, 1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ca0a7505",
+   "metadata": {},
+   "source": [
+    "### Plotting\n",
+    "\n",
+    "We can plot the footprint with the `plot` command."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "75a0fcdf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fp.plot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "11c32b1b",
+   "metadata": {},
+   "source": [
+    "However in most cases we will be interested in seeing the footprint in the context of a pointing on the sky. Let's plot the footprint centered on RA=20.0 and dec=10.0 with a 30 degree clockwise rotation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "458f4720",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fp.plot(center_ra=20.0, center_dec=10.0, rotation=30.0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3e9d5b01",
+   "metadata": {},
+   "source": [
+    "The `plot` command can also show points relative to the footprint and whether they are inside or outside the area."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d1cafd74",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ra_points = []\n",
+    "dec_points = []\n",
+    "for ra in np.linspace(18, 22, 20):\n",
+    "    for dec in np.linspace(8, 12, 20):\n",
+    "        ra_points.append(ra)\n",
+    "        dec_points.append(dec)\n",
+    "ra_points = np.array(ra_points)\n",
+    "dec_points = np.array(dec_points)\n",
+    "\n",
+    "ax = fp.plot(\n",
+    "    center_ra=20.0,\n",
+    "    center_dec=10.0,\n",
+    "    rotation=30.0,\n",
+    "    point_ra=ra_points,\n",
+    "    point_dec=dec_points,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cba4088b",
+   "metadata": {},
+   "source": [
+    "### Querying\n",
+    "\n",
+    "The code uses the same notation for querying whether a point is within the footprint. Unlike plotting, we might which to query multiple pointings (with different center locations and rotations) at once. The `contains` function can take a vector of center points and rotations. All arrays must be the same length."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "334d1bb4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# The query points alternate between (20, 10) and (25, 10))\n",
+    "query_ra = np.array([20.0, 25.0, 20.0, 25.0])\n",
+    "query_dec = np.array([10.0, 10.0, 10.0, 10.0])\n",
+    "\n",
+    "# The survey pointings alternate between (20, 10) and (10, 10).\n",
+    "# No rotation is applied.\n",
+    "pointing_ra = np.array([20.0, 20.0, 10.0, 10.0])\n",
+    "pointing_dec = np.array([10.0, 10.0, 10.0, 10.0])\n",
+    "\n",
+    "contains = fp.contains(query_ra, query_dec, pointing_ra, pointing_dec)\n",
+    "print(contains)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6c673f91",
+   "metadata": {},
+   "source": [
+    "As we see the first point falls within the footprint, but the remaining points do not."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "lightcurvelynx",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/lightcurvelynx/astro_utils/survey_footprint.py
+++ b/src/lightcurvelynx/astro_utils/survey_footprint.py
@@ -1,0 +1,314 @@
+"""A class for representing survey footprints."""
+
+import numpy as np
+import matplotlib.pyplot as plt
+
+
+class SurveyFootprint:
+    """A base class for representing survey footprints. This class is a No-Op and
+    does not implement any filtering.
+    """
+    def __init__(self, **kwargs):
+        pass
+
+    def _transform(self, ra, dec, center_ra, center_dec, *, rotation=None):
+        """Transform the given points, represented by (ra, dec) in degrees,
+        to a local coordinate system centered on (center_ra, center_dec), accounting
+        for rotation if specified.
+
+        Note
+        ----
+        This method assumes small angles and does not account for spherical geometry.
+        For large footprints or high precision, a more accurate transformation should
+        be implemented.
+
+        Parameters
+        ----------
+        ra : np.ndarray
+            Right ascension in degrees.
+        dec : np.ndarray
+            Declination in degrees.
+        center_ra : np.ndarray
+            Center right ascension of the detector in degrees.
+        center_dec : np.ndarray
+            Center declination of the detector in degrees.
+        rotation : np.ndarray, optional
+            The rotation angle of the detector for each pointing in degrees clockwise.
+            Used to represent non-axis-aligned footprints.
+
+        Returns
+        -------
+        tuple of np.ndarray
+            Transformed (x, y) coordinates in radians.
+        """
+        # Compute the distance in radians from the center of the footprint,
+        # accounting for RA wrapping.
+        ra_diff = np.radians(ra - center_ra)
+        ra_diff[ra_diff > np.pi] -= 2 * np.pi
+        ra_diff[ra_diff < -np.pi] += 2 * np.pi
+        dec_diff = np.radians(dec - center_dec)
+
+        # If rotation is specified, rotate the coordinates accordingly. We rotate
+        # counter-clockwise to account for the clockwise rotation of the footprint.
+        if rotation is not None:
+            rotation_rad = np.radians(rotation)
+            cos_rot = np.cos(rotation_rad)
+            sin_rot = np.sin(rotation_rad)
+            ra_rot = ra_diff * cos_rot - dec_diff * sin_rot
+            dec_rot = ra_diff * sin_rot + dec_diff * cos_rot
+            ra_diff, dec_diff = ra_rot, dec_rot
+
+        return ra_diff, dec_diff
+
+    def _contains(self, d_x, d_y):
+        """Check that given points, represented by distance in radians from the center
+        (accounting for rotation if specified), are within the footprint. This is a
+        No-Op implementation that always returns True. Subclasses should override this
+        method to implement specific footprint logic.
+
+        Parameters
+        ----------
+        d_x : np.ndarray
+            Distance in rotated x coordinate from the center of the detector in radians.
+        d_y : np.ndarray
+            Distance in rotated y coordinate from the center of the detector in radians.
+
+        Returns
+        -------
+        np.ndarray
+            True if the point is within the footprint, False otherwise.
+        """
+        return np.full(np.shape(d_x), True, dtype=bool)
+
+    def contains(self, ra, dec, center_ra, center_dec, *, rotation=None):
+        """Check that given points, represented by (ra, dec) in degrees,
+        are within the footprint. This is the outer interface that handles
+        both scalar and array inputs, does validation, and delegates to the
+        internal implementation. Subclasses should override _contains.
+
+        Parameters
+        ----------
+        ra : float or array-like
+            Right ascension in degrees.
+        dec : float or array-like
+            Declination in degrees.
+        center_ra : float or array-like
+            Center right ascension of the detector in degrees.
+        center_dec : float or array-like
+            Center declination of the detector in degrees.
+        rotation : np.ndarray, optional
+            The rotation angle of the detector for each pointing in degrees clockwise.
+            Used to represent non-axis-aligned footprints.
+
+        Returns
+        -------
+        bool or array-like of bool
+            True if the point is within the footprint, False otherwise.
+        """
+        # Convert all inputs to numpy arrays for uniform processing and perform validation.
+        scalar_data = np.isscalar(ra)
+        ra = np.asarray(ra)
+        dec = np.asarray(dec)
+        center_ra = np.asarray(center_ra)
+        center_dec = np.asarray(center_dec)
+        if ra.shape != dec.shape:
+            raise ValueError("ra and dec must have the same shape.")
+        if center_ra.shape != ra.shape:
+            raise ValueError("center_ra must have the same shape as ra and dec.")
+        if center_dec.shape != dec.shape:
+            raise ValueError("center_dec must have the same shape as ra and dec.")
+
+        # Rotation is optional, but if provided, it must match the shape of ra and dec.
+        if rotation is not None:
+            rotation = np.asarray(rotation)
+            if rotation.shape != ra.shape:
+                print(rotation.shape)
+                print(ra.shape)
+                raise ValueError("rotation must have the same shape as ra and dec.")
+
+        d_x, d_y = self._transform(ra, dec, center_ra, center_dec, rotation=rotation)
+        result = self._contains(d_x, d_y)
+        if scalar_data:
+            return result[0]
+        return result
+
+    def plot_bounds(self, ax, center_ra=0, center_dec=0, rotation=0, **kwargs):
+        """Plot the bounds of the footprint on the given axes. This base implementation
+        does nothing. Subclasses should override this method to implement specific plotting
+        logic.
+
+        Parameters
+        ----------
+        ax : matplotlib.pyplot.Axes
+            Axes to plot on.
+        center_ra : float, optional
+            Center right ascension of the detector in degrees. Default is 0.
+        center_dec : float, optional
+            Center declination of the detector in degrees. Default is 0.
+        rotation : np.ndarray, optional
+            The rotation angle of the detector for each pointing in degrees clockwise.
+            Used to represent non-axis-aligned footprints.
+            Default is 0.
+        **kwargs : dict
+            Optional parameters to pass to the plotting function
+        """
+        pass
+
+    def plot(
+            self,
+            *,
+            ax=None,
+            figure=None,
+            center_ra=0,
+            center_dec=0,
+            rotation=0,
+            point_ra=None,
+            point_dec=None,
+            **kwargs,
+        ):
+        """Plot the footprint using matplotlib and an optional set of points to overlay.
+
+        Parameters
+        ----------
+        ax : matplotlib.pyplot.Axes or None, optional
+            Axes, If None, a new axes will be created. None by default.
+        figure : matplotlib.pyplot.Figure or None
+            Figure, If None, a new figure will be created. None by default.
+        center_ra : float, optional
+            Center right ascension of the detector in degrees. Default is 0.
+        center_dec : float, optional
+            Center declination of the detector in degrees. Default is 0.
+        rotation : np.ndarray, optional
+            The rotation angle of the detector for each pointing in degrees clockwise.
+            Used to represent non-axis-aligned footprints.
+            Default is 0.
+        point_ra : array-like or None, optional
+            Right ascension of points to overlay in degrees. None by default.
+        point_dec : array-like or None, optional
+            Declination of points to overlay in degrees. None by default.
+        **kwargs : dict
+            Optional parameters to pass to the plotting function
+
+        Returns
+        -------
+        ax : matplotlib.pyplot.Axes
+            The axes containing the plot.
+        """
+        if ax is None:
+            if figure is None:
+                figure = plt.figure()
+            ax = figure.add_axes([0, 0, 1, 1])
+
+        # Plot the bounds of the footprint.
+        self.plot_bounds(ax, center_ra=center_ra, center_dec=center_dec, rotation=rotation, **kwargs)
+
+        # If points are provided, overlay them on the plot.
+        if point_ra is not None and point_dec is not None:
+            point_ra = np.asarray(point_ra)
+            point_dec = np.asarray(point_dec)
+
+            center_ra = np.full(np.shape(point_ra), center_ra)
+            center_dec = np.full(np.shape(point_dec), center_dec)
+            if rotation is not None:
+                rotation = np.full(np.shape(point_ra), rotation)
+
+            isin = self.contains(point_ra, point_dec, center_ra, center_dec, rotation=rotation)
+            ax.scatter(point_ra[~isin], point_dec[~isin], color='red', marker='x', label='Outside Footprint')
+            ax.scatter(point_ra[isin], point_dec[isin], color='green', marker='o', label='Inside Footprint')
+            ax.legend()
+
+        ax.set_title("Survey Footprint")
+        ax.axis("equal")
+        return ax
+
+
+class RectangularFootprint(SurveyFootprint):
+    """A rectangular survey footprint defined by minimum and maximum
+    right ascension and declination.
+
+    Attributes
+    ----------
+    height : float
+        Height of the rectangle in degrees.
+    width : float
+        Width of the rectangle in degrees.
+    half_height_rad : float
+        Half the height of the rectangle in radians.
+    half_width_rad : float
+        Half the width of the rectangle in radians.
+
+    Parameters
+    ----------
+    height : float
+        Height of the rectangle in degrees.
+    width : float
+        Width of the rectangle in degrees.
+    """
+    def __init__(self, width, height):
+        if width <= 0 or height <= 0:
+            raise ValueError("Width and height must be positive.")
+        self.half_width_rad = np.radians(width) / 2
+        self.half_height_rad = np.radians(height) / 2
+
+    def _contains(self, d_x, d_y):
+        """Check that given points, represented by distance in radians from the center
+        (accounting for rotation if specified), are within the footprint. This is a
+        No-Op implementation that always returns True. Subclasses should override this
+        method to implement specific footprint logic.
+
+        Parameters
+        ----------
+        d_x : np.ndarray
+            Distance in rotated x coordinate from the center of the detector in radians.
+        d_y : np.ndarray
+            Distance in rotated y coordinate from the center of the detector in radians.
+
+        Returns
+        -------
+        np.ndarray
+            True if the point is within the footprint, False otherwise.
+        """
+        return (np.abs(d_x) <= self.half_width_rad) & (np.abs(d_y) <= self.half_height_rad)
+
+    def plot_bounds(self, ax, center_ra=0, center_dec=0, rotation=0, **kwargs):
+        """Plot the bounds of the footprint on the given axes. This base implementation
+        does nothing. Subclasses should override this method to implement specific plotting
+        logic.
+
+        Parameters
+        ----------
+        ax : matplotlib.pyplot.Axes
+            Axes to plot on.
+        center_ra : float, optional
+            Center right ascension of the detector in degrees. Default is 0.
+        center_dec : float, optional
+            Center declination of the detector in degrees. Default is 0.
+        rotation : np.ndarray, optional
+            The rotation angle of the detector for each pointing in degrees clockwise.
+            Used to represent non-axis-aligned footprints.
+            Default is 0.
+        **kwargs : dict
+            Optional parameters to pass to the plotting function
+        """
+        # Define the corners of the rectangle in local coordinates (radians).
+        half_w = self.half_width_rad
+        half_h = self.half_height_rad
+        corners_x = np.array([-half_w, half_w, half_w, -half_w, -half_w])
+        corners_y = np.array([-half_h, -half_h, half_h, half_h, -half_h])
+
+        # If rotation is specified, rotate the corners accordingly.
+        if rotation:
+            rotation_rad = np.radians(rotation)
+            cos_rot = np.cos(rotation_rad)
+            sin_rot = np.sin(rotation_rad)
+            x_rot = corners_x * cos_rot + corners_y * sin_rot
+            y_rot = -corners_x * sin_rot + corners_y * cos_rot
+            corners_x, corners_y = x_rot, y_rot
+
+        # Convert the corners back to RA/Dec coordinates.
+        corners_ra = np.degrees(corners_x) + center_ra
+        corners_dec = np.degrees(corners_y) + center_dec
+
+        # Plot the rectangle.
+        ax.plot(corners_ra, corners_dec, color="k", **kwargs)
+ 

--- a/src/lightcurvelynx/math_nodes/ra_dec_sampler.py
+++ b/src/lightcurvelynx/math_nodes/ra_dec_sampler.py
@@ -224,7 +224,7 @@ class ObsTableUniformRADECSampler(NumpyRandomFunc):
             dec[~mask] = np.degrees(np.arcsin(rng.uniform(-1.0, 1.0, size=num_missing)))
 
             # Check if the samples are within the ObsTable coverage.
-            mask = np.asarray(self.data.is_observed(ra, dec, self.radius))
+            mask = np.asarray(self.data.is_observed(ra, dec, radius=self.radius))
             num_missing = np.sum(~mask)
             iter_num += 1
 

--- a/tests/lightcurvelynx/astro_utils/test_survey_footprint.py
+++ b/tests/lightcurvelynx/astro_utils/test_survey_footprint.py
@@ -1,0 +1,110 @@
+import numpy as np
+import pytest
+
+from lightcurvelynx.astro_utils.survey_footprint import (
+    CircularFootprint,
+    RectangularFootprint,
+    SurveyFootprint,
+)
+
+
+def test_survey_footprint_base_class():
+    """Test the base SurveyFootprint class."""
+    fp = SurveyFootprint()
+
+    ra = np.array([90.0, 91.0, 92.0])
+    dec = np.array([-10.0, -11.0, -10.0])
+    center_ra = np.array([90.0, 90.0, 92.0])
+    center_dec = np.array([-10.0, -10.0, -8.0])
+
+    # Test the internal transform method. The points should be relative to the
+    # center and in radians.
+    ra_t, dec_t = fp._transform(ra, dec, center_ra, center_dec)
+    assert np.allclose(ra_t, np.radians([0.0, 1.0, 0.0]))
+    assert np.allclose(dec_t, np.radians([0.0, -1.0, -2.0]))
+
+    # Test with rotation. Note the points will be rotated counter-clockwise
+    # since the footprint is rotated clockwise.
+    rotation = np.array([0.0, 90.0, 180.0])
+    ra_t, dec_t = fp._transform(ra, dec, center_ra, center_dec, rotation=rotation)
+    assert np.allclose(ra_t, np.radians([0.0, 1.0, 0.0]))
+    assert np.allclose(dec_t, np.radians([0.0, 1.0, 2.0]))
+
+    # Default contains should always return True for the base class.
+    assert np.all(fp.contains(ra, dec, center_ra, center_dec))
+    assert np.all(fp.contains(ra, dec, center_ra, center_dec, rotation=rotation))
+
+    # We can query scalars as well.
+    assert fp.contains(90.0, -10.0, 90.0, -10.0)
+    assert fp.contains(90.0, -10.0, 90.0, -10.0, rotation=90.0)
+
+    # We fail if the arrays are not the same shape.
+    with pytest.raises(ValueError):
+        fp.contains(ra, 1.0, center_ra, center_dec)
+    with pytest.raises(ValueError):
+        fp.contains(ra, dec, 1.0, center_dec)
+    with pytest.raises(ValueError):
+        fp.contains(ra, dec, center_ra, 1.0)
+    with pytest.raises(ValueError):
+        fp.contains(ra, dec, center_ra, center_dec, rotation=1.0)
+
+
+def test_circular_footprint():
+    """Test the CircularFootprint class."""
+    fp = CircularFootprint(1.0)
+
+    ra = np.array([90.0, 95.0, 90.0, 90.4])
+    center_ra = np.array([90.0, 90.0, 92.0, 90.0])
+    dec = np.array([-10.0, -15.0, -10.0, 10.4])
+    center_dec = np.array([-10.0, -10.0, -8.0, 10.0])
+
+    contained = fp.contains(ra, dec, center_ra, center_dec)
+    assert np.all(contained == np.array([True, False, False, True]))
+
+    # We can call the plot function without and with points. Here we are just testing
+    # that nothing crashes. The visualization can be confirmed in the notebook.
+    _ = fp.plot(center_ra=90.0, center_dec=-10.0, rotation=45.0)
+
+
+def test_rectangular_footprint():
+    """Test the RectangularFootprint class."""
+    width = 2.0
+    height = 1.0
+    fp = RectangularFootprint(width=width, height=height)
+
+    ra = np.array([90.0, 91.0, 92.0, 90.5, 90.0])
+    center_ra = np.array([90.0, 90.0, 92.0, 93.0, 90.0])
+    dec = np.array([-10.0, -13.0, -8.0, -10.25, -9.25])
+    center_dec = np.array([-10.0, -10.0, -8.0, -10.0, -10.0])
+
+    # Test contains without rotation.
+    contained = fp.contains(ra, dec, center_ra, center_dec)
+    assert np.all(contained == np.array([True, False, True, False, False]))
+
+    # Test contains with rotation. The fifth point should now be contained.
+    rotation = np.full(ra.shape, 90.0)
+    contained = fp.contains(ra, dec, center_ra, center_dec, rotation=rotation)
+    print(contained)
+    assert np.all(contained == np.array([True, False, True, False, True]))
+
+    # We can query scalars as well.
+    assert fp.contains(90.5, -10.25, 90.0, -10.0)
+    assert not fp.contains(91.5, -10.25, 90.0, -10.0)
+    assert fp.contains(89.75, -9.75, 90.0, -10.0)
+    assert not fp.contains(89.75, -9.25, 90.0, -10.0)
+
+    assert not fp.contains(91.5, -10.25, 90.0, -10.0, rotation=45.0)
+    assert fp.contains(89.75, -9.75, 90.0, -10.0, rotation=-45.0)
+    assert not fp.contains(89.75, -9.25, 90.0, -10.0, rotation=-45.0)
+
+    # We can call the plot function without and with points. Here we are just testing
+    # that nothing crashes. The visualization can be confirmed in the notebook.
+    _ = fp.plot()
+    _ = fp.plot(center_ra=90.0, center_dec=-10.0, rotation=45.0)
+    _ = fp.plot(
+        center_ra=90.0,
+        center_dec=-10.0,
+        rotation=45.0,
+        point_ra=np.array([90.0, 91.0]),
+        point_dec=np.array([-10.0, -10.5]),
+    )

--- a/tests/lightcurvelynx/obstable/test_obs_table.py
+++ b/tests/lightcurvelynx/obstable/test_obs_table.py
@@ -351,32 +351,32 @@ def test_obs_table_range_search():
     ops_data = ObsTable(values)
 
     # Test single queries.
-    assert set(ops_data.range_search(15.0, 10.0, 0.5)) == set([1, 2, 3])
-    assert set(ops_data.range_search(25.0, 10.0, 0.5)) == set([4, 5])
-    assert set(ops_data.range_search(15.0, 10.0, 100.0)) == set([0, 1, 2, 3, 4, 5, 6, 7])
-    assert set(ops_data.range_search(15.0, 10.0, 1e-6)) == set([1])
-    assert set(ops_data.range_search(15.02, 10.0, 1e-6)) == set()
+    assert set(ops_data.range_search(15.0, 10.0, radius=0.5)) == set([1, 2, 3])
+    assert set(ops_data.range_search(25.0, 10.0, radius=0.5)) == set([4, 5])
+    assert set(ops_data.range_search(15.0, 10.0, radius=100.0)) == set([0, 1, 2, 3, 4, 5, 6, 7])
+    assert set(ops_data.range_search(15.0, 10.0, radius=1e-6)) == set([1])
+    assert set(ops_data.range_search(15.02, 10.0, radius=1e-6)) == set()
 
     # Test that we can filter by time.
-    assert set(ops_data.range_search(15.0, 10.0, 0.5, t_min=1.0, t_max=3.0)) == set([1, 2, 3])
-    assert set(ops_data.range_search(15.0, 10.0, 0.5, t_min=2.0, t_max=4.0)) == set([2, 3])
-    assert set(ops_data.range_search(15.0, 10.0, 0.5, t_min=0.0, t_max=1.0)) == set([1])
-    assert set(ops_data.range_search(15.0, 10.0, 0.5, t_min=4.0, t_max=5.0)) == set()
+    assert set(ops_data.range_search(15.0, 10.0, radius=0.5, t_min=1.0, t_max=3.0)) == set([1, 2, 3])
+    assert set(ops_data.range_search(15.0, 10.0, radius=0.5, t_min=2.0, t_max=4.0)) == set([2, 3])
+    assert set(ops_data.range_search(15.0, 10.0, radius=0.5, t_min=0.0, t_max=1.0)) == set([1])
+    assert set(ops_data.range_search(15.0, 10.0, radius=0.5, t_min=4.0, t_max=5.0)) == set()
 
     # With no radius provided (and no default), the query fails.
     with pytest.raises(ValueError):
         _ = ops_data.range_search(15.0, 10.0)
 
     # Test is_observed() with single queries.
-    assert ops_data.is_observed(15.0, 10.0, 0.5)
-    assert not ops_data.is_observed(15.02, 10.0, 1e-6)
-    assert ops_data.is_observed(15.0, 10.0, 0.5, t_min=1.0, t_max=3.0)
-    assert not ops_data.is_observed(15.0, 10.0, 0.5, t_min=40.0, t_max=50.0)
+    assert ops_data.is_observed(15.0, 10.0, radius=0.5)
+    assert not ops_data.is_observed(15.02, 10.0, radius=1e-6)
+    assert ops_data.is_observed(15.0, 10.0, radius=0.5, t_min=1.0, t_max=3.0)
+    assert not ops_data.is_observed(15.0, 10.0, radius=0.5, t_min=40.0, t_max=50.0)
 
     # Test a batched query.
     query_ra = np.array([15.0, 25.0, 15.0])
     query_dec = np.array([10.0, 10.0, 5.0])
-    neighbors = ops_data.range_search(query_ra, query_dec, 0.5)
+    neighbors = ops_data.range_search(query_ra, query_dec, radius=0.5)
     assert len(neighbors) == 3
     assert set(neighbors[0]) == set([1, 2, 3])
     assert set(neighbors[1]) == set([4, 5])
@@ -385,7 +385,7 @@ def test_obs_table_range_search():
     # Do the same query with time filtering.
     t_min = np.array([0.0, 5.0, 0.0])
     t_max = np.array([2.0, 11.0, 1.0])
-    neighbors = ops_data.range_search(query_ra, query_dec, 0.5, t_min=t_min, t_max=t_max)
+    neighbors = ops_data.range_search(query_ra, query_dec, radius=0.5, t_min=t_min, t_max=t_max)
     assert len(neighbors) == 3
     assert set(neighbors[0]) == set([1, 2])
     assert set(neighbors[1]) == set([5])
@@ -393,19 +393,19 @@ def test_obs_table_range_search():
 
     # Test is_observed() with batched queries.
     assert np.array_equal(
-        ops_data.is_observed(query_ra, query_dec, 0.5),
+        ops_data.is_observed(query_ra, query_dec, radius=0.5),
         np.array([True, True, False]),
     )
 
     # Test that we fail if bad query arrays are provided.
     with pytest.raises(ValueError):
-        _ = ops_data.range_search(None, None, 0.5)
+        _ = ops_data.range_search(None, None, radius=0.5)
     with pytest.raises(ValueError):
-        _ = ops_data.range_search([1.0, 2.3], 4.5, 0.5)
+        _ = ops_data.range_search([1.0, 2.3], 4.5, radius=0.5)
     with pytest.raises(ValueError):
-        _ = ops_data.range_search([1.0, 2.3], [4.5, 6.7, 8.9], 0.5)
+        _ = ops_data.range_search([1.0, 2.3], [4.5, 6.7, 8.9], radius=0.5)
     with pytest.raises(ValueError):
-        _ = ops_data.range_search([1.0, 2.3], [4.5, None], 0.5)
+        _ = ops_data.range_search([1.0, 2.3], [4.5, None], radius=0.5)
 
 
 def test_obs_table_get_observations():

--- a/tests/lightcurvelynx/obstable/test_opsim.py
+++ b/tests/lightcurvelynx/obstable/test_opsim.py
@@ -369,32 +369,32 @@ def test_opsim_range_search():
     ops_data = OpSim(values)
 
     # Test single queries.
-    assert set(ops_data.range_search(15.0, 10.0, 0.5)) == set([1, 2, 3])
-    assert set(ops_data.range_search(25.0, 10.0, 0.5)) == set([4, 5])
-    assert set(ops_data.range_search(15.0, 10.0, 100.0)) == set([0, 1, 2, 3, 4, 5, 6, 7])
-    assert set(ops_data.range_search(15.0, 10.0, 1e-6)) == set([1])
-    assert set(ops_data.range_search(15.02, 10.0, 1e-6)) == set()
+    assert set(ops_data.range_search(15.0, 10.0, radius=0.5)) == set([1, 2, 3])
+    assert set(ops_data.range_search(25.0, 10.0, radius=0.5)) == set([4, 5])
+    assert set(ops_data.range_search(15.0, 10.0, radius=100.0)) == set([0, 1, 2, 3, 4, 5, 6, 7])
+    assert set(ops_data.range_search(15.0, 10.0, radius=1e-6)) == set([1])
+    assert set(ops_data.range_search(15.02, 10.0, radius=1e-6)) == set()
 
     # Test that we can filter by time.
-    assert set(ops_data.range_search(15.0, 10.0, 0.5, t_min=1.0, t_max=3.0)) == set([1, 2, 3])
-    assert set(ops_data.range_search(15.0, 10.0, 0.5, t_min=2.0, t_max=4.0)) == set([2, 3])
-    assert set(ops_data.range_search(15.0, 10.0, 0.5, t_min=0.0, t_max=1.0)) == set([1])
-    assert set(ops_data.range_search(15.0, 10.0, 0.5, t_min=4.0, t_max=5.0)) == set()
+    assert set(ops_data.range_search(15.0, 10.0, radius=0.5, t_min=1.0, t_max=3.0)) == set([1, 2, 3])
+    assert set(ops_data.range_search(15.0, 10.0, radius=0.5, t_min=2.0, t_max=4.0)) == set([2, 3])
+    assert set(ops_data.range_search(15.0, 10.0, radius=0.5, t_min=0.0, t_max=1.0)) == set([1])
+    assert set(ops_data.range_search(15.0, 10.0, radius=0.5, t_min=4.0, t_max=5.0)) == set()
 
     # With no radius provided, it should default to 1.75.
     assert set(ops_data.range_search(15.0, 10.0)) == set([1, 2, 3])
     assert set(ops_data.range_search(25.0, 10.0)) == set([4, 5])
 
     # Test is_observed() with single queries.
-    assert ops_data.is_observed(15.0, 10.0, 0.5)
-    assert not ops_data.is_observed(15.02, 10.0, 1e-6)
-    assert ops_data.is_observed(15.0, 10.0, 0.5, t_min=1.0, t_max=3.0)
-    assert not ops_data.is_observed(15.0, 10.0, 0.5, t_min=40.0, t_max=50.0)
+    assert ops_data.is_observed(15.0, 10.0, radius=0.5)
+    assert not ops_data.is_observed(15.02, 10.0, radius=1e-6)
+    assert ops_data.is_observed(15.0, 10.0, radius=0.5, t_min=1.0, t_max=3.0)
+    assert not ops_data.is_observed(15.0, 10.0, radius=0.5, t_min=40.0, t_max=50.0)
 
     # Test a batched query.
     query_ra = np.array([15.0, 25.0, 15.0])
     query_dec = np.array([10.0, 10.0, 5.0])
-    neighbors = ops_data.range_search(query_ra, query_dec, 0.5)
+    neighbors = ops_data.range_search(query_ra, query_dec, radius=0.5)
     assert len(neighbors) == 3
     assert set(neighbors[0]) == set([1, 2, 3])
     assert set(neighbors[1]) == set([4, 5])
@@ -403,7 +403,7 @@ def test_opsim_range_search():
     # Do the same query with time filtering.
     t_min = np.array([0.0, 5.0, 0.0])
     t_max = np.array([2.0, 11.0, 1.0])
-    neighbors = ops_data.range_search(query_ra, query_dec, 0.5, t_min=t_min, t_max=t_max)
+    neighbors = ops_data.range_search(query_ra, query_dec, radius=0.5, t_min=t_min, t_max=t_max)
     assert len(neighbors) == 3
     assert set(neighbors[0]) == set([1, 2])
     assert set(neighbors[1]) == set([5])
@@ -411,19 +411,19 @@ def test_opsim_range_search():
 
     # Test is_observed() with batched queries.
     assert np.array_equal(
-        ops_data.is_observed(query_ra, query_dec, 0.5),
+        ops_data.is_observed(query_ra, query_dec, radius=0.5),
         np.array([True, True, False]),
     )
 
     # Test that we fail if bad query arrays are provided.
     with pytest.raises(ValueError):
-        _ = ops_data.range_search(None, None, 0.5)
+        _ = ops_data.range_search(None, None, radius=0.5)
     with pytest.raises(ValueError):
-        _ = ops_data.range_search([1.0, 2.3], 4.5, 0.5)
+        _ = ops_data.range_search([1.0, 2.3], 4.5, radius=0.5)
     with pytest.raises(ValueError):
-        _ = ops_data.range_search([1.0, 2.3], [4.5, 6.7, 8.9], 0.5)
+        _ = ops_data.range_search([1.0, 2.3], [4.5, 6.7, 8.9], radius=0.5)
     with pytest.raises(ValueError):
-        _ = ops_data.range_search([1.0, 2.3], [4.5, None], 0.5)
+        _ = ops_data.range_search([1.0, 2.3], [4.5, None], radius=0.5)
 
 
 def test_opsim_get_observations():


### PR DESCRIPTION
Create a `SurveyFootprint` class to represent, query, and plot the survey's footprint. We also include two basic footprints for testing (circular and rectangular). Extend `ObsTable` to perform footprint filtering if a footprint was provided.