### PR TITLE
Move ZTF zeropoint code into zeropoint.py

### DIFF
--- a/tests/lightcurvelynx/astro_utils/test_zeropoint.py
+++ b/tests/lightcurvelynx/astro_utils/test_zeropoint.py
@@ -1,7 +1,12 @@
 import numpy as np
 from lightcurvelynx.astro_utils.mag_flux import flux2mag
-from lightcurvelynx.astro_utils.zeropoint import flux_electron_zeropoint, magnitude_electron_zeropoint
+from lightcurvelynx.astro_utils.zeropoint import (
+    calculate_zp_from_maglim,
+    flux_electron_zeropoint,
+    magnitude_electron_zeropoint,
+)
 from lightcurvelynx.obstable.opsim import LSSTCAM_PIXEL_SCALE, _lsstcam_dark_current, _lsstcam_readout_noise
+from scipy.optimize import fsolve
 
 
 def test_magnitude_electron_zeropoint():
@@ -84,3 +89,56 @@ def test_flux_electron_zeropoint_docstring():
     """Check if flux_electron_zeropoint has a docstring"""
     assert flux_electron_zeropoint.__doc__ is not None
     assert len(flux_electron_zeropoint.__doc__) > 100
+
+
+def _fluxeq(
+    flux, sky=None, gain=None, readnoise=None, nexposure=1, fwhm=None, darkcurrent=None, exptime=None
+):
+    """Define the equation to solve for flux at 5-sigma limit"""
+
+    npix = 2.266 * fwhm**2  # = 4 * pi * sigma**2 = pi/2/ln2 * FWHM**2
+    y = (
+        flux**2
+        - 25 * flux
+        - 25
+        * (sky * npix * gain + readnoise**2 * nexposure * npix + darkcurrent * npix * exptime * nexposure)
+    )
+    return y
+
+
+def test_zp_from_maglim():
+    """Test the calculation with numerical solution to the maglim function."""
+    maglim = 19.0
+    sky = 100.0
+    fwhm = 1.5
+    gain = 1.0
+    readnoise = 10.0
+    darkcurrent = 0.1
+    exptime = 30.0
+
+    root = fsolve(
+        lambda x: _fluxeq(
+            x,
+            sky=sky,
+            gain=gain,
+            readnoise=readnoise,
+            fwhm=fwhm,
+            darkcurrent=darkcurrent,
+            exptime=exptime,
+        ),
+        [100],
+    )
+    zp_expected = 2.5 * np.log10(root) + maglim
+
+    zp_cal = calculate_zp_from_maglim(
+        maglim=maglim,
+        sky=sky,
+        fwhm=fwhm,
+        gain=gain,
+        readnoise=readnoise,
+        darkcurrent=darkcurrent,
+        exptime=exptime,
+        nexposure=1,
+    )
+
+    assert np.isclose(zp_cal, zp_expected)

--- a/tests/lightcurvelynx/obstable/test_ztf_obstable.py
+++ b/tests/lightcurvelynx/obstable/test_ztf_obstable.py
@@ -1,58 +1,7 @@
 import numpy as np
 import pandas as pd
 import pytest
-from lightcurvelynx.obstable.ztf_obstable import (
-    ZTFObsTable,
-    calculate_ztf_zero_points,
-    create_random_ztf_obstable,
-)
-from scipy.optimize import fsolve
-
-
-def fluxeq(flux, sky=None, gain=None, readnoise=None, nexposure=1, fwhm=None, darkcurrent=None, exptime=None):
-    """Define the equation to solve for flux at 5-sigma limit"""
-
-    npix = 2.266 * fwhm**2  # =4*pi*sigma**2 = pi/2/ln2 * FWHM**2
-    y = (
-        flux**2
-        - 25 * flux
-        - 25
-        * (sky * npix * gain + readnoise**2 * nexposure * npix + darkcurrent * npix * exptime * nexposure)
-    )
-    return y
-
-
-def test_calculate_ztf_zero_points():
-    """Test the calculation with numerical solution to the maglim function."""
-
-    maglim = 19.0
-    sky = 100.0
-    fwhm = 1.5
-    gain = 1.0
-    readnoise = 10.0
-    darkcurrent = 0.1
-    exptime = 30.0
-
-    root = fsolve(
-        lambda x: fluxeq(
-            x, sky=sky, gain=gain, readnoise=readnoise, fwhm=fwhm, darkcurrent=darkcurrent, exptime=exptime
-        ),
-        [100],
-    )
-    zp_expected = 2.5 * np.log10(root) + maglim
-
-    zp_cal = calculate_ztf_zero_points(
-        maglim=maglim,
-        sky=sky,
-        fwhm=fwhm,
-        gain=gain,
-        readnoise=readnoise,
-        darkcurrent=darkcurrent,
-        exptime=exptime,
-        nexposure=1,
-    )
-
-    assert np.isclose(zp_cal, zp_expected)
+from lightcurvelynx.obstable.ztf_obstable import ZTFObsTable, create_random_ztf_obstable
 
 
 def test_ztf_obstable_init():


### PR DESCRIPTION
Small reorganization PR. Move the code to compute the zero points from maglim into the zeropoint.py file. Call it from ZTFObsTable with the ZTF default parameters.