### PR TITLE
Return result lightcurves sorted by time

### DIFF
--- a/src/lightcurvelynx/simulate.py
+++ b/src/lightcurvelynx/simulate.py
@@ -384,6 +384,7 @@ def _simulate_lightcurves_batch(simulation_info):
     results = NestedFrame(data=results_dict, index=[i for i in range(num_samples)])
     nested_frame = pd.DataFrame(data=nested_dict, index=nested_index)
     results = results.add_nested(nested_frame, "lightcurve")
+    results = results.sort_values(by="lightcurve.mjd")
     if simulation_info.output_file_path is not None:
         results.to_parquet(simulation_info.output_file_path)
         return simulation_info.output_file_path


### PR DESCRIPTION
Return the lightcurves for each object sorted by time even if the incoming times are out of order or we are combining surveys. Since we also include the survey index as a nested column, we can determine which observation came from which survey.