### PR TITLE
Add some helper functions

### DIFF
--- a/src/lightcurvelynx/base_models.py
+++ b/src/lightcurvelynx/base_models.py
@@ -586,6 +586,25 @@ class ParameterizedNode:
         # (as opposed to the setter for x).
         setattr(self, name, _AttributeIndicatorNode(name, self))
 
+    def get_parameter_indicator(self, param_name):
+        """Return the _AttributeIndicatorNode for a given parameter. This replicates
+        the behavior of accessing the parameter as an attribute of the object
+        (e.g., obj.param_name), but in functional form.
+
+        Parameters
+        ----------
+        param_name : str
+            The name of the parameter indicator to get.
+
+        Returns
+        -------
+        getter : _AttributeIndicatorNode
+            The indicator node for the given parameter.
+        """
+        if param_name not in self.setters:
+            raise KeyError(f"Parameter name '{param_name}' not found in node {self.node_string}.")
+        return getattr(self, param_name)
+
     def compute(self, graph_state, rng_info=None, **kwargs):
         """Placeholder for a general compute function, which is called at the end
         of the sampling process and can produce derived parameters. This function

--- a/src/lightcurvelynx/math_nodes/given_sampler.py
+++ b/src/lightcurvelynx/math_nodes/given_sampler.py
@@ -259,6 +259,8 @@ class TableSampler(FunctionNode):
 
     Attributes
     ----------
+    columns : list of str
+        The names of the columns in the table.
     data : astropy.table.Table
         The object containing the data to sample.
     in_order : bool
@@ -288,6 +290,9 @@ class TableSampler(FunctionNode):
         if self._num_values == 0:
             raise ValueError("No data provided to TableSampler.")
 
+        # Save a list of the column names.
+        self.columns = [col for col in self.data.colnames]
+
         # Initialize the FunctionNode with each column as an output.
         super().__init__(self._non_func, outputs=self.data.colnames, **kwargs)
 
@@ -310,6 +315,10 @@ class TableSampler(FunctionNode):
                 "in_order=False for distributed sampling."
             )
         return self.__dict__.copy()
+
+    def __len__(self):
+        """Return the number of items in the table."""
+        return self._num_values
 
     def reset(self):
         """Reset the next index to use. Only used for in-order sampling."""

--- a/tests/lightcurvelynx/math_nodes/test_given_sampler.py
+++ b/tests/lightcurvelynx/math_nodes/test_given_sampler.py
@@ -231,6 +231,9 @@ def test_table_sampler(test_data_type):
 
     # Create the table sampler from the data.
     table_node = TableSampler(data, in_order=True, node_label="node")
+    assert set(table_node.columns) == {"A", "B", "C"}
+    assert len(table_node) == 8
+
     state = table_node.sample_parameters(num_samples=2)
     assert len(state) == 3
     assert np.allclose(state["node"]["A"], [1, 2])

--- a/tests/lightcurvelynx/test_base_models.py
+++ b/tests/lightcurvelynx/test_base_models.py
@@ -110,6 +110,16 @@ def test_parameterized_node(capsys):
     model1 = PairModel(value1=0.5, value2=0.5)
     assert str(model1) == "PairModel"
 
+    # Check that we can access the parameter indicators.
+    assert model1.value1 is not None
+    assert model1.value2 is not None
+    assert model1.value_sum is not None
+    assert model1.get_parameter_indicator("value1") is not None
+    assert model1.get_parameter_indicator("value2") is not None
+    assert model1.get_parameter_indicator("value_sum") is not None
+    with pytest.raises(KeyError):
+        model1.get_parameter_indicator("value3")
+
     # Check that we can lookup parameters.
     assert model1.has_valid_param("value1")
     assert model1.has_valid_param("value2")


### PR DESCRIPTION
Add some helper functions to the `ParameterizedNode` and `TableSampler` classes that will be used in later PRs. These include:
- Access in parameterized node's parameter by function instead of by dot notation (needed when iterating through a list of parameters, such as with the `TableSampler`).
- Add an length function to the `TableSampler`
- Add save the column names for a table sampler.