### PR TITLE
Rename the tables in the Passbands

### DIFF
--- a/src/lightcurvelynx/example_runs/simulate_snia.py
+++ b/src/lightcurvelynx/example_runs/simulate_snia.py
@@ -123,7 +123,7 @@ def load_and_register_passband(passbands_dir, to_use):
     # Register sncosmo bandpasses
     for f, passband in passbands.passbands.items():
         sncosmo_bandpass = sncosmo.Bandpass(
-            *passband.processed_transmission_table.T, name=f"lightcurvelynx_{f}"
+            *passband.normalized_system_response.T, name=f"lightcurvelynx_{f}"
         )
         sncosmo.register(sncosmo_bandpass, force=True)
 

--- a/src/lightcurvelynx/models/lightcurve_template_model.py
+++ b/src/lightcurvelynx/models/lightcurve_template_model.py
@@ -464,7 +464,7 @@ class BaseLightcurveTemplateModel(BandfluxModel, ABC):
         for idx, filter in enumerate(filters):
             # Get all of the wavelengths that have a non-negligible transmission value
             # for this filter and find their indices in the passband group.
-            is_significant = passbands[filter].processed_transmission_table[:, 1] > 1e-5
+            is_significant = passbands[filter].normalized_system_response[:, 1] > 1e-5
             significant_waves = passbands[filter].waves[is_significant]
             indices = np.searchsorted(passbands.waves, significant_waves)
 

--- a/tests/lightcurvelynx/astro_utils/test_passband_groups.py
+++ b/tests/lightcurvelynx/astro_utils/test_passband_groups.py
@@ -288,7 +288,7 @@ def test_passband_group_from_dir(tmp_path):
         assert filter in pb_group
 
         wave_start = int(transmission_tables[filter].split()[0])
-        assert wave_start == pb_group[filter]._loaded_table[0][0]
+        assert wave_start == pb_group[filter].transmission_table[0][0]
 
     # Check that we throw an error if we try to access an invalid directory.
     with pytest.raises(ValueError):


### PR DESCRIPTION
Rename the tables in the `Passband` class to be more accurate:

- `processed_transmission_table` -> `normalized_system_response`
- `_loaded_table` -> `transmission_table`