### PR TITLE
Add support for the extinction package

### DIFF
--- a/docs/citations.rst
+++ b/docs/citations.rst
@@ -33,11 +33,12 @@ citation information in class and function docstrings to help users identify rel
 
 As an example, consider the dust extinction effect. LightCurveLynx supports a variety of external dustmaps
 libraries, but was primarily designed to work with the `dustmaps <https://github.com/gregreen/dustmaps>`_
-package (Green 2018). The dust extinction is computed via the ExtinctionEffect which used the
-`dust_extinction <https://github.com/karllark/dust_extinction>`_ package (Gordon 2024). In addition,
-each individual dustmap and extinction function should be cited from their original science paper.
-The `dustmaps readthedocs <https://dustmaps.readthedocs.io/en/latest/maps.html>`_ page provides
-more information on the available dustmaps and their citations.
+package (Green 2018). The dust extinction is computed via the DustExtinctionEffect which used the
+`dust_extinction <https://github.com/karllark/dust_extinction>`_ package (Gordon 2024) or the
+SncosmoExtinctionEffect which uses the `extinction <https://github.com/sncosmo/extinction>`_ package
+(Barbary et. al. 2017). In addition, each individual dustmap and extinction function should be cited
+from their original science paper. The `dustmaps readthedocs <https://dustmaps.readthedocs.io/en/latest/maps.html>`_
+page provides more information on the available dustmaps and their citations.
 
 Citation-Compass
 -------------------------------------------------------------------------------

--- a/docs/notebooks/adding_effects.ipynb
+++ b/docs/notebooks/adding_effects.ipynb
@@ -9,7 +9,7 @@
     "In this tutorial we look at how a user can add effects to the models that we are simulating in order to make their sampled flux more realistic. Effects are transformations applied to the source's computed flux.\n",
     "\n",
     "LightCurveLynx supports multiple model-level effects including:\n",
-    "  * Dust extinction\n",
+    "  * Dust extinction (using either the [extinction package](https://github.com/sncosmo/extinction) or [dust_extinction package](https://github.com/karllark/dust_extinction).\n",
     "  * Microlensing (using the [VBMicrolensing package](https://github.com/valboz/VBMicrolensing))\n",
     "  * Multiplicative scaling (including constant dimming)\n",
     "  * White Noise\n",
@@ -146,9 +146,13 @@
    "source": [
     "## Dust Maps\n",
     "\n",
-    "Dust extinction represents a more complex effect since it requires the user to specify both a dust map and an extinction function. The dust map is stored in a `ParameterizedNode` that uses the object's (RA, dec) to compute ebv values. The `ExtinctionEffect` then links these together by creating a new \"ebv\" parameter in the model node. This \"ebv\" parameter is the output of the dustmap and the input to the extinction effect.\n",
+    "Dust extinction represents a more complex effect since it requires the user to specify both a dust map and an extinction function. The dust map is stored in a `ParameterizedNode` that uses the object's (RA, dec) to compute ebv values. LightCurveLynx supports two different extinction packages:\n",
+    "   * The `DustExtinctionEffect` wraps the [dust_extinction package](https://github.com/karllark/dust_extinction) and uses the paramegter \"ebv\".\n",
+    "   * The `SncosmoExtinctionEffect` wraps the [extinction package](https://github.com/sncosmo/extinction) and uses two parameters \"a_v\" and \"r_v\".\n",
     "\n",
-    "The extinction effect requires the `dust_extinction` package which is not installed by default. Users can install the `pip install dust_extinction` or `conda install -c conda-forge dust_extinction` to run this cell of the notebook."
+    "Let's look at how the `DustExtinctionEffect` works by linking with the dust map to create a new \"ebv\" parameter in the model node. This \"ebv\" parameter is the output of the dustmap and the input to the extinction effect.\n",
+    "\n",
+    "The `DustExtinctionEffect` effect requires the `dust_extinction` package, which is not installed by default. Users can install the `pip install dust_extinction` or `conda install -c conda-forge dust_extinction` to run this cell of the notebook."
    ]
   },
   {
@@ -164,7 +168,7 @@
     "    states2 = None\n",
     "else:\n",
     "    from lightcurvelynx.astro_utils.dustmap import ConstantHemisphereDustMap, DustmapWrapper\n",
-    "    from lightcurvelynx.effects.extinction import ExtinctionEffect\n",
+    "    from lightcurvelynx.effects.dust_extinction import DustExtinctionEffect\n",
     "\n",
     "    model2 = ConstantSEDModel(\n",
     "        brightness=100.0,\n",
@@ -184,7 +188,7 @@
     "    )\n",
     "\n",
     "    # Create an add an extinction effect.\n",
-    "    ext_effect = ExtinctionEffect(\n",
+    "    ext_effect = DustExtinctionEffect(\n",
     "        extinction_model=\"CCM89\",\n",
     "        ebv=dust_map_node,\n",
     "        frame=\"rest\",\n",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dev = [
     "asv[virtualenv]==0.6.5", # Used to compute performance benchmarks
     "bilby",  # Used for Bayesian inference
     "dust_extinction",
-    "extinction>=0.4.7",  # Needed by sncosmo
+    "extinction>=0.4.7",
     "fsspec[http]",  # Read OpSim file from the web with utils/make_opsim_shorten.py
     "jupyter", # Clears output from Jupyter notebooks
     "jax",

--- a/src/lightcurvelynx/effects/dust_extinction.py
+++ b/src/lightcurvelynx/effects/dust_extinction.py
@@ -15,8 +15,8 @@ from citation_compass import CiteClass
 from lightcurvelynx.effects.effect_model import EffectModel
 
 
-class ExtinctionEffect(EffectModel, CiteClass):
-    """A general dust extinction effect model.
+class DustExtinctionEffect(EffectModel, CiteClass):
+    """A general dust_extinction effect model.
 
     References
     ----------
@@ -52,7 +52,7 @@ class ExtinctionEffect(EffectModel, CiteClass):
 
         if isinstance(extinction_model, str):
             self._model_name = extinction_model
-            extinction_model = ExtinctionEffect.load_extinction_model(extinction_model, **kwargs)
+            extinction_model = DustExtinctionEffect.load_extinction_model(extinction_model, **kwargs)
         else:
             self._model_name = None
         self.extinction_model = extinction_model
@@ -77,7 +77,7 @@ class ExtinctionEffect(EffectModel, CiteClass):
         it may not be picklable.
         """
         self.__dict__.update(state)
-        self.extinction_model = ExtinctionEffect.load_extinction_model(self._model_name)
+        self.extinction_model = DustExtinctionEffect.load_extinction_model(self._model_name)
 
     @staticmethod
     def list_extinction_models():
@@ -95,7 +95,7 @@ class ExtinctionEffect(EffectModel, CiteClass):
             import dust_extinction  # noqa: F401
         except ImportError as err:  # pragma: no cover
             raise ImportError(
-                "The dust_extinction package is needed to use the ExtinctionEffect. Please install it via"
+                "The dust_extinction package is needed to use the DustExtinctionEffect. Please install it via"
                 "`pip install dust_extinction` or `conda install conda-forge::dust_extinction`."
             ) from err
 
@@ -130,7 +130,7 @@ class ExtinctionEffect(EffectModel, CiteClass):
             import dust_extinction  # noqa: F401
         except ImportError as err:  # pragma: no cover
             raise ImportError(
-                "The dust_extinction package is needed to use the ExtinctionEffect. Please install it via"
+                "The dust_extinction package is needed to use the DustExtinctionEffect. Please install it via"
                 "`pip install dust_extinction` or `conda install conda-forge::dust_extinction`."
             ) from err
 

--- a/src/lightcurvelynx/effects/extinction.py
+++ b/src/lightcurvelynx/effects/extinction.py
@@ -1,0 +1,13 @@
+"""A place holder with a deprecation warning for the old ExtinctionEffect model."""
+
+from lightcurvelynx.effects.effect_model import EffectModel
+
+
+class ExtinctionEffect(EffectModel):
+    """A place holder with a deprecation warning for the old ExtinctionEffect model."""
+
+    def __init__(self, **kwargs):
+        raise NotImplementedError(
+            "The ExtinctionEffect has been deprecated and removed. Please use the "
+            "DustExtinctionEffect from lightcurvelynx.effects.dust_extinction instead."
+        )

--- a/src/lightcurvelynx/effects/sncosmo_extinction.py
+++ b/src/lightcurvelynx/effects/sncosmo_extinction.py
@@ -1,0 +1,170 @@
+"""A wrapper for applying extinction functions using the sncosmo extinction library.
+
+Citation:
+    https://github.com/sncosmo/extinction
+    Barbary et. al. 2017
+    doi: 10.5281/zenodo.804966
+"""
+
+import numpy as np
+from citation_compass import CiteClass
+
+from lightcurvelynx.effects.effect_model import EffectModel
+
+
+class SncosmoExtinctionEffect(EffectModel, CiteClass):
+    """A general dust extinction effect model.
+
+    References
+    ----------
+    https://github.com/sncosmo/extinction
+    Barbary et. al. 2017
+    doi: 10.5281/zenodo.804966
+
+    Attributes
+    ----------
+    extinction_model : function or str
+        The extinction object from the sncosmo extinction library or its name.
+        If a string is provided, the code will find a matching extinction
+        function in the extinction package and use that.
+    a_v : parameter
+        The setter for the extinction parameter A(V).
+    r_v : parameter
+        The setter for the extinction parameter R(V).
+    frame : str
+        The frame for extinction. 'rest' or 'observer'.
+    **kwargs : `dict`, optional
+        Any additional keyword arguments.
+    """
+
+    def __init__(
+        self,
+        extinction_model=None,
+        a_v=None,
+        r_v=None,
+        frame=None,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self.add_effect_parameter("a_v", a_v)
+        self.add_effect_parameter("r_v", r_v)
+
+        if frame == "observer":
+            self.rest_frame = False
+        elif frame == "rest":
+            self.rest_frame = True
+        else:
+            raise ValueError("frame must be 'observer' or 'rest'.")
+
+        if isinstance(extinction_model, str):
+            self._model_name = extinction_model
+            extinction_model = self.load_extinction_model(extinction_model, **kwargs)
+        else:
+            # Save the function name so we can pickle it later.
+            self._model_name = extinction_model.__name__
+        self.extinction_model = extinction_model
+
+    def __getstate__(self):
+        """We override the default pickling behavior to handle the extinction model, since
+        it may not be picklable.
+        """
+        if self._model_name is None:
+            raise ValueError(
+                "Extinction model must be specified as a string (of the model name) in order to "
+                "to be pickled and used with distributed computation."
+            )
+
+        # Return the state without the extinction model, since it may not be picklable.
+        state = self.__dict__.copy()
+        del state["extinction_model"]
+        return state
+
+    def __setstate__(self, state):
+        """We override the default unpickling behavior to handle the extinction model, since
+        it may not be picklable.
+        """
+        self.__dict__.update(state)
+        self.extinction_model = self.load_extinction_model(self._model_name)
+
+    @staticmethod
+    def load_extinction_model(name, **kwargs):
+        """Load the extinction model from the extinction package
+        (https://github.com/sncosmo/extinction)
+
+        Parameters
+        ----------
+        name : str
+            The name of the extinction model to use.
+        **kwargs : dict
+            Any additional keyword arguments needed to create that argument.
+
+        Returns
+        -------
+        ext_obj
+            A extinction function.
+        """
+        try:
+            import extinction  # noqa: F401
+        except ImportError as err:  # pragma: no cover
+            raise ImportError(
+                "The extinction package is needed to use the ExtinctionEffect. Please install it via"
+                "`pip install extinction` or `conda install conda-forge::extinction`."
+            ) from err
+
+        # We scan all of the submodules in the extinction package,
+        # looking for a matching name.
+        if name not in dir(extinction):
+            raise KeyError(f"Invalid extinction model '{name}'")
+        ext_fn = getattr(extinction, name)
+        return ext_fn
+
+    def apply(
+        self,
+        flux_density,
+        times=None,
+        wavelengths=None,
+        a_v=None,
+        r_v=None,
+        **kwargs,
+    ):
+        """Apply the extinction effect to the flux density.
+
+        Parameters
+        ----------
+        flux_density : numpy.ndarray
+            A length T X N matrix of flux density values (in nJy).
+        times : numpy.ndarray, optional
+            A length T array of times (in MJD). Not used for this effect.
+        wavelengths : numpy.ndarray, optional
+            A length N array of wavelengths (in angstroms). Not used for this effect.
+        a_v : float, optional
+            The extinction parameter A(V). Raises an error if None is provided.
+        r_v : float, optional
+            The extinction parameter R(V). Raises an error if None is provided
+            and the function requires it.
+        **kwargs : `dict`, optional
+           Any additional keyword arguments, including any additional
+           parameters needed to apply the effect.
+
+        Returns
+        -------
+        flux_density : numpy.ndarray
+            A length T x N matrix of flux densities after the effect is applied (in nJy).
+        """
+        if a_v is None:
+            raise ValueError("a_v must be provided")
+        if r_v is None and self._model_name != "fm07":
+            raise ValueError(f"r_v must be provided for model {self._model_name}")
+        if wavelengths is None:
+            raise ValueError("wavelengths must be provided")
+
+        # Use the function to compute the extinction magnitudes. Note that the fm07 model
+        # requires only a_v (r_v is fixed at 3.1).
+        if self._model_name == "fm07":
+            ext_mags = self.extinction_model(wavelengths, a_v=a_v, unit="aa")
+        else:
+            ext_mags = self.extinction_model(wavelengths, a_v=a_v, r_v=r_v, unit="aa")
+
+        # Apply the extinction to the flux density.
+        ext_factor = 10 ** (-0.4 * ext_mags)  # Convert mags to flux factor
+        return flux_density * ext_factor[np.newaxis, :]  # Broadcast to all times

--- a/src/lightcurvelynx/models/bayesn.py
+++ b/src/lightcurvelynx/models/bayesn.py
@@ -5,7 +5,7 @@ from citation_compass import CiteClass
 
 from lightcurvelynx import _LIGHTCURVELYNX_BASE_DATA_DIR
 from lightcurvelynx.astro_utils.unit_utils import flam_to_fnu
-from lightcurvelynx.effects.extinction import ExtinctionEffect
+from lightcurvelynx.effects.dust_extinction import DustExtinctionEffect
 from lightcurvelynx.models.physical_model import SEDModel
 
 
@@ -486,9 +486,9 @@ class BayesnModel(SEDModel, CiteClass):
         flux_density = H_grid * 10 ** (-0.4 * W_grid)
 
         # Apply dust extinction law
-        # Get ebv such that ebv = Rv/Av
+        # Get ebv such that ebv = Av/Rv
         ebv = params["Av"] / params["Rv"]
-        ext = ExtinctionEffect(extinction_model="F99", ebv=ebv, frame="rest")
+        ext = DustExtinctionEffect(extinction_model="F99", ebv=ebv, frame="rest")
         flux_density = ext.apply(flux_density, tau, wavelengths, ebv)
 
         # Apply the fixed distance modulus normalisation factor effect

--- a/tests/lightcurvelynx/effects/test_dust_extinction.py
+++ b/tests/lightcurvelynx/effects/test_dust_extinction.py
@@ -5,14 +5,14 @@ from pathlib import Path
 import numpy as np
 import pytest
 from lightcurvelynx.astro_utils.dustmap import ConstantHemisphereDustMap, DustmapWrapper
-from lightcurvelynx.effects.extinction import ExtinctionEffect
+from lightcurvelynx.effects.dust_extinction import DustExtinctionEffect
 from lightcurvelynx.math_nodes.given_sampler import GivenValueList
 from lightcurvelynx.models.basic_models import ConstantSEDModel
 
 
 def test_list_extinction_models():
     """List the available extinction models."""
-    model_names = ExtinctionEffect.list_extinction_models()
+    model_names = DustExtinctionEffect.list_extinction_models()
     assert len(model_names) > 10
     assert "G23" in model_names
     assert "CCM89" in model_names
@@ -20,16 +20,16 @@ def test_list_extinction_models():
 
 def test_load_extinction_model():
     """Load an extinction model by string."""
-    g23_model = ExtinctionEffect.load_extinction_model("G23", Rv=3.1)
+    g23_model = DustExtinctionEffect.load_extinction_model("G23", Rv=3.1)
     assert g23_model is not None
     assert hasattr(g23_model, "extinguish")
 
     # We fail if we try to load a model that does not exist.
     with pytest.raises(KeyError):
-        ExtinctionEffect.load_extinction_model("InvalidModel")
+        DustExtinctionEffect.load_extinction_model("InvalidModel")
 
-    # We can manually load the g23_model into an ExtinctionEffect node.
-    dust_effect = ExtinctionEffect(g23_model, ebv=0.1, frame="rest")
+    # We can manually load the g23_model into an DustExtinctionEffect node.
+    dust_effect = DustExtinctionEffect(g23_model, ebv=0.1, frame="rest")
 
     # We can apply the extinction effect to a set of fluxes.
     fluxes = np.full((10, 3), 1.0)
@@ -47,20 +47,20 @@ def test_load_extinction_model():
 
 def test_set_frame():
     """Test that correct frame is set"""
-    ext = ExtinctionEffect("G23", ebv=0.1, frame="observer")
+    ext = DustExtinctionEffect("G23", ebv=0.1, frame="observer")
     assert ext.rest_frame is False
 
     with pytest.raises(ValueError):
-        ExtinctionEffect("G23", ebv=0.1, frame="InvalidFrame")
+        DustExtinctionEffect("G23", ebv=0.1, frame="InvalidFrame")
 
 
 def test_pickle_extinction_model():
-    """Test that we can pickle and unpickle an ExtinctionEffect object."""
+    """Test that we can pickle and unpickle an DustExtinctionEffect object."""
     # Create two models: one defined by model name and the other with a given object.
-    F99_model = ExtinctionEffect("F99", Rv=3.1, frame="rest", ebv=0.1)
+    F99_model = DustExtinctionEffect("F99", Rv=3.1, frame="rest", ebv=0.1)
 
-    ext_model = ExtinctionEffect.load_extinction_model("F99")
-    F99_model_B = ExtinctionEffect(ext_model, Rv=3.1, frame="rest", ebv=0.1)
+    ext_model = DustExtinctionEffect.load_extinction_model("F99")
+    F99_model_B = DustExtinctionEffect(ext_model, Rv=3.1, frame="rest", ebv=0.1)
 
     # Compute the some sample fluxes before and after extinction.
     org_fluxes = np.full((10, 3), 1.0)
@@ -93,11 +93,11 @@ def test_pickle_extinction_model():
 
 
 def test_constant_dust_extinction():
-    """Test that we can create and sample a ExtinctionEffect object."""
+    """Test that we can create and sample a DustExtinctionEffect object."""
     # Use given ebv values. Usually these would be computed from a dustmap,
     # based on (RA, dec).
     ebv_node = GivenValueList([0.1, 0.2, 0.3, 0.4, 0.5])
-    dust_effect = ExtinctionEffect("CCM89", ebv=ebv_node, Rv=3.1, frame="rest")
+    dust_effect = DustExtinctionEffect("CCM89", ebv=ebv_node, Rv=3.1, frame="rest")
     assert dust_effect.extinction_model is not None
     assert hasattr(dust_effect.extinction_model, "extinguish")
 
@@ -136,7 +136,7 @@ def test_dustmap_chain():
     dust_map_node = DustmapWrapper(dust_map, ra=model.ra, dec=model.dec)
 
     # Create an extinction effect using the EBVs from that dust map.
-    ext_effect = ExtinctionEffect(extinction_model="CCM89", ebv=dust_map_node, Rv=3.1, frame="rest")
+    ext_effect = DustExtinctionEffect(extinction_model="CCM89", ebv=dust_map_node, Rv=3.1, frame="rest")
     model.add_effect(ext_effect)
 
     # Sample the model.

--- a/tests/lightcurvelynx/effects/test_sncosmo_extinction.py
+++ b/tests/lightcurvelynx/effects/test_sncosmo_extinction.py
@@ -1,0 +1,143 @@
+import pickle
+import tempfile
+from pathlib import Path
+
+import numpy as np
+import pytest
+from lightcurvelynx.effects.sncosmo_extinction import SncosmoExtinctionEffect
+from lightcurvelynx.math_nodes.given_sampler import GivenValueList
+from lightcurvelynx.models.basic_models import ConstantSEDModel
+
+
+def test_load_extinction_model():
+    """Load an extinction model by string."""
+    fm07_model = SncosmoExtinctionEffect.load_extinction_model("fm07")
+    assert fm07_model is not None
+    assert callable(fm07_model)
+
+    # We can manually load the fm07_model into an ExtinctionEffect node.
+    dust_effect = SncosmoExtinctionEffect(fm07_model, a_v=0.1, frame="rest")
+
+    # We can apply the extinction effect to a set of fluxes.
+    fluxes = np.full((10, 3), 1.0)
+    wavelengths = np.array([7000.0, 5200.0, 4800.0])
+    new_fluxes = dust_effect.apply(fluxes, wavelengths=wavelengths, a_v=0.1)
+    assert new_fluxes.shape == (10, 3)
+    assert np.all(new_fluxes < fluxes)
+
+    # We fail if we are missing a required parameter.
+    with pytest.raises(ValueError):
+        _ = dust_effect.apply(fluxes, wavelengths=wavelengths)
+    with pytest.raises(ValueError):
+        _ = dust_effect.apply(fluxes, a_v=0.1)
+
+
+def test_load_extinction_model_with_r_v():
+    """Load an extinction model by string."""
+    od94_model = SncosmoExtinctionEffect.load_extinction_model("odonnell94")
+    assert od94_model is not None
+    assert callable(od94_model)
+
+    # We can manually load the od94_model into an ExtinctionEffect node.
+    dust_effect = SncosmoExtinctionEffect(od94_model, a_v=0.1, r_v=3.1, frame="rest")
+
+    # We can apply the extinction effect to a set of fluxes.
+    fluxes = np.full((10, 3), 1.0)
+    wavelengths = np.array([7000.0, 5200.0, 4800.0])
+    new_fluxes = dust_effect.apply(fluxes, wavelengths=wavelengths, a_v=0.1, r_v=3.1)
+    assert new_fluxes.shape == (10, 3)
+    assert np.all(new_fluxes < fluxes)
+
+    # We fail if we are missing a required parameter.
+    with pytest.raises(ValueError):
+        _ = dust_effect.apply(fluxes, wavelengths=wavelengths, r_v=3.1)
+    with pytest.raises(ValueError):
+        _ = dust_effect.apply(fluxes, a_v=0.1, r_v=3.1)
+    with pytest.raises(ValueError):
+        _ = dust_effect.apply(fluxes, wavelengths=wavelengths, a_v=0.1)
+
+
+def test_set_frame():
+    """Test that correct frame is set"""
+    ext = SncosmoExtinctionEffect("odonnell94", a_v=0.1, r_v=3.1, frame="observer")
+    assert ext.rest_frame is False
+
+    with pytest.raises(ValueError):
+        SncosmoExtinctionEffect("odonnell94", a_v=0.1, r_v=3.1, frame="InvalidFrame")
+
+
+def test_pickle_extinction_model():
+    """Test that we can pickle and unpickle an SncosmoExtinctionEffect object."""
+    # Create two models: one defined by model name and the other with a given object.
+    model_A = SncosmoExtinctionEffect("odonnell94", a_v=0.1, r_v=3.1, frame="rest")
+
+    ext_model = SncosmoExtinctionEffect.load_extinction_model("odonnell94")
+    model_B = SncosmoExtinctionEffect(ext_model, a_v=0.1, r_v=3.1, frame="rest")
+
+    # Compute the some sample fluxes before and after extinction.
+    org_fluxes = np.full((10, 3), 1.0)
+    wavelengths = np.array([7000.0, 5200.0, 4800.0])
+    ext_fluxes_1 = model_A.apply(org_fluxes, wavelengths=wavelengths, a_v=0.1, r_v=3.1)
+    assert ext_fluxes_1.shape == (10, 3)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Pickle the model determined by a string.
+        file_path = Path(tmpdir) / "test_model_a.pkl"
+        assert not file_path.exists()
+
+        with open(file_path, "wb") as f:
+            pickle.dump(model_A, f)
+        assert file_path.exists()
+
+        with open(file_path, "rb") as f:
+            loaded_model = pickle.load(f)
+        assert loaded_model is not None
+
+        ext_fluxes_2 = loaded_model.apply(org_fluxes, wavelengths=wavelengths, a_v=0.1, r_v=3.1)
+        assert ext_fluxes_2.shape == (10, 3)
+        assert np.allclose(ext_fluxes_1, ext_fluxes_2)
+
+        # Now try to pickle the model defined with an actual extinction object.
+        file_path = Path(tmpdir) / "test_model_b.pkl"
+        assert not file_path.exists()
+
+        with open(file_path, "wb") as f:
+            pickle.dump(model_B, f)
+        assert file_path.exists()
+
+        with open(file_path, "rb") as f:
+            loaded_model = pickle.load(f)
+        assert loaded_model is not None
+
+        ext_fluxes_2 = loaded_model.apply(org_fluxes, wavelengths=wavelengths, a_v=0.1, r_v=3.1)
+        assert ext_fluxes_2.shape == (10, 3)
+        assert np.allclose(ext_fluxes_1, ext_fluxes_2)
+
+
+def test_constant_sncosmo_extinction():
+    """Test that we can create and sample a SncosmoExtinctionEffect object."""
+    # Use given ebv values. Usually these would be computed from a dustmap,
+    # based on (RA, dec).
+    a_v_node = GivenValueList([0.1, 0.2, 0.3, 0.4, 0.5])
+    dust_effect = SncosmoExtinctionEffect("odonnell94", a_v=a_v_node, r_v=3.1, frame="rest")
+    assert dust_effect.extinction_model is not None
+
+    model = ConstantSEDModel(
+        brightness=100.0,
+        ra=0.0,
+        dec=40.0,
+        redshift=0.0,
+    )
+    model.add_effect(dust_effect)
+
+    times = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+    wavelengths = np.array([7000.0, 5200.0, 4800.0])  # Red, green, blue
+    states = model.sample_parameters(num_samples=3)
+    fluxes = model.evaluate_sed(times, wavelengths, states)
+
+    # We check that all fluxes are reduced, and that higher a_v leads to
+    # lower fluxes.
+    assert fluxes.shape == (3, 5, 3)
+    assert np.all(fluxes < 100.0)
+    assert np.all(fluxes[0, :, :] > fluxes[1, :, :])
+    assert np.all(fluxes[1, :, :] > fluxes[2, :, :])

--- a/tests/lightcurvelynx/effects/test_sncosmo_extinction.py
+++ b/tests/lightcurvelynx/effects/test_sncosmo_extinction.py
@@ -9,19 +9,19 @@ from lightcurvelynx.math_nodes.given_sampler import GivenValueList
 from lightcurvelynx.models.basic_models import ConstantSEDModel
 
 
-def test_load_extinction_model():
+def test_load_sncosmo_extinction_model():
     """Load an extinction model by string."""
     fm07_model = SncosmoExtinctionEffect.load_extinction_model("fm07")
     assert fm07_model is not None
     assert callable(fm07_model)
 
     # We can manually load the fm07_model into an ExtinctionEffect node.
-    dust_effect = SncosmoExtinctionEffect(fm07_model, a_v=0.1, frame="rest")
+    dust_effect = SncosmoExtinctionEffect(fm07_model, ebv=0.1, frame="rest")
 
     # We can apply the extinction effect to a set of fluxes.
     fluxes = np.full((10, 3), 1.0)
     wavelengths = np.array([7000.0, 5200.0, 4800.0])
-    new_fluxes = dust_effect.apply(fluxes, wavelengths=wavelengths, a_v=0.1)
+    new_fluxes = dust_effect.apply(fluxes, wavelengths=wavelengths, ebv=0.1)
     assert new_fluxes.shape == (10, 3)
     assert np.all(new_fluxes < fluxes)
 
@@ -29,22 +29,22 @@ def test_load_extinction_model():
     with pytest.raises(ValueError):
         _ = dust_effect.apply(fluxes, wavelengths=wavelengths)
     with pytest.raises(ValueError):
-        _ = dust_effect.apply(fluxes, a_v=0.1)
+        _ = dust_effect.apply(fluxes, ebv=0.1)
 
 
-def test_load_extinction_model_with_r_v():
+def test_load_sncosmo_extinction_model_with_r_v():
     """Load an extinction model by string."""
     od94_model = SncosmoExtinctionEffect.load_extinction_model("odonnell94")
     assert od94_model is not None
     assert callable(od94_model)
 
     # We can manually load the od94_model into an ExtinctionEffect node.
-    dust_effect = SncosmoExtinctionEffect(od94_model, a_v=0.1, r_v=3.1, frame="rest")
+    dust_effect = SncosmoExtinctionEffect(od94_model, ebv=0.1, r_v=3.1, frame="rest")
 
     # We can apply the extinction effect to a set of fluxes.
     fluxes = np.full((10, 3), 1.0)
     wavelengths = np.array([7000.0, 5200.0, 4800.0])
-    new_fluxes = dust_effect.apply(fluxes, wavelengths=wavelengths, a_v=0.1, r_v=3.1)
+    new_fluxes = dust_effect.apply(fluxes, wavelengths=wavelengths, ebv=0.1, r_v=3.1)
     assert new_fluxes.shape == (10, 3)
     assert np.all(new_fluxes < fluxes)
 
@@ -52,32 +52,32 @@ def test_load_extinction_model_with_r_v():
     with pytest.raises(ValueError):
         _ = dust_effect.apply(fluxes, wavelengths=wavelengths, r_v=3.1)
     with pytest.raises(ValueError):
-        _ = dust_effect.apply(fluxes, a_v=0.1, r_v=3.1)
+        _ = dust_effect.apply(fluxes, ebv=0.1, r_v=3.1)
     with pytest.raises(ValueError):
-        _ = dust_effect.apply(fluxes, wavelengths=wavelengths, a_v=0.1)
+        _ = dust_effect.apply(fluxes, wavelengths=wavelengths, ebv=0.1)
 
 
-def test_set_frame():
+def test_sncosmo_extinction_set_frame():
     """Test that correct frame is set"""
-    ext = SncosmoExtinctionEffect("odonnell94", a_v=0.1, r_v=3.1, frame="observer")
+    ext = SncosmoExtinctionEffect("odonnell94", ebv=0.1, r_v=3.1, frame="observer")
     assert ext.rest_frame is False
 
     with pytest.raises(ValueError):
-        SncosmoExtinctionEffect("odonnell94", a_v=0.1, r_v=3.1, frame="InvalidFrame")
+        SncosmoExtinctionEffect("odonnell94", ebv=0.1, r_v=3.1, frame="InvalidFrame")
 
 
-def test_pickle_extinction_model():
+def test_pickle_sncosmo_extinction_model():
     """Test that we can pickle and unpickle an SncosmoExtinctionEffect object."""
     # Create two models: one defined by model name and the other with a given object.
-    model_A = SncosmoExtinctionEffect("odonnell94", a_v=0.1, r_v=3.1, frame="rest")
+    model_A = SncosmoExtinctionEffect("odonnell94", ebv=0.1, r_v=3.1, frame="rest")
 
     ext_model = SncosmoExtinctionEffect.load_extinction_model("odonnell94")
-    model_B = SncosmoExtinctionEffect(ext_model, a_v=0.1, r_v=3.1, frame="rest")
+    model_B = SncosmoExtinctionEffect(ext_model, ebv=0.1, r_v=3.1, frame="rest")
 
     # Compute the some sample fluxes before and after extinction.
     org_fluxes = np.full((10, 3), 1.0)
     wavelengths = np.array([7000.0, 5200.0, 4800.0])
-    ext_fluxes_1 = model_A.apply(org_fluxes, wavelengths=wavelengths, a_v=0.1, r_v=3.1)
+    ext_fluxes_1 = model_A.apply(org_fluxes, wavelengths=wavelengths, ebv=0.1, r_v=3.1)
     assert ext_fluxes_1.shape == (10, 3)
 
     with tempfile.TemporaryDirectory() as tmpdir:
@@ -93,7 +93,7 @@ def test_pickle_extinction_model():
             loaded_model = pickle.load(f)
         assert loaded_model is not None
 
-        ext_fluxes_2 = loaded_model.apply(org_fluxes, wavelengths=wavelengths, a_v=0.1, r_v=3.1)
+        ext_fluxes_2 = loaded_model.apply(org_fluxes, wavelengths=wavelengths, ebv=0.1, r_v=3.1)
         assert ext_fluxes_2.shape == (10, 3)
         assert np.allclose(ext_fluxes_1, ext_fluxes_2)
 
@@ -109,7 +109,7 @@ def test_pickle_extinction_model():
             loaded_model = pickle.load(f)
         assert loaded_model is not None
 
-        ext_fluxes_2 = loaded_model.apply(org_fluxes, wavelengths=wavelengths, a_v=0.1, r_v=3.1)
+        ext_fluxes_2 = loaded_model.apply(org_fluxes, wavelengths=wavelengths, ebv=0.1, r_v=3.1)
         assert ext_fluxes_2.shape == (10, 3)
         assert np.allclose(ext_fluxes_1, ext_fluxes_2)
 
@@ -118,8 +118,8 @@ def test_constant_sncosmo_extinction():
     """Test that we can create and sample a SncosmoExtinctionEffect object."""
     # Use given ebv values. Usually these would be computed from a dustmap,
     # based on (RA, dec).
-    a_v_node = GivenValueList([0.1, 0.2, 0.3, 0.4, 0.5])
-    dust_effect = SncosmoExtinctionEffect("odonnell94", a_v=a_v_node, r_v=3.1, frame="rest")
+    ebv_node = GivenValueList([0.1, 0.2, 0.3, 0.4, 0.5])
+    dust_effect = SncosmoExtinctionEffect("odonnell94", ebv=ebv_node, r_v=3.1, frame="rest")
     assert dust_effect.extinction_model is not None
 
     model = ConstantSEDModel(


### PR DESCRIPTION
Closes #680

This is a breaking change. We add support for the extinction package (https://github.com/sncosmo/extinction) by creating a new `SncosmoExtinctionEffect` class. To avoid confusion we rename the `ExtinctionEffect` to `DustExtinctionEffect`. This forces the users to choose one or the other.