### PR TITLE
Add tests to confirm conflicting filter names are not a problem

### DIFF
--- a/docs/notebooks/multiple_surveys.ipynb
+++ b/docs/notebooks/multiple_surveys.ipynb
@@ -96,9 +96,9 @@
     "obstable2 = OpSim(obsdata2)\n",
     "\n",
     "passband_group2 = PassbandGroup.from_preset(\n",
-    "    preset=\"LSST\",\n",
+    "    preset=\"ZTF\",\n",
     "    table_dir=table_dir,\n",
-    "    filters=[\"r\", \"z\"],\n",
+    "    filters=[\"r\", \"g\"],\n",
     ")"
    ]
   },
@@ -166,6 +166,37 @@
    "metadata": {},
    "source": [
     "In addition to the standard information like mjd and flux, we capture the survey index to help us trace which survey the data came from. This is stored in the `survey_idx` column of the nested light curve table. We also can save per-survey, per-observation data, such as the zero point for that observation, using the `obstable_save_cols` parameter as shown above."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## FAQ\n",
+    "\n",
+    "### Can we use multiple surveys and parallelization?\n",
+    "\n",
+    "Yes.\n",
+    "\n",
+    "### What happens if the filter names overlap?\n",
+    "\n",
+    "For the simulation, everything will just work. Since you are passing one `PassbandGroup` for each `ObsTable` it will only look for the matching filter names in that group. So if you are using LSST data with observations in r and then ZTF data with observations in r, the SEDs will be integrated by the correct filter transmission at each step.\n",
+    "\n",
+    "However the name of the filter in the result column will match what appears in the `ObsTable` columns. So you may only see 'r' for each entry. If you are interested in plotting the light curves or performing any other per-filter analysis, you can expand the filter names with the survey prefix using `test_results_use_full_filter_names()`\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from lightcurvelynx.utils.post_process_results import results_use_full_filter_names\n",
+    "\n",
+    "print(\"Filters (before):\", list(results[\"lightcurve.filter\"].values))\n",
+    "\n",
+    "results_use_full_filter_names(results, [passband_group1, passband_group2])\n",
+    "print(\"Filters (after):\", list(results[\"lightcurve.filter\"].values))"
    ]
   }
  ],


### PR DESCRIPTION
Closes #682

Add tests and an example to demonstrate that having multiple surveys using the same filter names (such as "r") is not a problem. Also creates a post processing helper function to expand the filter names to make analysis easier.