### PR TITLE
Switch DetectorFootprint units to be consistent with ObsTable

### DIFF
--- a/docs/notebooks/detector_footprint.ipynb
+++ b/docs/notebooks/detector_footprint.ipynb
@@ -38,7 +38,7 @@
     "\n",
     "The `DetectorFootprint` class is a wrapper around the AstroPy region that handles data validation, handles transformations, and provides helper functions. Most users will not need to work with the `DetectorFootprint` directly as the wrapping will be handled automatically by the `ObsTable`.\n",
     "\n",
-    "We start by defining a rectangular footprint with a width of 2 degrees and a height of 1 degree. In addition to the shape information, the user needs to pass in either the wcs or pixel scale."
+    "We start by defining a rectangular footprint with a width of 2 degrees and a height of 1 degree. In addition to the shape information, the user needs to pass in either the wcs or pixel scale (in arcseconds per pixel)."
    ]
   },
   {
@@ -51,7 +51,7 @@
     "center = SkyCoord(ra=0.0, dec=0.0, unit=\"deg\", frame=\"icrs\")\n",
     "rect_region = RectangleSkyRegion(center=center, width=2.0 * u.deg, height=1.0 * u.deg, angle=0.0 * u.deg)\n",
     "\n",
-    "fp = DetectorFootprint(rect_region, pixel_scale=0.1)"
+    "fp = DetectorFootprint(rect_region, pixel_scale=10.0)"
    ]
   },
   {
@@ -197,7 +197,7 @@
     "region3 = RectanglePixelRegion(center=PixCoord(x=0, y=-30), width=41, height=5, angle=0.0 * u.deg)\n",
     "combined_region = region1 | region2 | region3\n",
     "\n",
-    "fp_combined = DetectorFootprint(combined_region, pixel_scale=0.5)"
+    "fp_combined = DetectorFootprint(combined_region, pixel_scale=0.5 * 3600.0)"
    ]
   },
   {

--- a/src/lightcurvelynx/astro_utils/detector_footprint.py
+++ b/src/lightcurvelynx/astro_utils/detector_footprint.py
@@ -28,7 +28,7 @@ class DetectorFootprint:
     wcs : astropy.wcs.WCS or None
         The WCS associated with the region, if any.
     pixel_scale : float or None
-        The pixel scale in degrees/pixel, this is required if no WCS is provided.
+        The pixel scale in arcseconds/pixel, this is required if no WCS is provided.
     center_pixels : tuple of float, optional
         The pixel coordinates of the center of the detector. Default is (0.5, 0.5) for
         the center of the (0, 0) pixel. This is only used if no WCS is provided and
@@ -42,13 +42,14 @@ class DetectorFootprint:
                 raise ValueError("Either wcs or pixel_scale must be provided.")
             if pixel_scale <= 0:
                 raise ValueError("pixel_scale must be positive.")
+            pixel_scale_deg = pixel_scale / 3600.0  # Convert to degrees/pixel
 
             # Create a simple TAN WCS centered on (0.0, 0.0) with the given pixel scale.
             wcs = WCS(naxis=2)
             wcs.wcs.ctype = ["RA---TAN", "DEC--TAN"]
             wcs.wcs.crval = [0.0, 0.0]  # Centered on RA=0.0, dec=0.0
             wcs.wcs.crpix = [center_pixels[0], center_pixels[1]]
-            wcs.wcs.cdelt = [pixel_scale, pixel_scale]  # The given pixel scale in degrees/pixel
+            wcs.wcs.cdelt = [-pixel_scale_deg, pixel_scale_deg]  # The given pixel scale in degrees/pixel
         self.wcs = wcs
 
         # Store the region as a pixel region, since we will always need to do a conversion
@@ -76,7 +77,7 @@ class DetectorFootprint:
         wcs : astropy.wcs.WCS, optional
             The WCS associated with the region. If None, a default WCS will be created.
         pixel_scale : float, optional
-            The pixel scale in degrees/pixel, this is required if no WCS is provided.
+            The pixel scale in arcseconds/pixel, this is required if no WCS is provided.
         **kwargs : dict
             Additional keyword arguments to pass to the RectangleSkyRegion constructor.
 
@@ -108,7 +109,7 @@ class DetectorFootprint:
         wcs : astropy.wcs.WCS, optional
             The WCS associated with the region. If None, a default WCS will be created.
         pixel_scale : float, optional
-            The pixel scale in degrees/pixel, this is required if no WCS is provided.
+            The pixel scale in arcseconds/pixel, this is required if no WCS is provided.
         **kwargs : dict
             Additional keyword arguments to pass to the RectangleSkyRegion constructor.
 

--- a/tests/lightcurvelynx/astro_utils/test_detector_footprint.py
+++ b/tests/lightcurvelynx/astro_utils/test_detector_footprint.py
@@ -58,7 +58,7 @@ def test_create_detector_footprint():
     """Test creating a DetectorFootprint."""
     center = SkyCoord(ra=0.0, dec=0.0, unit="deg", frame="icrs")
     circle_region = CircleSkyRegion(center=center, radius=1.0 * u.deg)
-    fp = DetectorFootprint(circle_region, pixel_scale=0.000277778)  # 1 arcsec/pixel
+    fp = DetectorFootprint(circle_region, pixel_scale=1.0)  # 1 arcsec/pixel
     assert isinstance(fp, DetectorFootprint)
     assert isinstance(fp.region, CirclePixelRegion)
     assert fp.wcs is not None
@@ -104,7 +104,7 @@ def test_rectangular_sky_footprint():
     """Test the DetectorFootprint's from_sky_rect function."""
     width = 2.0  # degrees = 200 pixels at 0.01 deg/pix
     height = 1.0  # degrees = 100 pixels at 0.01 deg/pix
-    fp = DetectorFootprint.from_sky_rect(width=width, height=height, pixel_scale=0.01)
+    fp = DetectorFootprint.from_sky_rect(width=width, height=height, pixel_scale=36.0)  # 0.01 deg/pix
 
     ra = np.array([90.0, 91.0, 90.5, 91.5, 92.0, 90.5, 90.0])
     center_ra = np.array([90.0, 90.0, 90.0, 90.0, 92.0, 93.0, 90.0])
@@ -156,14 +156,14 @@ def test_rectangular_sky_footprint():
     center = PixCoord(x=100.0, y=0.0)
     offset_region = RectanglePixelRegion(center=center, width=2.0, height=10.0, angle=0.0 * u.deg)
     with pytest.raises(ValueError):
-        DetectorFootprint(offset_region, pixel_scale=0.01)
+        DetectorFootprint(offset_region, pixel_scale=36.0)  # 0.01 deg/pix
 
 
 def test_rectangular_pixel_footprint():
     """Test the DetectorFootprint's from_pixel_rect function."""
     width = 200.0  # pixels = 2 degrees at 0.01 deg/pix
     height = 100.0  # pixels = 1 degree at 0.01 deg/pix
-    fp = DetectorFootprint.from_pixel_rect(width=width, height=height, pixel_scale=0.01)
+    fp = DetectorFootprint.from_pixel_rect(width=width, height=height, pixel_scale=36.0)  # 0.01 deg/pix
     ra = np.array([90.0, 91.0, 90.5, 91.5, 92.0, 90.5, 90.0])
     center_ra = np.array([90.0, 90.0, 90.0, 90.0, 92.0, 93.0, 90.0])
     dec = np.array([-10.0, -13.0, -10.0, -10.0, -8.0, -10.25, -9.25])
@@ -214,4 +214,4 @@ def test_rectangular_pixel_footprint():
     center = PixCoord(x=100.0, y=0.0)
     offset_region = RectanglePixelRegion(center=center, width=2.0, height=10.0, angle=0.0 * u.deg)
     with pytest.raises(ValueError):
-        DetectorFootprint(offset_region, pixel_scale=0.01)
+        DetectorFootprint(offset_region, pixel_scale=36.0)  # 0.01 deg/pix

--- a/tests/lightcurvelynx/obstable/test_obs_table.py
+++ b/tests/lightcurvelynx/obstable/test_obs_table.py
@@ -476,7 +476,7 @@ def test_obs_table_range_search_detector_footprint():
     }
     # Add a circular footprint with radius 0.5 deg.
     detector_footprint = CircleSkyRegion(center=SkyCoord(ra=0.0, dec=0.0, unit="deg"), radius=0.5 * u.deg)
-    ops_data = ObsTable(values, detector_footprint=detector_footprint, pixel_scale=0.1)
+    ops_data = ObsTable(values, detector_footprint=detector_footprint, pixel_scale=360.0)  # 0.1 deg/pix
 
     # Check that the ObsTable radius was increased to account for the bounding box of the
     # detector footprint.
@@ -512,12 +512,14 @@ def test_obs_table_range_search_detector_footprint():
     assert set(ops_data.range_search(15.0, 10.0, radius=100.0)) == set([0, 1, 2, 3, 4, 5, 6, 7])
 
     # If we create a new ObsTable with no radius, it is filled in by the detector footprint.
-    ops_data = ObsTable(values, detector_footprint=detector_footprint, pixel_scale=0.1)
+    ops_data = ObsTable(values, detector_footprint=detector_footprint, pixel_scale=360.0)  # 0.1 deg/pix
     assert ops_data.radius > 0.5
     assert ops_data.radius < 1.5
 
     # If we manually provide a radius larger than the detector footprint, it is used.
-    ops_data = ObsTable(values, detector_footprint=detector_footprint, radius=2.0, pixel_scale=0.1)
+    ops_data = ObsTable(
+        values, detector_footprint=detector_footprint, radius=2.0, pixel_scale=360.0
+    )  # 0.1 deg/pix
     assert ops_data.radius == 2.0
 
 


### PR DESCRIPTION
`ObsTable` was using arcseconds per pixel for the scale while `DetectorFootprint` was using degrees per pixel. Standardize on arcseconds per pixel.