### PR TITLE
Add a context handler to squash output

### DIFF
--- a/src/lightcurvelynx/utils/io_utils.py
+++ b/src/lightcurvelynx/utils/io_utils.py
@@ -2,7 +2,6 @@ import gzip
 import logging
 import os
 import sys
-import warnings
 from pathlib import Path
 
 import numpy as np
@@ -10,13 +9,7 @@ from astropy.table import Table
 
 
 class SquashOutput:
-    """Context manager to temporarily squash all output to stdout and stderr
-    (and optionally warnings)
-
-    Attributes
-    ----------
-    include_warnings : bool
-        Whether to also squash warnings. Default: False
+    """Context manager to temporarily squash all output to stdout and stderr.
 
     Example
     -------
@@ -25,8 +18,7 @@ class SquashOutput:
         ...
     """
 
-    def __init__(self, include_warnings=False):
-        self.include_warnings = include_warnings
+    def __init__(self):
         self._original_stdout = None
         self._original_stderr = None
         self._null_file = None
@@ -43,10 +35,6 @@ class SquashOutput:
         sys.stdout = self._null_file
         sys.stderr = self._null_file
 
-        # Optionally suppress warnings.
-        if self.include_warnings:
-            warnings.filterwarnings("ignore")
-
     def __exit__(self, exc_type, exc_value, traceback):
         # Restore the original stdout and stderr streams.
         sys.stdout = self._original_stdout
@@ -54,10 +42,6 @@ class SquashOutput:
 
         # Close the null file.
         self._null_file.close()  # noqa: SIM115
-
-        # Restore warning filters.
-        if self.include_warnings:
-            warnings.resetwarnings()
 
 
 def write_results_as_hats(base_catalog_path, results, *, catalog_name=None, overwrite=False):

--- a/tests/lightcurvelynx/utils/test_io_utils.py
+++ b/tests/lightcurvelynx/utils/test_io_utils.py
@@ -1,5 +1,3 @@
-import warnings
-
 import numpy as np
 import pandas as pd
 import pytest
@@ -29,21 +27,6 @@ def test_squash_output(capfd):
     print("This is a test.")
     captured = capfd.readouterr()
     assert "This is a test." in captured.out
-
-
-def test_squash_output_warning(capfd):
-    """Test that we can squash warnings from a block of code."""
-    # No warning squashed.
-    with pytest.warns():
-        with SquashOutput(include_warnings=False):
-            warnings.warn("This is a test warning.")
-
-    # Warning squashed.
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")
-        with SquashOutput(include_warnings=True):
-            warnings.warn("This is a test warning.")
-        warnings.resetwarnings()
 
 
 def test_read_write_numpy_data(tmp_path):


### PR DESCRIPTION
Some external libraries include print statements that add a lot of noise when we are running a large batch. This PR adds a context manager that allows us to shut off those print statements.