### PR TITLE
Fix bug in Table Sampler

### DIFF
--- a/src/lightcurvelynx/math_nodes/given_sampler.py
+++ b/src/lightcurvelynx/math_nodes/given_sampler.py
@@ -364,7 +364,13 @@ class TableSampler(FunctionNode):
         # Parse out each column into a separate parameter with the column name as its name.
         results = []
         for attr_name in self.outputs:
-            attr_values = np.asarray(self.data[attr_name][sample_inds])
+            # If we only have a single sample, return it directly as a scalar.
+            # Otherwise cast it to a numpy array.
+            if graph_state.num_samples == 1:
+                attr_values = self.data[attr_name][sample_inds.item()]
+            else:
+                attr_values = np.asarray(self.data[attr_name][sample_inds])
+
             results.append(attr_values)
 
         # Save and return the results.

--- a/tests/lightcurvelynx/math_nodes/test_given_sampler.py
+++ b/tests/lightcurvelynx/math_nodes/test_given_sampler.py
@@ -264,6 +264,11 @@ def test_table_sampler(test_data_type):
     assert state["node"]["B"] == 1
     assert state["node"]["C"] == 3
 
+    # The results are scalars (not lists or arrays).
+    assert isinstance(state["node"]["A"], (int | np.integer))
+    assert isinstance(state["node"]["B"], (int | np.integer))
+    assert isinstance(state["node"]["C"], (int | np.integer))
+
     # We can sample later values using a forced offset. No warning
     # should be produced here since the offset is different.
     state = table_node.sample_parameters(num_samples=4, sample_offset=2)

--- a/tests/lightcurvelynx/math_nodes/test_ra_dec_sampler.py
+++ b/tests/lightcurvelynx/math_nodes/test_ra_dec_sampler.py
@@ -102,6 +102,11 @@ def test_obstable_ra_dec_sampler():
     assert state["sampler"]["dec"] == values["fieldDec"][idx]
     assert state["sampler"]["time"] == values["observationStartMJD"][idx]
 
+    # Check that we returned floats, not arrays.
+    assert isinstance(state["sampler"]["ra"], float)
+    assert isinstance(state["sampler"]["dec"], float)
+    assert isinstance(state["sampler"]["time"], float)
+
     # Do randomized sampling (with no offset).
     sampler_node2 = ObsTableRADECSampler(ops_data, radius=0.0, seed=100, node_label="sampler")
     state = sampler_node2.sample_parameters(num_samples=5000)


### PR DESCRIPTION
There is a small bug in the table sampler where it is returning an array of length 1 instead of a scalar when asked for a single sample (num_samples==1). This is fine for most of the code flow, but breaks when we try to write out results.