### PR TITLE
Do not show private class members

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -57,6 +57,8 @@ add_module_names = False
 autoapi_type = "python"
 autoapi_dirs = ["../src"]
 autoapi_ignore = ["*/__main__.py", "*/_version.py"]
+# Additional configuration to skip private members
+autoapi_python_class_content = "class"
 autoapi_add_toc_tree_entry = False
 autoapi_member_order = "bysource"
 autoapi_options = [
@@ -66,7 +68,7 @@ autoapi_options = [
     "show-module-summary",
     "special-members",
     "imported-members",
-]  # No private-members
+]
 
 html_theme = "sphinx_rtd_theme"
 
@@ -74,12 +76,15 @@ html_theme = "sphinx_rtd_theme"
 napoleon_custom_sections = ["Citations"]
 
 
-def skip_private_members(app, what, name, obj, skip, options):  # noqa: D103
-    if name.startswith("_") and not name.startswith("__"):  # Skip members starting with a single underscore
+def skip_private_members(app, what, name, obj, skip, options):
+    """Skip private members (those starting with a single underscore)."""
+    # Skip private members (single underscore) but keep special methods (double underscore)
+    if name.startswith("_") and not name.startswith("__"):
         return True
-    return None
+    # Let autoapi handle other cases
+    return skip
 
 
-def setup(app):  # noqa: D103
+def setup(app):
     """Set up the Sphinx app with custom configurations."""
     app.connect("autoapi-skip-member", skip_private_members)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -59,6 +59,14 @@ autoapi_dirs = ["../src"]
 autoapi_ignore = ["*/__main__.py", "*/_version.py"]
 autoapi_add_toc_tree_entry = False
 autoapi_member_order = "bysource"
+autoapi_options = [
+    "members",
+    "undoc-members",
+    "show-inheritance",
+    "show-module-summary",
+    "special-members",
+    "imported-members",
+]  # No private-members
 
 html_theme = "sphinx_rtd_theme"
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -78,10 +78,13 @@ autoapi_options = [
 # Try direct configuration approach
 def autoapi_skip_member_handler(app, what, name, obj, skip, options):
     """Direct handler for autoapi skip member."""
-    print(f"DEBUG: Direct handler called for {what} {name}")
-    if name.startswith("_") and not name.startswith("__"):
-        print(f"DEBUG: Direct handler skipping: {name}")
-        return True
+    member_name = name.split(".")[-1] if "." in name else name
+    print(f"DEBUG: Direct handler called for {what} {name}, member_name={member_name}")
+
+    if member_name.startswith("_") and not member_name.startswith("__"):
+        print(f"DEBUG: Direct handler FORCING SKIP: {member_name}")
+        return True  # Force skip private members
+
     return skip
 
 
@@ -92,10 +95,13 @@ autoapi_skip_member = autoapi_skip_member_handler
 # Alternative direct assignment approach
 def autoapi_skip_member_direct(app, what, name, obj, skip, options):
     """Module-level skip function that autoapi might find automatically."""
-    print(f"DEBUG: Module-level handler called for {what} {name}")
-    if name.startswith("_") and not name.startswith("__"):
-        print(f"DEBUG: Module-level handler skipping: {name}")
-        return True
+    member_name = name.split(".")[-1] if "." in name else name
+    print(f"DEBUG: Module-level handler called for {what} {name}, member_name={member_name}")
+
+    if member_name.startswith("_") and not member_name.startswith("__"):
+        print(f"DEBUG: Module-level handler FORCING SKIP: {member_name}")
+        return True  # Force skip private members
+
     return skip
 
 
@@ -107,21 +113,34 @@ napoleon_custom_sections = ["Citations"]
 
 def skip_private_members(app, what, name, obj, skip, options):
     """Skip private members during autoapi generation."""
-    print(f"DEBUG: skip_private_members called with: what={what}, name={name}, skip={skip}")
+    # Get just the member name (without module path)
+    member_name = name.split(".")[-1] if "." in name else name
+
+    print(
+        f"DEBUG: skip_private_members called with: what={what}, "
+        "name={name}, member_name={member_name}, skip={skip}"
+    )
 
     # Skip private members (single underscore) but keep special methods (double underscore)
-    if name.startswith("_") and not name.startswith("__"):
-        print(f"DEBUG: Skipping private member: {name}")
-        return True
+    if member_name.startswith("_") and not member_name.startswith("__"):
+        print(f"DEBUG: FORCING SKIP for private member: {member_name}")
+        return True  # Force skip private members
+
+    # For non-private members, use the default behavior
     return skip
 
 
 def skip_member_new_signature(app, what, name, obj, skip, options):
     """Alternative signature for autoapi skip member."""
-    print(f"DEBUG: New signature called with: what={what}, name={name}, skip={skip}")
-    if name.startswith("_") and not name.startswith("__"):
-        print(f"DEBUG: New signature skipping: {name}")
-        return True
+    member_name = name.split(".")[-1] if "." in name else name
+    print(
+        f"DEBUG: New signature called with: what={what}, name={name}, member_name={member_name}, skip={skip}"
+    )
+
+    if member_name.startswith("_") and not member_name.startswith("__"):
+        print(f"DEBUG: New signature FORCING SKIP: {member_name}")
+        return True  # Force skip private members
+
     return skip
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -81,10 +81,9 @@ def skip_private_members(app, what, name, obj, skip, options):
     """Skip private members during autoapi generation."""
     # Get just the member name (including the module path if present)
     # and skip if any component is private (starts with a single underscore).
-    member_names = name.split(".") if "." in name else [name]
-    for member_name in member_names:
-        if member_name.startswith("_") and not member_name.startswith("__"):
-            return True  # Force skip private members
+    member_name = name.split(".")[-1] if "." in name else name
+    if member_name.startswith("_") and not member_name.startswith("__"):
+        return True  # Force skip private members
 
     # For non-private members, use the default behavior
     return skip
@@ -93,3 +92,4 @@ def skip_private_members(app, what, name, obj, skip, options):
 def setup(app):
     """Set up the Sphinx app with custom configurations."""
     app.connect("autoapi-skip-member", skip_private_members)
+    app.connect("autodoc-skip-member", skip_private_members)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -72,3 +72,14 @@ html_theme = "sphinx_rtd_theme"
 
 # Support use of arbitrary section titles in docstrings
 napoleon_custom_sections = ["Citations"]
+
+
+def skip_private_members(app, what, name, obj, skip, options):  # noqa: D103
+    if name.startswith("_") and not name.startswith("__"):  # Skip members starting with a single underscore
+        return True
+    return None
+
+
+def setup(app):  # noqa: D103
+    """Set up the Sphinx app with custom configurations."""
+    app.connect("autoapi-skip-member", skip_private_members)


### PR DESCRIPTION
Set the documentation options so that private members are not included.