### PR TITLE
Expand the sampling positions notebook

### DIFF
--- a/docs/notebooks/sampling_positions.ipynb
+++ b/docs/notebooks/sampling_positions.ipynb
@@ -201,7 +201,7 @@
     "\n",
     "For example, if we use depth=8, the survey's coverage is approximated by a grid of only 786,432 pixels over the entire sky with (an average pixel width of around 14 arc minutes). We recommend at least a depth of 12 (average pixel width around 50 arc seconds) for reasonable accuracy.\n",
     "\n",
-    "As a concrete example, let's look at what happens if we prebuild the MOC at depth=4 (very coarse). Although the sampler users a depth of 14, it cannot extract any more resolution from the input than it was given (a depth=4 MOC)."
+    "As a concrete example, let's look at what happens if we prebuild the MOC at depth=4 (very coarse). Although the sampler uses a depth of 14, it cannot extract any more resolution from the input than it was given (a depth=4 MOC)."
    ]
   },
   {


### PR DESCRIPTION
Expand the documentation to provide an example of the new `from_obstable` function, to discuss how to set depth in MOCs, and to talk about sampled points outside the survey footprint.
