### PR TITLE
Include static resources

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,7 +14,7 @@ sys.path.insert(0, os.path.abspath("../src/"))
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
-project = "lightcurvelynx"
+project = "LightCurveLynx"
 copyright = "2024, LINCC Frameworks"
 author = "LINCC Frameworks"
 release = version("lightcurvelynx")


### PR DESCRIPTION
Static resources, like images, are not found by the RTD build system.

<img width="792" height="673" alt="image" src="https://github.com/user-attachments/assets/80cf244c-5ac7-40c7-a538-0b2ae3c73d2a" />
