### PR TITLE
Fix flaky tests

### DIFF
--- a/tests/lightcurvelynx/astro_utils/test_mag_flux.py
+++ b/tests/lightcurvelynx/astro_utils/test_mag_flux.py
@@ -19,16 +19,18 @@ def test_mag2flux():
 
 
 def test_mag2flux2mag():
-    """Tesst that mag2flux inverts flux2mag."""
-    mag = np.random.uniform(-10, 30, 1024)
+    """Test that mag2flux inverts flux2mag."""
+    rng = np.random.default_rng(42)
+    mag = rng.uniform(-10, 30, 1024)
     flux = mag2flux(mag)
     mag2 = flux2mag(flux)
     np.testing.assert_allclose(mag, mag2, rtol=1e-10)
 
 
 def test_flux2mag2flux():
-    """Tesst that flux2mag inverts mag2flux."""
-    flux = np.random.uniform(1e-3, 1e3, 1024)
+    """Test that flux2mag inverts mag2flux."""
+    rng = np.random.default_rng(43)
+    flux = rng.uniform(1e-3, 1e3, 1024)
     mag = flux2mag(flux)
     flux2 = mag2flux(mag)
     np.testing.assert_allclose(flux, flux2, rtol=1e-10)


### PR DESCRIPTION
Use a fixed random seed to prevent test flakiness. The tests fail very rarely due to small numerical precision issues (relative error just above 10e-10).