### PR TITLE
Add a helper copy method to GraphState

### DIFF
--- a/src/lightcurvelynx/graph_state.py
+++ b/src/lightcurvelynx/graph_state.py
@@ -173,6 +173,27 @@ class GraphState:
         else:
             raise KeyError(f"Unknown GraphState key: {key}")
 
+    def copy(self):
+        """Create a deep copy of the GraphState.
+
+        Returns
+        -------
+        GraphState
+            The copied GraphState.
+        """
+        new_state = GraphState(num_samples=self.num_samples)
+        new_state.num_parameters = self.num_parameters
+        for node_name, node_vars in self.states.items():
+            new_state.states[node_name] = {}
+            for var_name, var_value in node_vars.items():
+                if self.num_samples == 1:
+                    new_state.states[node_name][var_name] = var_value
+                else:
+                    new_state.states[node_name][var_name] = var_value.copy()
+        for node_name, fixed_vars in self.fixed_vars.items():
+            new_state.fixed_vars[node_name] = fixed_vars.copy()
+        return new_state
+
     @staticmethod
     def extended_param_name(node_name, param_name):
         """A helper function to create the full parameter name.

--- a/tests/lightcurvelynx/test_graph_state.py
+++ b/tests/lightcurvelynx/test_graph_state.py
@@ -263,6 +263,50 @@ def test_create_single_graph_state_from_nested_dict():
         _ = GraphState.from_dict(input, num_samples=2)
 
 
+def test_graph_state_copy():
+    """Test that we can deep copy a GraphState."""
+    state = GraphState()
+    state.set("a", "v1", 1.0)
+    state.set("a", "v2", 2.0)
+    state.set("b", "v1", 3.0)
+
+    state2 = state.copy()
+    state2.set("a", "v1", 10.0)
+    state2.set("a", "v2", 20.0)
+    state2.set("b", "v1", 30.0)
+
+    # State 1 is unchanged
+    assert state["a"]["v1"] == 1.0
+    assert state["a"]["v2"] == 2.0
+    assert state["b"]["v1"] == 3.0
+
+    # State 2 has the new values.
+    assert state2["a"]["v1"] == 10.0
+    assert state2["a"]["v2"] == 20.0
+    assert state2["b"]["v1"] == 30.0
+
+    # Test with arrays.
+    state = GraphState(3)
+    state.set("a", "v1", np.array([1.0, 2.0, 3.0]))
+    state.set("a", "v2", np.array([2.0, 3.0, 4.0]))
+    state.set("b", "v1", np.array([3.0, 4.0, 5.0]))
+
+    state2 = state.copy()
+    state2["a.v1"][1] = 10.0
+    state2["a.v2"][0] = 20.0
+    state2["b.v1"][2] = 30.0
+
+    # State 1 is unchanged
+    assert np.array_equal(state["a"]["v1"], [1.0, 2.0, 3.0])
+    assert np.array_equal(state["a"]["v2"], [2.0, 3.0, 4.0])
+    assert np.array_equal(state["b"]["v1"], [3.0, 4.0, 5.0])
+
+    # State 2 has the new values.
+    assert np.array_equal(state2["a"]["v1"], [1.0, 10.0, 3.0])
+    assert np.array_equal(state2["a"]["v2"], [20.0, 3.0, 4.0])
+    assert np.array_equal(state2["b"]["v1"], [3.0, 4.0, 30.0])
+
+
 def test_create_single_graph_state_from_list():
     """Test that we can create a single GraphState from a list of states."""
     state1 = GraphState(num_samples=1)


### PR DESCRIPTION
This lets us eventually copy and modify GraphStates to try other configurations (e.g. setting t0 to 0.0).