### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A Fast and Nimble Package for Time Domain Astronomy
 [![Template](https://img.shields.io/badge/Template-LINCC%20Frameworks%20Python%20Project%20Template-brightgreen)](https://lincc-ppt.readthedocs.io/en/latest/)
 
 [![PyPI](https://img.shields.io/pypi/v/lightcurvelynx?color=blue&logo=pypi&logoColor=white)](https://pypi.org/project/lightcurvelynx/)
-[![Conda Version](https://img.shields.io/conda/vn/conda-forge/citation-compass.svg)](https://anaconda.org/conda-forge/citation-compass)
+[![Conda Version](https://img.shields.io/conda/vn/conda-forge/lightcurvelynx.svg)](https://anaconda.org/conda-forge/lightcurvelynx)
 
 [![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/lincc-frameworks/lightcurvelynx/smoke-test.yml)](https://github.com/lincc-frameworks/lightcurvelynx/actions/workflows/smoke-test.yml)
 [![Codecov](https://codecov.io/gh/lincc-frameworks/lightcurvelynx/branch/main/graph/badge.svg)](https://codecov.io/gh/lincc-frameworks/lightcurvelynx)


### PR DESCRIPTION
Fix the conda-forge badge to point to LightCurveLynx (it is currently pointing to citation-compass).