### PR TITLE
replace time with obsmjd in obstable calculation to avoid error about…

### DIFF
--- a/src/lightcurvelynx/obstable/ztf_obstable.py
+++ b/src/lightcurvelynx/obstable/ztf_obstable.py
@@ -137,10 +137,10 @@ class ZTFObsTable(ObsTable):
 
         # Make a copy of the table data with the obsdate converted to the MJD and
         # save in time.
-        if "obsdate" in table and "time" not in table:
+        if "obsdate" in table and "obsmjd" not in table:
             table = table.copy()
             t = Time(list(table["obsdate"]), format="iso", scale="utc")
-            table["time"] = t.mjd
+            table["obsmjd"] = t.mjd
 
         super().__init__(table, colmap=colmap, **kwargs)
 

--- a/src/lightcurvelynx/obstable/ztf_obstable.py
+++ b/src/lightcurvelynx/obstable/ztf_obstable.py
@@ -242,7 +242,7 @@ class ZTFObsTable(ObsTable):
         )
 
 
-def create_random_ztf_obstable(num_obs, seed=None):
+def create_random_ztf_obs_data(num_obs, seed=None):
     """Create a random ObsTable pointings drawn uniformly from (RA, dec).
 
     Parameters
@@ -256,10 +256,8 @@ def create_random_ztf_obstable(num_obs, seed=None):
 
     Returns
     -------
-    obstable : ZTFObsTable
-        The ObsTable data structure.
-    seed : int, optional
-        The seed for the random number generator.
+    obstable : pd.DataFrame
+        The data for the ObsTable.
     """
     if num_obs <= 0:
         raise ValueError("Number of observations must be greater than zero.")
@@ -286,7 +284,4 @@ def create_random_ztf_obstable(num_obs, seed=None):
         "filter": filter,
         "exptime": 30.0 * np.ones(num_obs),
     }
-
-    obstable = ZTFObsTable(input_data)
-
-    return obstable
+    return pd.DataFrame(input_data)

--- a/tests/lightcurvelynx/obstable/test_ztf_obstable.py
+++ b/tests/lightcurvelynx/obstable/test_ztf_obstable.py
@@ -4,7 +4,7 @@ import pytest
 from lightcurvelynx.obstable.ztf_obstable import (
     ZTFObsTable,
     calculate_ztf_zero_points,
-    create_random_ztf_obstable,
+    create_random_ztf_obs_data,
 )
 from scipy.optimize import fsolve
 
@@ -57,7 +57,7 @@ def test_calculate_ztf_zero_points():
 
 def test_ztf_obstable_init():
     """Test initializing ZTFObsTable."""
-    survey_data_table = create_random_ztf_obstable(100)._table
+    survey_data_table = create_random_ztf_obs_data(100)
     survey_data = ZTFObsTable(table=survey_data_table)
 
     assert "zp" in survey_data
@@ -74,7 +74,7 @@ def test_ztf_obstable_init():
 
 def test_create_ztf_obstable_override():
     """Test that we can override the default survey values."""
-    survey_data_table = create_random_ztf_obstable(100)._table
+    survey_data_table = create_random_ztf_obs_data(100)
 
     survey_data = ZTFObsTable(
         table=survey_data_table,


### PR DESCRIPTION
`time` column was assigned in ZTFObsTable (when converting `obsdate` to `obsmjd`, which will cause error when using a new colmap that include `time`. Changed to `obsmjd`.