### PR TITLE
Require kwarg tags

### DIFF
--- a/src/lightcurvelynx/math_nodes/ra_dec_sampler.py
+++ b/src/lightcurvelynx/math_nodes/ra_dec_sampler.py
@@ -224,7 +224,7 @@ class ObsTableUniformRADECSampler(NumpyRandomFunc):
             dec[~mask] = np.degrees(np.arcsin(rng.uniform(-1.0, 1.0, size=num_missing)))
 
             # Check if the samples are within the ObsTable coverage.
-            mask = np.asarray(self.data.is_observed(ra, dec, self.radius))
+            mask = np.asarray(self.data.is_observed(ra, dec, radius=self.radius))
             num_missing = np.sum(~mask)
             iter_num += 1
 

--- a/src/lightcurvelynx/obstable/obs_table.py
+++ b/src/lightcurvelynx/obstable/obs_table.py
@@ -391,7 +391,7 @@ class ObsTable:
 
         return self
 
-    def is_observed(self, query_ra, query_dec, radius=None, t_min=None, t_max=None):
+    def is_observed(self, query_ra, query_dec, *, radius=None, t_min=None, t_max=None):
         """Check if the query point(s) fall within the field of view of any
         pointing in the ObsTable.
 
@@ -417,12 +417,12 @@ class ObsTable:
             whether the query point is observed or a list of bools for an array
             of query points.
         """
-        inds = self.range_search(query_ra, query_dec, radius, t_min=t_min, t_max=t_max)
+        inds = self.range_search(query_ra, query_dec, radius=radius, t_min=t_min, t_max=t_max)
         if np.isscalar(query_ra):
             return len(inds) > 0
         return [len(entry) > 0 for entry in inds]
 
-    def range_search(self, query_ra, query_dec, radius=None, t_min=None, t_max=None):
+    def range_search(self, query_ra, query_dec, *, radius=None, t_min=None, t_max=None):
         """Return the indices of the pointings that fall within the field
         of view of the query point(s).
 
@@ -510,7 +510,7 @@ class ObsTable:
             inds = inds[0]
         return inds
 
-    def get_observations(self, query_ra, query_dec, radius=None, t_min=None, t_max=None, cols=None):
+    def get_observations(self, query_ra, query_dec, *, radius=None, t_min=None, t_max=None, cols=None):
         """Return the observation information when the query point falls within
         the field of view of a pointing in the ObsTable.
 
@@ -538,7 +538,7 @@ class ObsTable:
         results : dict
             A dictionary mapping the given column name to a numpy array of values.
         """
-        neighbors = self.range_search(query_ra, query_dec, radius, t_min=t_min, t_max=t_max)
+        neighbors = self.range_search(query_ra, query_dec, radius=radius, t_min=t_min, t_max=t_max)
 
         results = {}
         if cols is None:

--- a/src/lightcurvelynx/obstable/opsim.py
+++ b/src/lightcurvelynx/obstable/opsim.py
@@ -294,7 +294,7 @@ def oversample_opsim(
 
     """
     ra, dec = pointing
-    observations = opsim._table.iloc[opsim.range_search(ra, dec, search_radius)]
+    observations = opsim._table.iloc[opsim.range_search(ra, dec, radius=search_radius)]
     if len(observations) == 0:
         raise ValueError("No observations found for the given pointing.")
 

--- a/tests/lightcurvelynx/obstable/test_obs_table.py
+++ b/tests/lightcurvelynx/obstable/test_obs_table.py
@@ -351,32 +351,32 @@ def test_obs_table_range_search():
     ops_data = ObsTable(values)
 
     # Test single queries.
-    assert set(ops_data.range_search(15.0, 10.0, 0.5)) == set([1, 2, 3])
-    assert set(ops_data.range_search(25.0, 10.0, 0.5)) == set([4, 5])
-    assert set(ops_data.range_search(15.0, 10.0, 100.0)) == set([0, 1, 2, 3, 4, 5, 6, 7])
-    assert set(ops_data.range_search(15.0, 10.0, 1e-6)) == set([1])
-    assert set(ops_data.range_search(15.02, 10.0, 1e-6)) == set()
+    assert set(ops_data.range_search(15.0, 10.0, radius=0.5)) == set([1, 2, 3])
+    assert set(ops_data.range_search(25.0, 10.0, radius=0.5)) == set([4, 5])
+    assert set(ops_data.range_search(15.0, 10.0, radius=100.0)) == set([0, 1, 2, 3, 4, 5, 6, 7])
+    assert set(ops_data.range_search(15.0, 10.0, radius=1e-6)) == set([1])
+    assert set(ops_data.range_search(15.02, 10.0, radius=1e-6)) == set()
 
     # Test that we can filter by time.
-    assert set(ops_data.range_search(15.0, 10.0, 0.5, t_min=1.0, t_max=3.0)) == set([1, 2, 3])
-    assert set(ops_data.range_search(15.0, 10.0, 0.5, t_min=2.0, t_max=4.0)) == set([2, 3])
-    assert set(ops_data.range_search(15.0, 10.0, 0.5, t_min=0.0, t_max=1.0)) == set([1])
-    assert set(ops_data.range_search(15.0, 10.0, 0.5, t_min=4.0, t_max=5.0)) == set()
+    assert set(ops_data.range_search(15.0, 10.0, radius=0.5, t_min=1.0, t_max=3.0)) == set([1, 2, 3])
+    assert set(ops_data.range_search(15.0, 10.0, radius=0.5, t_min=2.0, t_max=4.0)) == set([2, 3])
+    assert set(ops_data.range_search(15.0, 10.0, radius=0.5, t_min=0.0, t_max=1.0)) == set([1])
+    assert set(ops_data.range_search(15.0, 10.0, radius=0.5, t_min=4.0, t_max=5.0)) == set()
 
     # With no radius provided (and no default), the query fails.
     with pytest.raises(ValueError):
         _ = ops_data.range_search(15.0, 10.0)
 
     # Test is_observed() with single queries.
-    assert ops_data.is_observed(15.0, 10.0, 0.5)
-    assert not ops_data.is_observed(15.02, 10.0, 1e-6)
-    assert ops_data.is_observed(15.0, 10.0, 0.5, t_min=1.0, t_max=3.0)
-    assert not ops_data.is_observed(15.0, 10.0, 0.5, t_min=40.0, t_max=50.0)
+    assert ops_data.is_observed(15.0, 10.0, radius=0.5)
+    assert not ops_data.is_observed(15.02, 10.0, radius=1e-6)
+    assert ops_data.is_observed(15.0, 10.0, radius=0.5, t_min=1.0, t_max=3.0)
+    assert not ops_data.is_observed(15.0, 10.0, radius=0.5, t_min=40.0, t_max=50.0)
 
     # Test a batched query.
     query_ra = np.array([15.0, 25.0, 15.0])
     query_dec = np.array([10.0, 10.0, 5.0])
-    neighbors = ops_data.range_search(query_ra, query_dec, 0.5)
+    neighbors = ops_data.range_search(query_ra, query_dec, radius=0.5)
     assert len(neighbors) == 3
     assert set(neighbors[0]) == set([1, 2, 3])
     assert set(neighbors[1]) == set([4, 5])
@@ -385,7 +385,7 @@ def test_obs_table_range_search():
     # Do the same query with time filtering.
     t_min = np.array([0.0, 5.0, 0.0])
     t_max = np.array([2.0, 11.0, 1.0])
-    neighbors = ops_data.range_search(query_ra, query_dec, 0.5, t_min=t_min, t_max=t_max)
+    neighbors = ops_data.range_search(query_ra, query_dec, radius=0.5, t_min=t_min, t_max=t_max)
     assert len(neighbors) == 3
     assert set(neighbors[0]) == set([1, 2])
     assert set(neighbors[1]) == set([5])
@@ -393,19 +393,19 @@ def test_obs_table_range_search():
 
     # Test is_observed() with batched queries.
     assert np.array_equal(
-        ops_data.is_observed(query_ra, query_dec, 0.5),
+        ops_data.is_observed(query_ra, query_dec, radius=0.5),
         np.array([True, True, False]),
     )
 
     # Test that we fail if bad query arrays are provided.
     with pytest.raises(ValueError):
-        _ = ops_data.range_search(None, None, 0.5)
+        _ = ops_data.range_search(None, None, radius=0.5)
     with pytest.raises(ValueError):
-        _ = ops_data.range_search([1.0, 2.3], 4.5, 0.5)
+        _ = ops_data.range_search([1.0, 2.3], 4.5, radius=0.5)
     with pytest.raises(ValueError):
-        _ = ops_data.range_search([1.0, 2.3], [4.5, 6.7, 8.9], 0.5)
+        _ = ops_data.range_search([1.0, 2.3], [4.5, 6.7, 8.9], radius=0.5)
     with pytest.raises(ValueError):
-        _ = ops_data.range_search([1.0, 2.3], [4.5, None], 0.5)
+        _ = ops_data.range_search([1.0, 2.3], [4.5, None], radius=0.5)
 
 
 def test_obs_table_get_observations():
@@ -421,36 +421,36 @@ def test_obs_table_get_observations():
     ops_data = ObsTable(values, colmap={"airmass_data": "airmass"})
 
     # Test basic queries (all columns).
-    obs = ops_data.get_observations(15.0, 10.0, 0.5)
+    obs = ops_data.get_observations(15.0, 10.0, radius=0.5)
     assert len(obs) == 5
     assert np.allclose(obs["time"], [1.0, 2.0, 3.0])
 
-    obs = ops_data.get_observations(25.0, 10.0, 0.5)
+    obs = ops_data.get_observations(25.0, 10.0, radius=0.5)
     assert np.allclose(obs["time"], [4.0, 5.0])
 
-    obs = ops_data.get_observations(15.0, 10.0, 100.0)
+    obs = ops_data.get_observations(15.0, 10.0, radius=100.0)
     assert np.allclose(obs["time"], [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0])
 
-    obs = ops_data.get_observations(15.0, 10.0, 1e-6)
+    obs = ops_data.get_observations(15.0, 10.0, radius=1e-6)
     assert np.allclose(obs["time"], [1.0])
 
-    obs = ops_data.get_observations(15.02, 10.0, 1e-6)
+    obs = ops_data.get_observations(15.02, 10.0, radius=1e-6)
     assert len(obs["time"]) == 0
 
     # Test we can get a subset of columns.
-    obs = ops_data.get_observations(15.0, 10.0, 0.5, cols=["time", "zp"])
+    obs = ops_data.get_observations(15.0, 10.0, radius=0.5, cols=["time", "zp"])
     assert len(obs) == 2
     assert np.allclose(obs["time"], [1.0, 2.0, 3.0])
 
     # Test we can use the mapped or original column names.
-    obs = ops_data.get_observations(15.0, 10.0, 0.5, cols="airmass")
+    obs = ops_data.get_observations(15.0, 10.0, radius=0.5, cols="airmass")
     assert np.allclose(obs["airmass"], [2, 3, 4])
-    obs = ops_data.get_observations(15.0, 10.0, 0.5, cols="airmass_data")
+    obs = ops_data.get_observations(15.0, 10.0, radius=0.5, cols="airmass_data")
     assert np.allclose(obs["airmass_data"], [2, 3, 4])
 
     # Test we fail with an unrecognized column name.
     with pytest.raises(KeyError):
-        _ = ops_data.get_observations(15.0, 10.0, 0.5, cols=["time", "custom_col"])
+        _ = ops_data.get_observations(15.0, 10.0, radius=0.5, cols=["time", "custom_col"])
 
 
 def test_obs_table_docstring():

--- a/tests/lightcurvelynx/obstable/test_opsim.py
+++ b/tests/lightcurvelynx/obstable/test_opsim.py
@@ -369,32 +369,32 @@ def test_opsim_range_search():
     ops_data = OpSim(values)
 
     # Test single queries.
-    assert set(ops_data.range_search(15.0, 10.0, 0.5)) == set([1, 2, 3])
-    assert set(ops_data.range_search(25.0, 10.0, 0.5)) == set([4, 5])
-    assert set(ops_data.range_search(15.0, 10.0, 100.0)) == set([0, 1, 2, 3, 4, 5, 6, 7])
-    assert set(ops_data.range_search(15.0, 10.0, 1e-6)) == set([1])
-    assert set(ops_data.range_search(15.02, 10.0, 1e-6)) == set()
+    assert set(ops_data.range_search(15.0, 10.0, radius=0.5)) == set([1, 2, 3])
+    assert set(ops_data.range_search(25.0, 10.0, radius=0.5)) == set([4, 5])
+    assert set(ops_data.range_search(15.0, 10.0, radius=100.0)) == set([0, 1, 2, 3, 4, 5, 6, 7])
+    assert set(ops_data.range_search(15.0, 10.0, radius=1e-6)) == set([1])
+    assert set(ops_data.range_search(15.02, 10.0, radius=1e-6)) == set()
 
     # Test that we can filter by time.
-    assert set(ops_data.range_search(15.0, 10.0, 0.5, t_min=1.0, t_max=3.0)) == set([1, 2, 3])
-    assert set(ops_data.range_search(15.0, 10.0, 0.5, t_min=2.0, t_max=4.0)) == set([2, 3])
-    assert set(ops_data.range_search(15.0, 10.0, 0.5, t_min=0.0, t_max=1.0)) == set([1])
-    assert set(ops_data.range_search(15.0, 10.0, 0.5, t_min=4.0, t_max=5.0)) == set()
+    assert set(ops_data.range_search(15.0, 10.0, radius=0.5, t_min=1.0, t_max=3.0)) == set([1, 2, 3])
+    assert set(ops_data.range_search(15.0, 10.0, radius=0.5, t_min=2.0, t_max=4.0)) == set([2, 3])
+    assert set(ops_data.range_search(15.0, 10.0, radius=0.5, t_min=0.0, t_max=1.0)) == set([1])
+    assert set(ops_data.range_search(15.0, 10.0, radius=0.5, t_min=4.0, t_max=5.0)) == set()
 
     # With no radius provided, it should default to 1.75.
     assert set(ops_data.range_search(15.0, 10.0)) == set([1, 2, 3])
     assert set(ops_data.range_search(25.0, 10.0)) == set([4, 5])
 
     # Test is_observed() with single queries.
-    assert ops_data.is_observed(15.0, 10.0, 0.5)
-    assert not ops_data.is_observed(15.02, 10.0, 1e-6)
-    assert ops_data.is_observed(15.0, 10.0, 0.5, t_min=1.0, t_max=3.0)
-    assert not ops_data.is_observed(15.0, 10.0, 0.5, t_min=40.0, t_max=50.0)
+    assert ops_data.is_observed(15.0, 10.0, radius=0.5)
+    assert not ops_data.is_observed(15.02, 10.0, radius=1e-6)
+    assert ops_data.is_observed(15.0, 10.0, radius=0.5, t_min=1.0, t_max=3.0)
+    assert not ops_data.is_observed(15.0, 10.0, radius=0.5, t_min=40.0, t_max=50.0)
 
     # Test a batched query.
     query_ra = np.array([15.0, 25.0, 15.0])
     query_dec = np.array([10.0, 10.0, 5.0])
-    neighbors = ops_data.range_search(query_ra, query_dec, 0.5)
+    neighbors = ops_data.range_search(query_ra, query_dec, radius=0.5)
     assert len(neighbors) == 3
     assert set(neighbors[0]) == set([1, 2, 3])
     assert set(neighbors[1]) == set([4, 5])
@@ -403,7 +403,7 @@ def test_opsim_range_search():
     # Do the same query with time filtering.
     t_min = np.array([0.0, 5.0, 0.0])
     t_max = np.array([2.0, 11.0, 1.0])
-    neighbors = ops_data.range_search(query_ra, query_dec, 0.5, t_min=t_min, t_max=t_max)
+    neighbors = ops_data.range_search(query_ra, query_dec, radius=0.5, t_min=t_min, t_max=t_max)
     assert len(neighbors) == 3
     assert set(neighbors[0]) == set([1, 2])
     assert set(neighbors[1]) == set([5])
@@ -411,19 +411,19 @@ def test_opsim_range_search():
 
     # Test is_observed() with batched queries.
     assert np.array_equal(
-        ops_data.is_observed(query_ra, query_dec, 0.5),
+        ops_data.is_observed(query_ra, query_dec, radius=0.5),
         np.array([True, True, False]),
     )
 
     # Test that we fail if bad query arrays are provided.
     with pytest.raises(ValueError):
-        _ = ops_data.range_search(None, None, 0.5)
+        _ = ops_data.range_search(None, None, radius=0.5)
     with pytest.raises(ValueError):
-        _ = ops_data.range_search([1.0, 2.3], 4.5, 0.5)
+        _ = ops_data.range_search([1.0, 2.3], 4.5, radius=0.5)
     with pytest.raises(ValueError):
-        _ = ops_data.range_search([1.0, 2.3], [4.5, 6.7, 8.9], 0.5)
+        _ = ops_data.range_search([1.0, 2.3], [4.5, 6.7, 8.9], radius=0.5)
     with pytest.raises(ValueError):
-        _ = ops_data.range_search([1.0, 2.3], [4.5, None], 0.5)
+        _ = ops_data.range_search([1.0, 2.3], [4.5, None], radius=0.5)
 
 
 def test_opsim_get_observations():
@@ -438,35 +438,35 @@ def test_opsim_get_observations():
     ops_data = OpSim(values)
 
     # Test basic queries (all columns).
-    obs = ops_data.get_observations(15.0, 10.0, 0.5)
+    obs = ops_data.get_observations(15.0, 10.0, radius=0.5)
     assert len(obs) == 4
     assert np.allclose(obs["time"], [1.0, 2.0, 3.0])
 
-    obs = ops_data.get_observations(25.0, 10.0, 0.5)
+    obs = ops_data.get_observations(25.0, 10.0, radius=0.5)
     assert np.allclose(obs["time"], [4.0, 5.0])
 
-    obs = ops_data.get_observations(15.0, 10.0, 100.0)
+    obs = ops_data.get_observations(15.0, 10.0, radius=100.0)
     assert np.allclose(obs["time"], [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0])
 
-    obs = ops_data.get_observations(15.0, 10.0, 1e-6)
+    obs = ops_data.get_observations(15.0, 10.0, radius=1e-6)
     assert np.allclose(obs["time"], [1.0])
 
-    obs = ops_data.get_observations(15.02, 10.0, 1e-6)
+    obs = ops_data.get_observations(15.02, 10.0, radius=1e-6)
     assert len(obs["time"]) == 0
 
     # Test we can get a subset of columns.
-    obs = ops_data.get_observations(15.0, 10.0, 0.5, cols=["time", "zp"])
+    obs = ops_data.get_observations(15.0, 10.0, radius=0.5, cols=["time", "zp"])
     assert len(obs) == 2
     assert np.allclose(obs["time"], [1.0, 2.0, 3.0])
 
     # Test we can use the colmap names.
-    obs = ops_data.get_observations(15.0, 10.0, 0.5, cols=["time", "ra"])
+    obs = ops_data.get_observations(15.0, 10.0, radius=0.5, cols=["time", "ra"])
     assert len(obs) == 2
     assert np.allclose(obs["time"], [1.0, 2.0, 3.0])
 
     # Test we fail with an unrecognized column name.
     with pytest.raises(KeyError):
-        _ = ops_data.get_observations(15.0, 10.0, 0.5, cols=["time", "custom_col"])
+        _ = ops_data.get_observations(15.0, 10.0, radius=0.5, cols=["time", "custom_col"])
 
 
 def test_opsim_docstring():


### PR DESCRIPTION
For the ObsTable range-search queries, require that the optional parameters be specified with a kwarg tag. Previously we let radius be an optional positional argument. But now we require it to be `radius=` for clarity.