### PR TITLE
Alter comment wording when setting default survey values

### DIFF
--- a/src/lightcurvelynx/obstable/obs_table.py
+++ b/src/lightcurvelynx/obstable/obs_table.py
@@ -128,8 +128,7 @@ class ObsTable:
             if col not in self._table.columns:
                 raise KeyError(f"Missing required column: {col}")
 
-        # Save the survey values, overwriting anything that is manually specified
-        # as a keyword argument or provided in the table's metadata.
+        # Save the survey values, with table metadata and keyword arguments overwriting the defaults.
         self.survey_values = self._default_survey_values.copy()
         if "lightcurvelynx_survey_data" in self._table.attrs:
             metadata = self._table.attrs["lightcurvelynx_survey_data"]


### PR DESCRIPTION
This confused me for a minute when tracing through how `_default_survey_values` is handled. 

Rewriting to clarify that it is user-specified or metadata values which overwrite the default survey values.