### PR TITLE
Create FunctionNodes for mag2flux and flux2mag

### DIFF
--- a/src/lightcurvelynx/astro_utils/mag_flux.py
+++ b/src/lightcurvelynx/astro_utils/mag_flux.py
@@ -3,6 +3,8 @@
 import numpy as np
 import numpy.typing as npt
 
+from lightcurvelynx.base_models import FunctionNode
+
 # AB definition is zp=8.9 for 1 Jy
 MAG_AB_ZP_NJY = 8.9 + 2.5 * 9
 
@@ -37,3 +39,35 @@ def flux2mag(flux_njy: npt.ArrayLike) -> npt.ArrayLike:
         The magnitude corresponding to the input bandflux.
     """
     return MAG_AB_ZP_NJY - 2.5 * np.log10(flux_njy)
+
+
+class Mag2FluxNode(FunctionNode):
+    """A wrapper class for the mag2flux() function.
+
+    Parameters
+    ----------
+    mag : ndarray of float
+        The magnitude to convert to bandflux.
+    **kwargs : dict, optional
+        Any additional keyword arguments.
+    """
+
+    def __init__(self, mag, **kwargs):
+        # Call the super class's constructor with the needed information.
+        super().__init__(func=mag2flux, mag=mag, **kwargs)
+
+
+class Flux2MagNode(FunctionNode):
+    """A wrapper class for the flux2mag() function.
+
+    Parameters
+    ----------
+    flux_njy : float or array-like
+        The flux in nJy to convert to magnitude.
+    **kwargs : dict, optional
+        Any additional keyword arguments.
+    """
+
+    def __init__(self, flux_njy, **kwargs):
+        # Call the super class's constructor with the needed information.
+        super().__init__(func=flux2mag, flux_njy=flux_njy, **kwargs)

--- a/tests/lightcurvelynx/astro_utils/test_mag_flux.py
+++ b/tests/lightcurvelynx/astro_utils/test_mag_flux.py
@@ -1,7 +1,14 @@
 """Test magnitude-flux conversion utilities."""
 
 import numpy as np
-from lightcurvelynx.astro_utils.mag_flux import flux2mag, mag2flux
+import pytest
+from lightcurvelynx.astro_utils.mag_flux import (
+    Flux2MagNode,
+    Mag2FluxNode,
+    flux2mag,
+    mag2flux,
+)
+from lightcurvelynx.math_nodes.np_random import NumpyRandomFunc
 
 
 def test_flux2mag():
@@ -34,3 +41,38 @@ def test_flux2mag2flux():
     mag = flux2mag(flux)
     flux2 = mag2flux(mag)
     np.testing.assert_allclose(flux, flux2, rtol=1e-10)
+
+
+def test_flux2magnode():
+    """Test the computation of the Flux2MagNode."""
+    fluxes = np.array([3631e9, 1e9, 3631])
+    expected = flux2mag(fluxes)
+
+    for idx, f in enumerate(fluxes):
+        node = Flux2MagNode(flux_njy=f)
+        state = node.sample_parameters(num_samples=1)
+        assert node.get_param(state, "function_node_result") == pytest.approx(expected[idx])
+
+
+def test_mag2fluxnode():
+    """Test the computation of the Mag2FluxNode."""
+    mags = np.array([0, 8.9, 8.9 + 2.5 * 9])
+    expected = mag2flux(mags)
+
+    for idx, m in enumerate(mags):
+        node = Mag2FluxNode(mag=m)
+        state = node.sample_parameters(num_samples=1)
+        assert node.get_param(state, "function_node_result") == pytest.approx(expected[idx])
+
+
+def test_flux2magnode_chained():
+    """Test chaining Flux2MagNode and Mag2FluxNode."""
+    flux_node = NumpyRandomFunc("uniform", low=100.0, high=1e6, seed=101, node_label="node1")
+    mag_node = Flux2MagNode(flux_njy=flux_node, node_label="node2")
+
+    num_samples = 10
+    state_flux = mag_node.sample_parameters(num_samples=num_samples)
+    assert np.allclose(
+        state_flux["node2"]["function_node_result"],
+        flux2mag(state_flux["node1"]["function_node_result"]),
+    )


### PR DESCRIPTION
Wrap the flux2mag and mag2flux functions in `FunctionNode`s. This is needed to support pyLIMA input, which is specified in mags, but needs to be translated to fluxes.