### PR TITLE
Some tests and bug fixes for passbands

### DIFF
--- a/docs/notebooks/advanced_sampling.ipynb
+++ b/docs/notebooks/advanced_sampling.ipynb
@@ -61,7 +61,9 @@
     "source = ConstantSEDModel(brightness=10.0, ra=host.ra, dec=host.dec, node_label=\"source\")\n",
     "state = source.sample_parameters(num_samples=10)\n",
     "for i in range(10):\n",
-    "    print(f\"Sample {i+1}: Host RA = {state['host']['ra'][i]:.2f}, Source RA = {state['source']['ra'][i]:.2f}\")"
+    "    print(\n",
+    "        f\"Sample {i + 1}: Host RA = {state['host']['ra'][i]:.2f}, Source RA = {state['source']['ra'][i]:.2f}\"\n",
+    "    )"
    ]
   },
   {


### PR DESCRIPTION
Fix a few small errors in the Passbands class and add some features, including:
- Handling duplicate wavelengths (need to access first element from `where`).
- Clip the upper bound when trimming the table (we shouldn't run into this in practice).
- Add support for microns
- Emit warnings