### PR TITLE
Fix issue487

### DIFF
--- a/src/lightcurvelynx/models/agn.py
+++ b/src/lightcurvelynx/models/agn.py
@@ -92,6 +92,9 @@ class AGN(SEDModel):
         The black hole mass in solar masses.
     edd_ratio: float
         Eddington ratio
+    node_label : str, optional
+        The label for the node in the model graph.
+        Default: None
     seed : int, optional
         The seed to use for the random number generator.
         Default: None
@@ -99,8 +102,10 @@ class AGN(SEDModel):
         Additional keyword arguments.
     """
 
-    def __init__(self, t0, blackhole_mass, edd_ratio, seed=None, **kwargs):
-        super().__init__(t0=t0, **kwargs)
+    def __init__(self, t0, blackhole_mass, edd_ratio, node_label=None, seed=None, **kwargs):
+        # We manually specify "node_label" as a parameter so it does not get
+        # passed to the functions nodes below as part of kwargs.
+        super().__init__(t0=t0, node_label=node_label, **kwargs)
 
         if "redshift" not in kwargs:
             raise ValueError("'redshift' parameter is required for the AGN model.")

--- a/src/lightcurvelynx/models/physical_model.py
+++ b/src/lightcurvelynx/models/physical_model.py
@@ -50,6 +50,8 @@ class BasePhysicalModel(ParameterizedNode, ABC):
         The object's luminosity distance (in pc). If no value is provided and
         a cosmology parameter is given, the model will try to derive from
         the redshift and the cosmology.
+    node_label : str, optional
+        The label for the node in the model graph.
     seed : int, optional
         The seed for a random number generator.
     **kwargs : dict, optional
@@ -58,15 +60,17 @@ class BasePhysicalModel(ParameterizedNode, ABC):
 
     def __init__(
         self,
+        *,
         ra=None,
         dec=None,
         redshift=None,
         t0=None,
         distance=None,
+        node_label=None,
         seed=None,
         **kwargs,
     ):
-        super().__init__(**kwargs)
+        super().__init__(node_label=node_label, **kwargs)
 
         # Set the parameters for the model.
         self.add_parameter("ra", ra, allow_gradient=False)

--- a/tests/lightcurvelynx/models/test_agn.py
+++ b/tests/lightcurvelynx/models/test_agn.py
@@ -153,6 +153,7 @@ def test_create_agn():
         redshift=1.0,
         edd_ratio=0.9,
         cosmology="Planck18",
+        node_label="AGN_0",
     )
     state = agn_node.sample_parameters(num_samples=10_000)
 


### PR DESCRIPTION
Closes #487 

The node label was being passed to the superclass via kwargs. Since those were also passed to internal function nodes, those nodes were getting the same label. This change passes node label directly so it does not get passed to the function nodes.