### PR TITLE
Save some more meta data

### DIFF
--- a/docs/notebooks/pre_executed/wrapping_redback.ipynb
+++ b/docs/notebooks/pre_executed/wrapping_redback.ipynb
@@ -430,7 +430,7 @@
     "        times=np.asarray(lc[\"lightcurve\"][\"mjd\"], dtype=float),\n",
     "        fluxerrs=np.asarray(lc[\"lightcurve\"][\"fluxerr\"], dtype=float),\n",
     "        filters=np.asarray(lc[\"lightcurve\"][\"filter\"], dtype=str),\n",
-    "        title=f\"Sample {idx} from with t0={lc[\"t0\"]:.2f}\",\n",
+    "        title=f\"Sample {idx} from with t0={lc['t0']:.2f}\",\n",
     "    )\n",
     "    ax.legend()\n",
     "    plt.show()"

--- a/src/lightcurvelynx/base_models.py
+++ b/src/lightcurvelynx/base_models.py
@@ -676,7 +676,7 @@ class ParameterizedNode:
         if any_compute:
             self.compute(graph_state, rng_info)
 
-    def sample_parameters(self, given_args=None, num_samples=1, rng_info=None):
+    def sample_parameters(self, given_args=None, num_samples=1, rng_info=None, sample_offset=0):
         """Sample the model's underlying parameters if they are provided by a function
         or ParameterizedNode.
 
@@ -691,6 +691,10 @@ class ParameterizedNode:
         rng_info : numpy.random._generator.Generator, optional
             A given numpy random number generator to use for this computation. If not
             provided, the function uses the node's random number generator.
+        sample_offset : int
+            An optional offset to add to the graph state for any stateful nodes.
+            This allows the system to better support testing and parallelized sampling.
+            Default: 0 (no offset)
 
         Returns
         -------
@@ -710,7 +714,7 @@ class ParameterizedNode:
             self.set_graph_positions(seen_nodes=nodes)
 
         # Create space for the results and set all the given_args as fixed parameters.
-        results = GraphState(num_samples)
+        results = GraphState(num_samples, sample_offset=sample_offset)
         if given_args is not None:
             results.update(given_args, all_fixed=True)
 

--- a/src/lightcurvelynx/graph_state.py
+++ b/src/lightcurvelynx/graph_state.py
@@ -48,9 +48,12 @@ class GraphState:
     fixed_vars : dict
         A dictionary mapping the node name to a set of the variable names that
         are fixed (not changed by resampling) in this GraphState instance.
+    sample_offset : int
+        An optional offset to add to the graph state for any stateful nodes.
+        Default: 0
     """
 
-    def __init__(self, num_samples=1):
+    def __init__(self, num_samples=1, sample_offset=0):
         if num_samples < 1:
             raise ValueError(
                 f"Invalid number of samples for GraphState ({num_samples}). Must be a positive integer."
@@ -59,6 +62,7 @@ class GraphState:
         self.num_parameters = 0
         self.states = {}
         self.fixed_vars = {}
+        self.sample_offset = sample_offset
 
     def __len__(self):
         return self.num_parameters

--- a/src/lightcurvelynx/simulate.py
+++ b/src/lightcurvelynx/simulate.py
@@ -229,9 +229,8 @@ def _simulate_lightcurves_batch(simulation_info):
         for each object. Otherwise the NestedFrame is saved to a file and the function
         returns that file's path.
     """
-    logger.info(
-        f"Starting batch at {simulation_info.sample_offset} with {simulation_info.num_samples} samples."
-    )
+    sample_offset = simulation_info.sample_offset
+    logger.info(f"Starting batch at {sample_offset} with {simulation_info.num_samples} samples.")
 
     # Extract the parameters from the SimulationInfo that are used repeated
     # (so we have shorter names).
@@ -247,7 +246,11 @@ def _simulate_lightcurves_batch(simulation_info):
     if num_samples <= 0:
         raise ValueError("Invalid number of samples.")
     logger.info(f"Sampling {num_samples} parameter sets from the model.")
-    sample_states = model.sample_parameters(num_samples=num_samples, rng_info=rng)
+    sample_states = model.sample_parameters(
+        num_samples=num_samples,
+        rng_info=rng,
+        sample_offset=sample_offset,
+    )
 
     # If we are given information for a single survey, make it into a list.
     if not isinstance(obstable, list):

--- a/tests/lightcurvelynx/test_graph_state.py
+++ b/tests/lightcurvelynx/test_graph_state.py
@@ -14,6 +14,7 @@ def test_create_single_sample_graph_state():
     assert len(state) == 0
     assert state.num_samples == 1
     assert state.get_all_params_names() == []
+    assert state.sample_offset == 0
 
     state.set("a", "v1", 1.0)
     state.set("a", "v2", 2.0)
@@ -101,6 +102,14 @@ def test_create_single_sample_graph_state():
         _ = state.extract_single_sample(-1)
     with pytest.raises(ValueError):
         _ = state.extract_single_sample(5)
+
+
+def test_create_graph_state_offset():
+    """Test that we can create a sample GraphState with an offset."""
+    state = GraphState(sample_offset=5)
+    assert len(state) == 0
+    assert state.num_samples == 1
+    assert state.sample_offset == 5
 
 
 def test_create_single_graph_state_from_flattened_dict():

--- a/tests/lightcurvelynx/test_simulate.py
+++ b/tests/lightcurvelynx/test_simulate.py
@@ -93,8 +93,11 @@ def test_simulation_info():
     batches = sim_info.split(num_batches=3)
     assert len(batches) == 3
     assert batches[0].num_samples == 34
+    assert batches[0].sample_offset == 0
     assert batches[1].num_samples == 34
+    assert batches[1].sample_offset == 34
     assert batches[2].num_samples == 32
+    assert batches[2].sample_offset == 68
 
     # We propagate all the keyword parameters.
     assert batches[0].time_window_offset == (-5.0, 10.0)


### PR DESCRIPTION
Save the sample offset used for parallelized runs to the `GraphState`. We do not currently use this anywhere, but it will help with correctly handling stateful nodes during distributed runs. It is also useful for debugging (to know which chunk of samples a given graph state used).