### PR TITLE
Extend ObsTable's colmap

### DIFF
--- a/src/lightcurvelynx/example_runs/simulate_snia.py
+++ b/src/lightcurvelynx/example_runs/simulate_snia.py
@@ -40,8 +40,8 @@ def construct_snia_source(oversampled_observations, zpdf):
     logger.info("Creating the source model.")
 
     # Get the range in which t0 can occur.
-    t_min = oversampled_observations["observationStartMJD"].min()
-    t_max = oversampled_observations["observationStartMJD"].max()
+    t_min = oversampled_observations["time"].min()
+    t_max = oversampled_observations["time"].max()
 
     # TODO: Extract the ra and dec center from the opsim in case that changes.
     # Currently we are relying on the fact the test opsim has all pointings

--- a/src/lightcurvelynx/obstable/fake_obs_table.py
+++ b/src/lightcurvelynx/obstable/fake_obs_table.py
@@ -25,7 +25,8 @@ class FakeObsTable(ObsTable):
         The table with all the ObsTable information.  Must have columns
         "time", "ra", "dec", and "filter".
     colmap : dict, optional
-        A mapping of standard column names to their names in the input table.
+        A mapping of standard column names to a list of possible names in the input table.
+        Each value in the dictionary can be a string or a list of strings.
     zp_per_band : dict, optional
         A dictionary mapping filter names to their instrumental zero points (flux in nJy
         corresponding to 1 electron per exposure). The filters provided must match those

--- a/src/lightcurvelynx/obstable/obs_table.py
+++ b/src/lightcurvelynx/obstable/obs_table.py
@@ -33,7 +33,8 @@ class ObsTable:
         The table with all the survey information. Metadata can be included in the
         "lightcurvelynx_survey_data" entry of the attributes dictionary.
     colmap : dict, optional
-        A mapping of standard column names to their names in the input table.
+        A mapping of standard column names to a list of possible names in the input table.
+        Each value in the dictionary can be a string or a list of strings.
         For example, in Rubin's OpSim we might have the column "observationStartMJD"
         which maps to "time". In that case we would have an entry with key="time"
         and value="observationStartMJD".
@@ -110,12 +111,30 @@ class ObsTable:
             self._table = table.copy()
 
         # Remap the columns to standard names. Start with the existing names (from the table)
-        # and overwrite anything provided by the column map. Save the inverse mapping.
+        # and overwrite anything provided by the column map. The column map can have multiple
+        # potential options for each standard name to handle changes in schema
+        # (e.g. Rubin Opsim, DP1, DP2, etc.).
+        # name_map will be the mapping of current -> standard name.
+        # inv_colmap will be the mapping of standard -> current name.
         name_map = {col: col for col in self._table.columns}
         self._inv_colmap = {}
         self._colmap = colmap if colmap is not None else {}
         if colmap is not None:
             for key, value in colmap.items():
+                # If the standard column name (key) could be taken from multiple options,
+                # find the first one that exists in the table.
+                if isinstance(value, list):
+                    match_value = None
+                    for val in value:
+                        if val in self._table.columns:
+                            match_value = val
+                            break
+
+                    if match_value is None:
+                        value = value[0]  # Default to the first option if none found
+                    else:
+                        value = match_value
+
                 if value in name_map:
                     # Check for collisions (mapping a column to an existing column)
                     if key in self._table.columns and key != value:

--- a/src/lightcurvelynx/obstable/obs_table.py
+++ b/src/lightcurvelynx/obstable/obs_table.py
@@ -119,6 +119,7 @@ class ObsTable:
         name_map = {col: col for col in self._table.columns}
         self._inv_colmap = {}
         self._colmap = colmap if colmap is not None else {}
+        all_cols = set(self._table.columns)
         if colmap is not None:
             for key, value in colmap.items():
                 # If the standard column name (key) could be taken from multiple options,
@@ -126,7 +127,7 @@ class ObsTable:
                 if isinstance(value, list):
                     match_value = None
                     for val in value:
-                        if val in self._table.columns:
+                        if val in all_cols:
                             match_value = val
                             break
 

--- a/src/lightcurvelynx/obstable/opsim.py
+++ b/src/lightcurvelynx/obstable/opsim.py
@@ -90,9 +90,9 @@ class OpSim(ObsTable):
     table : dict or pandas.core.frame.DataFrame
         The table with all the OpSim information.
     colmap : dict
-        A mapping of short column names to their names in the underlying table.
-        Defaults to the Rubin OpSim column names, stored in the class variable
-        _opsim_colnames.
+        A mapping of standard column names to a list of possible names in the input table.
+        Each value in the dictionary can be a string or a list of strings.
+        Defaults to the Rubin column names (OpSim, DP1, etc.), stored in _default_colnames.
     saturation_mags : dict, optional
         A dictionary mapping filter names to their saturation thresholds in magnitudes. The filters
         provided must match those in the table. If not provided, OpSim-specific defaults will be

--- a/src/lightcurvelynx/obstable/opsim.py
+++ b/src/lightcurvelynx/obstable/opsim.py
@@ -110,18 +110,23 @@ class OpSim(ObsTable):
 
     _required_names = ["ra", "dec", "time"]
 
-    # Default column names for the Rubin OpSim.
+    # Default column names for the Rubin from the different schemas including
+    # OpSim, DP1 CCDVisit, DP2 CCDVisit, etc.
     _default_colnames = {
         "airmass": "airmass",
-        "dec": "fieldDec",
-        "exptime": "visitExposureTime",
-        "filter": "filter",
-        "ra": "fieldRA",
-        "time": "observationStartMJD",
-        "zp": "zp_nJy",  # We add this column to the table
+        "dec": ["dec", "fieldDec"],
+        "exptime": ["exptime", "visitExposureTime", "expTime"],
+        "filter": ["filter", "band"],
+        "maglim": ["maglim", "magLim", "fiveSigmaDepth"],
+        "nexposure": ["nexposure", "numExposures", "nexp"],
+        "ra": ["ra", "fieldRA"],
+        "rotation": ["rotation", "skyRotation"],
         "seeing": "seeingFwhmEff",
         "skybrightness": "skyBrightness",
-        "nexposure": "numExposures",
+        "skynoise": ["skyNoise", "skynoise", "sky_noise_median"],
+        "time": ["time", "observationStartMJD", "expMidptMJD", "obsStart"],
+        "zp": "zp_nJy",  # We add this column to the table
+        "zp_mag": ["zp_mag", "zeroPoint", "zero_point_median"],
     }
 
     # Default survey values.

--- a/src/lightcurvelynx/obstable/roman_obstable.py
+++ b/src/lightcurvelynx/obstable/roman_obstable.py
@@ -93,7 +93,8 @@ class RomanObsTable(ObsTable):
     table : dict or pandas.core.frame.DataFrame
         The table with all the observation information.
     colmap : dict
-        A mapping of short column names to their names in the underlying table.
+        A mapping of standard column names to a list of possible names in the input table.
+        Each value in the dictionary can be a string or a list of strings.
         Defaults to the Roman APT column names, stored in _default_colnames.
     ma_table_path : str or pathlib.Path, optional
         The path to the Roman MultiAccum table CSV file. If not provided, a default table included

--- a/src/lightcurvelynx/obstable/ztf_obstable.py
+++ b/src/lightcurvelynx/obstable/ztf_obstable.py
@@ -40,7 +40,8 @@ class ZTFObsTable(ObsTable):
     table : dict or pandas.core.frame.DataFrame
         The table with all the observation information.
     colmap : dict
-        A mapping of short column names to their names in the underlying table.
+        A mapping of standard column names to a list of possible names in the input table.
+        Each value in the dictionary can be a string or a list of strings.
         Defaults to the ZTF column names, stored in _default_colnames.
     saturation_mags : dict, optional
         A dictionary mapping filter names to their saturation thresholds in magnitudes. The filters

--- a/tests/lightcurvelynx/obstable/test_obs_table.py
+++ b/tests/lightcurvelynx/obstable/test_obs_table.py
@@ -169,12 +169,15 @@ def test_create_obs_table_custom_names():
     assert np.allclose(ops_data["time"], values["custom_time"])
     assert np.allclose(ops_data["other"], values["other"])
 
-    # Load succeeds if we pass multiple options for the colmap.
+    # Load succeeds if we pass multiple options for the colmap and also
+    # provide mapping for non-existing columns.
     colmap = {
         "ra": ["not_used_ra", "custom_ra", "ra"],
-        "dec": ["custom_dec", "dec"],
-        "time": ["custom_time", "time", "obs_time"],
+        "dec": "custom_dec",
+        "time": "custom_time",
         "my_val": ["something", "other"],
+        "not_a_col": ["nothing", "no_column"],
+        "not_a_col2": "not_here",
     }
     ops_data = ObsTable(values, colmap=colmap)
     assert len(ops_data) == 5

--- a/tests/lightcurvelynx/obstable/test_obs_table.py
+++ b/tests/lightcurvelynx/obstable/test_obs_table.py
@@ -164,6 +164,24 @@ def test_create_obs_table_custom_names():
     colmap = {"ra": "custom_ra", "dec": "custom_dec", "time": "custom_time"}
     ops_data = ObsTable(values, colmap=colmap)
     assert len(ops_data) == 5
+    assert np.allclose(ops_data["ra"], values["custom_ra"])
+    assert np.allclose(ops_data["dec"], values["custom_dec"])
+    assert np.allclose(ops_data["time"], values["custom_time"])
+    assert np.allclose(ops_data["other"], values["other"])
+
+    # Load succeeds if we pass multiple options for the colmap.
+    colmap = {
+        "ra": ["not_used_ra", "custom_ra", "ra"],
+        "dec": ["custom_dec", "dec"],
+        "time": ["custom_time", "time", "obs_time"],
+        "my_val": ["something", "other"],
+    }
+    ops_data = ObsTable(values, colmap=colmap)
+    assert len(ops_data) == 5
+    assert np.allclose(ops_data["ra"], values["custom_ra"])
+    assert np.allclose(ops_data["dec"], values["custom_dec"])
+    assert np.allclose(ops_data["time"], values["custom_time"])
+    assert np.allclose(ops_data["my_val"], values["other"])
 
     # Test that we fail if we try to map a column onto an existing column (mapping the given
     # "other" column onto the existing "zp" column).


### PR DESCRIPTION
Extend `ObsTable`'s colmap so that users can include a list of possible column names (in priority order). This allows us to support schema changes without having to create an entirely new `ObsTable`, such as supporting Rubin OpSim, DP1, DP2, etc.