### PR TITLE
Rename footprint

### DIFF
--- a/src/lightcurvelynx/astro_utils/noise_model.py
+++ b/src/lightcurvelynx/astro_utils/noise_model.py
@@ -9,7 +9,7 @@ def poisson_bandflux_std(
     *,
     total_exposure_time: npt.ArrayLike,
     exposure_count: npt.ArrayLike,
-    footprint: npt.ArrayLike,
+    psf_footprint: npt.ArrayLike,
     sky: npt.ArrayLike,
     zp: npt.ArrayLike,
     readout_noise: npt.ArrayLike | Callable,
@@ -29,7 +29,7 @@ def poisson_bandflux_std(
     sky : array_like of float
         Sky background per unit angular area,
         in the units of electrons / pixel^2.
-    footprint : array_like of float
+    psf_footprint : array_like of float
         Point spread function effective area, in pixel^2.
     zp : array_like of float
         Zero point bandflux for the observation, i.e. bandflux
@@ -66,12 +66,12 @@ def poisson_bandflux_std(
     # Get variances, in electrons^2
 
     source_variance = bandflux / zp
-    sky_variance = sky * footprint
+    sky_variance = sky * psf_footprint
     if callable(readout_noise):
         readout_variance = readout_noise(total_exposure_time) ** 2
     else:
-        readout_variance = readout_noise**2 * footprint * exposure_count
-    dark_variance = dark_current * total_exposure_time * footprint
+        readout_variance = readout_noise**2 * psf_footprint * exposure_count
+    dark_variance = dark_current * total_exposure_time * psf_footprint
 
     total_variance = source_variance + sky_variance + readout_variance + dark_variance
 

--- a/src/lightcurvelynx/obstable/opsim.py
+++ b/src/lightcurvelynx/obstable/opsim.py
@@ -166,7 +166,7 @@ class OpSim(ObsTable):
         # https://smtn-002.lsst.io/v/OPSIM-1171/index.html
         # We need it in pixel^2
         pixel_scale = self.safe_get_survey_value("pixel_scale")
-        footprint = GAUSS_EFF_AREA2FWHM_SQ * (observations["seeing"] / pixel_scale) ** 2
+        psf_footprint = GAUSS_EFF_AREA2FWHM_SQ * (observations["seeing"] / pixel_scale) ** 2
         zp = observations["zp"]
 
         # Table value is in mag/arcsec^2
@@ -178,7 +178,7 @@ class OpSim(ObsTable):
             bandflux,
             total_exposure_time=observations["exptime"],
             exposure_count=observations["nexposure"],
-            footprint=footprint,
+            psf_footprint=psf_footprint,
             sky=sky,
             zp=zp,
             readout_noise=self.safe_get_survey_value("read_noise"),

--- a/src/lightcurvelynx/obstable/roman_obstable.py
+++ b/src/lightcurvelynx/obstable/roman_obstable.py
@@ -233,7 +233,7 @@ class RomanObsTable(ObsTable):
             bandflux,  # nJy
             total_exposure_time=observations["exptime"],
             exposure_count=1,
-            footprint=observations["N_Eff_Pix"],
+            psf_footprint=observations["N_Eff_Pix"],
             sky=observations["sky"],
             zp=observations["zp"] / observations["exptime"],  # (nJy/s * s)^-1
             readout_noise=self.readnoise_func,  # e-/pixel

--- a/src/lightcurvelynx/obstable/ztf_obstable.py
+++ b/src/lightcurvelynx/obstable/ztf_obstable.py
@@ -234,7 +234,7 @@ class ZTFObsTable(ObsTable):
             bandflux,  # nJy
             total_exposure_time=observations["exptime"],
             exposure_count=1,
-            footprint=footprint,
+            psf_footprint=footprint,
             sky=observations["sky"] * self.safe_get_survey_value("gain"),  # e-/pixel^2
             zp=observations["zp"],  # nJy
             readout_noise=self.safe_get_survey_value("read_noise"),  # e-/pixel

--- a/tests/lightcurvelynx/astro_utils/test_noise_model.py
+++ b/tests/lightcurvelynx/astro_utils/test_noise_model.py
@@ -15,7 +15,7 @@ def test_poisson_flux_std_flux():
         bandflux=flux,
         total_exposure_time=rng.uniform(),
         exposure_count=rng.integers(1, 100),
-        footprint=rng.uniform(),
+        psf_footprint=rng.uniform(),
         sky=0.0,
         zp=1.0,
         readout_noise=0.0,
@@ -34,14 +34,14 @@ def test_poisson_flux_std_sky():
 
     zp = 10.0
     sky = 10 ** rng.uniform(-2.0, 2.0, n)
-    footprint = 10 ** rng.uniform(0.0, 2.0, n)
-    expected_flux_err = np.sqrt(sky * footprint) * zp
+    psf_footprint = 10 ** rng.uniform(0.0, 2.0, n)
+    expected_flux_err = np.sqrt(sky * psf_footprint) * zp
 
     flux_err = poisson_bandflux_std(
         bandflux=0.0,
         total_exposure_time=rng.uniform(),
         exposure_count=rng.integers(1, 100),
-        footprint=footprint,
+        psf_footprint=psf_footprint,
         sky=sky,
         zp=zp,
         readout_noise=0.0,
@@ -59,15 +59,15 @@ def test_poisson_flux_std_readout():
     n = 100
 
     readout_noise = 10 ** rng.uniform(-2.0, 2.0, n)
-    footprint = 10 ** rng.uniform(0.0, 2.0, n)
+    psf_footprint = 10 ** rng.uniform(0.0, 2.0, n)
     exposure_count = rng.integers(1, 100, n)
-    expected_flux_err = readout_noise * np.sqrt(footprint) * np.sqrt(exposure_count)
+    expected_flux_err = readout_noise * np.sqrt(psf_footprint) * np.sqrt(exposure_count)
 
     flux_err = poisson_bandflux_std(
         bandflux=0.0,
         total_exposure_time=rng.uniform(),
         exposure_count=exposure_count,
-        footprint=footprint,
+        psf_footprint=psf_footprint,
         sky=0.0,
         zp=1.0,
         readout_noise=readout_noise,
@@ -86,16 +86,16 @@ def test_poisson_flux_std_dark():
 
     dark_current = 10 ** rng.uniform(-2.0, 2.0, n)
     total_exposure_time = rng.uniform(1.0, 3.0, n)
-    footprint = 10 ** rng.uniform(0.0, 2.0, n)
+    psf_footprint = 10 ** rng.uniform(0.0, 2.0, n)
 
-    dark_current_total = dark_current * total_exposure_time * footprint
+    dark_current_total = dark_current * total_exposure_time * psf_footprint
     expected_flux_err = np.sqrt(dark_current_total)
 
     flux_err = poisson_bandflux_std(
         bandflux=0.0,
         total_exposure_time=total_exposure_time,
         exposure_count=rng.integers(1, 100, n),
-        footprint=footprint,
+        psf_footprint=psf_footprint,
         sky=0.0,
         zp=1.0,
         readout_noise=0.0,
@@ -118,7 +118,7 @@ def test_readout_noise_from_function():
 
     n = 100
 
-    footprint = 10 ** rng.uniform(0.0, 2.0, n)
+    psf_footprint = 10 ** rng.uniform(0.0, 2.0, n)
     exposure_time = rng.uniform(30, 100, n)
     expected_flux_err = readout_noise_function(exptime=exposure_time)
 
@@ -126,7 +126,7 @@ def test_readout_noise_from_function():
         bandflux=0.0,
         total_exposure_time=exposure_time,
         exposure_count=1,
-        footprint=footprint,
+        psf_footprint=psf_footprint,
         sky=0.0,
         zp=1.0,
         readout_noise=readout_noise_function,

--- a/tests/lightcurvelynx/obstable/test_fake_obs_table.py
+++ b/tests/lightcurvelynx/obstable/test_fake_obs_table.py
@@ -31,7 +31,7 @@ def test_create_fake_obs_table_consts():
     assert np.allclose(ops_data["zp"], [27.0, 26.0, 27.0, 28.0, 26.0])
 
     # Derived from fwhm_px.
-    assert np.allclose(ops_data["footprint"], [GAUSS_EFF_AREA2FWHM_SQ * (2.0) ** 2] * 5)
+    assert np.allclose(ops_data["psf_footprint"], [GAUSS_EFF_AREA2FWHM_SQ * (2.0) ** 2] * 5)
 
     assert ops_data.survey_values["dark_current"] == 0
     assert ops_data.survey_values["nexposure"] == 1
@@ -49,9 +49,9 @@ def test_create_fake_obs_table_consts():
     assert np.all(flux_error > 0)
     assert len(np.unique(flux_error)) > 1  # Not all the same
 
-    # If we give footprint, we use that instead of fwhm_px.
-    ops_data = FakeObsTable(pdf, zp_per_band=zp_per_band, fwhm_px=2.0, footprint=1.0, sky=100.0)
-    assert np.allclose(ops_data["footprint"], [1.0] * 5)
+    # If we give psf_footprint, we use that instead of fwhm_px.
+    ops_data = FakeObsTable(pdf, zp_per_band=zp_per_band, fwhm_px=2.0, psf_footprint=1.0, sky=100.0)
+    assert np.allclose(ops_data["psf_footprint"], [1.0] * 5)
 
     # We can override the defaults, using dictionaries of values for fwhm_px and sky.
     ops_data = FakeObsTable(


### PR DESCRIPTION
Closes #499 

Renames the `footprint` parameter in both the ObsTable classes and the noise functions to `psf_footprint` to avoid any confusion with the detector's footprint.