### PR TITLE
Suppress 'df concat with empty/all-NA cols' warning

### DIFF
--- a/src/lightcurvelynx/utils/post_process_results.py
+++ b/src/lightcurvelynx/utils/post_process_results.py
@@ -26,12 +26,17 @@ def concat_results(results_list):
     nested_pandas.NestedFrame
         The concatenated DataFrame.
     """
-    result = pd.concat(results_list, ignore_index=True)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", category=FutureWarning, message=".*DataFrame concatenation with empty.*"
+        )
 
-    # We need to update the ID column to be unique across all results.
-    if "id" in result.columns:
-        result["id"] = np.arange(len(result))
-    return result
+        result = pd.concat(results_list, ignore_index=True)
+
+        # We need to update the ID column to be unique across all results.
+        if "id" in result.columns:
+            result["id"] = np.arange(len(result))
+        return result
 
 
 def results_drop_empty(results):


### PR DESCRIPTION
In the interest of removing clutter, I was seeing a warning when running the parallel_runs notebook:
```[/astro/users/olynn/lightcurvelynx/src/lightcurvelynx/utils/post_process_results.py:29]
(.../astro/users/olynn/lightcurvelynx/src/lightcurvelynx/utils/post_process_results.py:29): 
FutureWarning: The behavior of DataFrame concatenation with empty or all-NA entries is deprecated. 
In a future version, this will no longer exclude empty or all-NA columns when determining the result dtypes. 
To retain the old behavior, exclude the relevant entries before the concat operation. 

result = pd.concat(results_list, ignore_index=True)
```

It seems to me that a user running a simulation where they generate all empty or NA entries within a column won't really need to know the column's dtype, since they'll mostly just be focused on fine-tuning their parameters to get the results they're looking for—so this is acceptable future behavior.

However I'm happy to hear other opinions. (Maybe we'd want to keep the warning, so we can at some point more explicitly handle these cases and make things easier for someone getting a lot of empty/NA entries when wrapping a new model, or such.)