### PR TITLE
Fix problems with RA, dec sampling

### DIFF
--- a/src/lightcurvelynx/math_nodes/ra_dec_sampler.py
+++ b/src/lightcurvelynx/math_nodes/ra_dec_sampler.py
@@ -85,7 +85,7 @@ class ObsTableRADECSampler(TableSampler):
     data : ObsTable
         The ObsTable object to use for sampling.
     radius : float
-        The radius of the observations in degrees. Use 0.0 to just sample
+        The radius of the the field of view of the observations in degrees. Use 0.0 to just sample
         the centers of the images. Default: None
     in_order : bool
         Return the given data in order of the rows (True). If False, performs
@@ -167,7 +167,7 @@ class ObsTableUniformRADECSampler(NumpyRandomFunc):
     data : ObsTable
         The ObsTable object to use for sampling.
     radius : float
-        The radius of the observations in degrees.
+        The radius of the field of view of the observations in degrees.
     max_iterations : int
         The maximum number of iterations to perform. Default: 1000
 

--- a/src/lightcurvelynx/math_nodes/ra_dec_sampler.py
+++ b/src/lightcurvelynx/math_nodes/ra_dec_sampler.py
@@ -86,13 +86,17 @@ class ObsTableRADECSampler(TableSampler):
         The ObsTable object to use for sampling.
     radius : float
         The radius of the observations in degrees. Use 0.0 to just sample
-        the centers of the images. Default: 0.0
+        the centers of the images. Default: None
     in_order : bool
         Return the given data in order of the rows (True). If False, performs
         random sampling with replacement. Default: False
     """
 
-    def __init__(self, data, radius=0.0, in_order=False, **kwargs):
+    def __init__(self, data, radius=None, in_order=False, **kwargs):
+        if radius is None:
+            radius = data.survey_values.get("radius", None)
+            if radius is None:
+                raise ValueError("ObsTable has no radius. Must provide radius.")
         if radius < 0.0:
             raise ValueError("Invalid radius: {radius}")
         self.radius = radius
@@ -163,15 +167,34 @@ class ObsTableUniformRADECSampler(NumpyRandomFunc):
     data : ObsTable
         The ObsTable object to use for sampling.
     radius : float
-        The radius of the observations in degrees. Must be > 0.0.
-        Default: 1.0
+        The radius of the observations in degrees.
     max_iterations : int
         The maximum number of iterations to perform. Default: 1000
+
+    Parameters
+    ----------
+    data : ObsTable
+        The ObsTable object to use for sampling.
+    radius : float, optional
+        The search radius around the center of the pointing. If None, uses the
+        value from the ObsTable.
+    outputs : list of str, optional
+        The list of output names. Default: ["ra", "dec"]
+    seed : int, optional
+        The random seed to use for the internal random number generator. Default: None
+    max_iterations : int, optional
+        The maximum number of iterations to perform. Default: 1000
+    **kwargs : dict, optional
+        Additional keyword arguments to pass to the parent class constructor.
     """
 
-    def __init__(self, data, radius=1.0, outputs=None, seed=None, max_iterations=1000, **kwargs):
+    def __init__(self, data, *, radius=None, outputs=None, seed=None, max_iterations=1000, **kwargs):
+        if radius is None:
+            radius = data.survey_values.get("radius", None)
+            if radius is None:
+                raise ValueError("ObsTable has no radius. Must provide radius.")
         if radius <= 0.0:
-            raise ValueError("Invalid radius: {radius}")
+            raise ValueError(f"Invalid override_radius: {radius}")
         self.radius = radius
 
         if len(data) == 0:

--- a/src/lightcurvelynx/obstable/obs_table.py
+++ b/src/lightcurvelynx/obstable/obs_table.py
@@ -152,6 +152,19 @@ class ObsTable:
         return value
 
     @property
+    def radius(self):
+        """Return the radius if it exists."""
+        return self.survey_values.get("radius", None)
+
+    @radius.setter
+    def radius(self, new_val):
+        """Create a setter for radius."""
+        if new_val <= 0:
+            raise ValueError(f"Invalid radius: {new_val}")
+        print("Setter called")
+        self.survey_values["radius"] = new_val
+
+    @property
     def columns(self):
         """Get the column names."""
         return self._table.columns

--- a/src/lightcurvelynx/obstable/obs_table.py
+++ b/src/lightcurvelynx/obstable/obs_table.py
@@ -161,7 +161,6 @@ class ObsTable:
         """Create a setter for radius."""
         if new_val <= 0:
             raise ValueError(f"Invalid radius: {new_val}")
-        print("Setter called")
         self.survey_values["radius"] = new_val
 
     @property

--- a/tests/lightcurvelynx/obstable/test_obs_table.py
+++ b/tests/lightcurvelynx/obstable/test_obs_table.py
@@ -120,6 +120,17 @@ def test_create_obs_table_override():
     assert ops_data2.survey_values["dark_current"] == 0.5
     assert ops_data2.survey_values["radius"] == 1.0
 
+    # We can use the radius to get and set the property.
+    assert ops_data2.radius == 1.0
+    ops_data2.radius = 5.0
+    assert ops_data2.survey_values["radius"] == 5.0
+
+    # If we delete the radius survey value, we get None and can reset it.
+    del ops_data2.survey_values["radius"]
+    assert ops_data2.radius is None
+    ops_data2.radius = 5.0
+    assert ops_data2.survey_values["radius"] == 5.0
+
 
 def test_create_obs_table_custom_names():
     """Create a minimal ObsTable object from alternate column names."""


### PR DESCRIPTION
There were a few bugs found when debugging @mi-dai 's notebook that this PR fixes:

1) We should use the OpsTable's radius for RA, dec sampling unless a specific alternative is provided.

2) The `radius` attribute had been moved to a dictionary entry so the assignment `ztf_obstable.radius` was not being used in the actual simulation. This PR adds a property that allows user to access and set ObsTable radius with `.radius`