### PR TITLE
Save Sampled Indices for TableSampler

### DIFF
--- a/src/lightcurvelynx/math_nodes/given_sampler.py
+++ b/src/lightcurvelynx/math_nodes/given_sampler.py
@@ -239,7 +239,7 @@ class GivenValueSelector(FunctionNode):
         return self.values[index]
 
 
-class TableSampler(NumpyRandomFunc):
+class TableSampler(FunctionNode):
     """A FunctionNode that returns values from a table-like data,
     including a Pandas DataFrame or AstroPy Table. The results returned
     can be in-order (for testing) or randomly selected with replacement.
@@ -288,8 +288,16 @@ class TableSampler(NumpyRandomFunc):
         if self._num_values == 0:
             raise ValueError("No data provided to TableSampler.")
 
-        # Add each of the flow's data columns as an output parameter.
-        super().__init__("uniform", outputs=self.data.colnames, **kwargs)
+        # Initialize the FunctionNode with each column as an output.
+        super().__init__(self._non_func, outputs=self.data.colnames, **kwargs)
+
+        # If we are using random sampling, add a random index generator.
+        if not self.in_order:
+            self.add_parameter(
+                "selected_table_index",
+                NumpyRandomFunc("integers", low=0, high=self._num_values),
+                "The index of the selected row in the table.",
+            )
 
     def __getstate__(self):
         """We override the default pickling behavior to add a warning when in_order is true
@@ -337,17 +345,13 @@ class TableSampler(NumpyRandomFunc):
             sample_inds = np.arange(self.next_ind, end_index)
             self.next_ind = end_index
         else:
-            rng = rng_info if rng_info is not None else self._rng
-            sample_inds = rng.integers(0, self._num_values, size=graph_state.num_samples)
+            sample_inds = self.get_param(graph_state, "selected_table_index")
 
         # Parse out each column into a separate parameter with the column name as its name.
         results = []
         for attr_name in self.outputs:
             attr_values = np.asarray(self.data[attr_name][sample_inds])
-            if graph_state.num_samples == 1:
-                results.append(attr_values[0])
-            else:
-                results.append(attr_values)
+            results.append(attr_values)
 
         # Save and return the results.
         self._save_results(results, graph_state)

--- a/tests/lightcurvelynx/math_nodes/test_given_sampler.py
+++ b/tests/lightcurvelynx/math_nodes/test_given_sampler.py
@@ -287,12 +287,22 @@ def test_table_sampler_randomized():
     # Create the table sampler from the data.
     table_node = TableSampler(raw_data_dict, node_label="node")
     state = table_node.sample_parameters(num_samples=2000)
-    assert len(state) == 2
 
-    # We have sampled the a_vals roughly uniformly from the three options.
+    # Check that we can sample a single point.
+    single_state = table_node.sample_parameters(num_samples=1)
+    idx = single_state["node"]["selected_table_index"]
+    assert single_state["node"]["A"] == raw_data_dict["A"][idx]
+    assert single_state["node"]["B"] == raw_data_dict["B"][idx]
+
+    # We have sampled the a_vals roughly uniformly from the three options,
+    # and that the row inds match what was sampled.
     a_vals = state["node"]["A"]
+    row_inds = state["node"]["selected_table_index"]
     assert len(a_vals) == 2000
     assert np.all((a_vals == 1) | (a_vals == 3) | (a_vals == 5))
+    assert np.array_equal((row_inds == 0), (a_vals == 1))
+    assert np.array_equal((row_inds == 1), (a_vals == 3))
+    assert np.array_equal((row_inds == 2), (a_vals == 5))
     assert len(a_vals[a_vals == 1]) > 500
     assert len(a_vals[a_vals == 3]) > 500
     assert len(a_vals[a_vals == 5]) > 500


### PR DESCRIPTION
This PR makes two related changes:
1) It saves the indices of the rows sampled in the `TableSampler` by replacing the random function in compute with a new node that first generates the indices to sample. Users can more easily debug by looking up the which row was sampled.
2) Make `ObsTableRADECSampler` strictly stateless. Do not allow in order sampling (because it doesn't work well with parallelization). To support this change 1 was needed so we could test that we are getting the correct results.