### PR TITLE
Update support for Rubin ccdvisit table

### DIFF
--- a/docs/notebooks.rst
+++ b/docs/notebooks.rst
@@ -25,6 +25,7 @@ features and models of the LightCurveLynx package.
     :maxdepth: 1
 
     Using Rubin OpSims in Simulations <notebooks/opsim_notebook>
+    Using Rubin CCD Visit Table in Simulations <notebooks/pre_executed/rubin_ccdvisit>
     Passband Demo <notebooks/passband-demo>
     Adding New Model Types <notebooks/adding_models>
     Debugging Models <notebooks/debugging>

--- a/docs/notebooks/opsim_notebook.ipynb
+++ b/docs/notebooks/opsim_notebook.ipynb
@@ -8,7 +8,7 @@
     "\n",
     "A critical aspect to producing realistic simulations of time varying phenomena is correctly modeling the cadence at which the objects will be observed and capturing the relevant physical details about the observation. LightCurveLynx provides an `OpSim` module that can load a Rubin opsim file and use that to filter observations based on location, associate observations with their filter, apply detector noise, etc. `OpSim` objects are subclasses of the more general `ObsTable` data structures and a lot of the same concepts apply to `ObsTable`s for different surveys.\n",
     "\n",
-    "This notebook provides an introduction to using opsim data in the simulations."
+    "This notebook provides an introduction to using opsim data in the simulations. For an example of how to load a CCD Visit table from actual runs, such as DP1, see the [corresponding notebook](https://lightcurvelynx.readthedocs.io/en/latest/notebooks/pre_executed/rubin_ccdvisit.html)."
    ]
   },
   {

--- a/docs/notebooks/pre_executed/rubin_ccdvisit.ipynb
+++ b/docs/notebooks/pre_executed/rubin_ccdvisit.ipynb
@@ -1,0 +1,180 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "424653e4",
+   "metadata": {},
+   "source": [
+    "# Working with Rubin CCDVisit Table Data\n",
+    "\n",
+    "In this notebook we look at how we can import data from the Rubin CCDVisit table such as [DP1](https://dp1.lsst.io/products/index.html) or DP2 (coming soon).\n",
+    "\n",
+    "Note that the lsst packages are not installed as part of the default LightCurveLynx installation. Users will need to manually install them via in order to run this notebook (e.g. `pip install lsst-rsp`)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b2ae6f87",
+   "metadata": {},
+   "source": [
+    "## Get the Visits Table\n",
+    "\n",
+    "Users will need to download the CCDVisits table. Here we use the parquet version of the [DP1 ccdvisits table on LSDB.io](https://data.lsdb.io/hats/dp1/). This notebook assumes the table has been downloaded to a local directory."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "f7d62cd7",
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "FileNotFoundError",
+     "evalue": "[Errno 2] No such file or directory: '../../../data/ccd_visit.parquet'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
+      "\u001b[31mFileNotFoundError\u001b[39m                         Traceback (most recent call last)",
+      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[1]\u001b[39m\u001b[32m, line 4\u001b[39m\n\u001b[32m      1\u001b[39m \u001b[38;5;28;01mimport\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34;01mpandas\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;28;01mas\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34;01mpd\u001b[39;00m\n\u001b[32m      3\u001b[39m filename = \u001b[33m\"\u001b[39m\u001b[33m../../../data/ccd_visit.parquet\u001b[39m\u001b[33m\"\u001b[39m\n\u001b[32m----> \u001b[39m\u001b[32m4\u001b[39m survey_data = \u001b[43mpd\u001b[49m\u001b[43m.\u001b[49m\u001b[43mread_parquet\u001b[49m\u001b[43m(\u001b[49m\u001b[43mfilename\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m      5\u001b[39m survey_data.head()\n",
+      "\u001b[36mFile \u001b[39m\u001b[32m~/envs/lightcurvelynx/lib/python3.13/site-packages/pandas/io/parquet.py:669\u001b[39m, in \u001b[36mread_parquet\u001b[39m\u001b[34m(path, engine, columns, storage_options, use_nullable_dtypes, dtype_backend, filesystem, filters, **kwargs)\u001b[39m\n\u001b[32m    666\u001b[39m     use_nullable_dtypes = \u001b[38;5;28;01mFalse\u001b[39;00m\n\u001b[32m    667\u001b[39m check_dtype_backend(dtype_backend)\n\u001b[32m--> \u001b[39m\u001b[32m669\u001b[39m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mimpl\u001b[49m\u001b[43m.\u001b[49m\u001b[43mread\u001b[49m\u001b[43m(\u001b[49m\n\u001b[32m    670\u001b[39m \u001b[43m    \u001b[49m\u001b[43mpath\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m    671\u001b[39m \u001b[43m    \u001b[49m\u001b[43mcolumns\u001b[49m\u001b[43m=\u001b[49m\u001b[43mcolumns\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m    672\u001b[39m \u001b[43m    \u001b[49m\u001b[43mfilters\u001b[49m\u001b[43m=\u001b[49m\u001b[43mfilters\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m    673\u001b[39m \u001b[43m    \u001b[49m\u001b[43mstorage_options\u001b[49m\u001b[43m=\u001b[49m\u001b[43mstorage_options\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m    674\u001b[39m \u001b[43m    \u001b[49m\u001b[43muse_nullable_dtypes\u001b[49m\u001b[43m=\u001b[49m\u001b[43muse_nullable_dtypes\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m    675\u001b[39m \u001b[43m    \u001b[49m\u001b[43mdtype_backend\u001b[49m\u001b[43m=\u001b[49m\u001b[43mdtype_backend\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m    676\u001b[39m \u001b[43m    \u001b[49m\u001b[43mfilesystem\u001b[49m\u001b[43m=\u001b[49m\u001b[43mfilesystem\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m    677\u001b[39m \u001b[43m    \u001b[49m\u001b[43m*\u001b[49m\u001b[43m*\u001b[49m\u001b[43mkwargs\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m    678\u001b[39m \u001b[43m\u001b[49m\u001b[43m)\u001b[49m\n",
+      "\u001b[36mFile \u001b[39m\u001b[32m~/envs/lightcurvelynx/lib/python3.13/site-packages/pandas/io/parquet.py:258\u001b[39m, in \u001b[36mPyArrowImpl.read\u001b[39m\u001b[34m(self, path, columns, filters, use_nullable_dtypes, dtype_backend, storage_options, filesystem, **kwargs)\u001b[39m\n\u001b[32m    256\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m manager == \u001b[33m\"\u001b[39m\u001b[33marray\u001b[39m\u001b[33m\"\u001b[39m:\n\u001b[32m    257\u001b[39m     to_pandas_kwargs[\u001b[33m\"\u001b[39m\u001b[33msplit_blocks\u001b[39m\u001b[33m\"\u001b[39m] = \u001b[38;5;28;01mTrue\u001b[39;00m\n\u001b[32m--> \u001b[39m\u001b[32m258\u001b[39m path_or_handle, handles, filesystem = \u001b[43m_get_path_or_handle\u001b[49m\u001b[43m(\u001b[49m\n\u001b[32m    259\u001b[39m \u001b[43m    \u001b[49m\u001b[43mpath\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m    260\u001b[39m \u001b[43m    \u001b[49m\u001b[43mfilesystem\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m    261\u001b[39m \u001b[43m    \u001b[49m\u001b[43mstorage_options\u001b[49m\u001b[43m=\u001b[49m\u001b[43mstorage_options\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m    262\u001b[39m \u001b[43m    \u001b[49m\u001b[43mmode\u001b[49m\u001b[43m=\u001b[49m\u001b[33;43m\"\u001b[39;49m\u001b[33;43mrb\u001b[39;49m\u001b[33;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\n\u001b[32m    263\u001b[39m \u001b[43m\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m    264\u001b[39m \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[32m    265\u001b[39m     pa_table = \u001b[38;5;28mself\u001b[39m.api.parquet.read_table(\n\u001b[32m    266\u001b[39m         path_or_handle,\n\u001b[32m    267\u001b[39m         columns=columns,\n\u001b[32m   (...)\u001b[39m\u001b[32m    270\u001b[39m         **kwargs,\n\u001b[32m    271\u001b[39m     )\n",
+      "\u001b[36mFile \u001b[39m\u001b[32m~/envs/lightcurvelynx/lib/python3.13/site-packages/pandas/io/parquet.py:141\u001b[39m, in \u001b[36m_get_path_or_handle\u001b[39m\u001b[34m(path, fs, storage_options, mode, is_dir)\u001b[39m\n\u001b[32m    131\u001b[39m handles = \u001b[38;5;28;01mNone\u001b[39;00m\n\u001b[32m    132\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m (\n\u001b[32m    133\u001b[39m     \u001b[38;5;129;01mnot\u001b[39;00m fs\n\u001b[32m    134\u001b[39m     \u001b[38;5;129;01mand\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m is_dir\n\u001b[32m   (...)\u001b[39m\u001b[32m    139\u001b[39m     \u001b[38;5;66;03m# fsspec resources can also point to directories\u001b[39;00m\n\u001b[32m    140\u001b[39m     \u001b[38;5;66;03m# this branch is used for example when reading from non-fsspec URLs\u001b[39;00m\n\u001b[32m--> \u001b[39m\u001b[32m141\u001b[39m     handles = \u001b[43mget_handle\u001b[49m\u001b[43m(\u001b[49m\n\u001b[32m    142\u001b[39m \u001b[43m        \u001b[49m\u001b[43mpath_or_handle\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mmode\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mis_text\u001b[49m\u001b[43m=\u001b[49m\u001b[38;5;28;43;01mFalse\u001b[39;49;00m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mstorage_options\u001b[49m\u001b[43m=\u001b[49m\u001b[43mstorage_options\u001b[49m\n\u001b[32m    143\u001b[39m \u001b[43m    \u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m    144\u001b[39m     fs = \u001b[38;5;28;01mNone\u001b[39;00m\n\u001b[32m    145\u001b[39m     path_or_handle = handles.handle\n",
+      "\u001b[36mFile \u001b[39m\u001b[32m~/envs/lightcurvelynx/lib/python3.13/site-packages/pandas/io/common.py:882\u001b[39m, in \u001b[36mget_handle\u001b[39m\u001b[34m(path_or_buf, mode, encoding, compression, memory_map, is_text, errors, storage_options)\u001b[39m\n\u001b[32m    873\u001b[39m         handle = \u001b[38;5;28mopen\u001b[39m(\n\u001b[32m    874\u001b[39m             handle,\n\u001b[32m    875\u001b[39m             ioargs.mode,\n\u001b[32m   (...)\u001b[39m\u001b[32m    878\u001b[39m             newline=\u001b[33m\"\u001b[39m\u001b[33m\"\u001b[39m,\n\u001b[32m    879\u001b[39m         )\n\u001b[32m    880\u001b[39m     \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[32m    881\u001b[39m         \u001b[38;5;66;03m# Binary mode\u001b[39;00m\n\u001b[32m--> \u001b[39m\u001b[32m882\u001b[39m         handle = \u001b[38;5;28;43mopen\u001b[39;49m\u001b[43m(\u001b[49m\u001b[43mhandle\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mioargs\u001b[49m\u001b[43m.\u001b[49m\u001b[43mmode\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m    883\u001b[39m     handles.append(handle)\n\u001b[32m    885\u001b[39m \u001b[38;5;66;03m# Convert BytesIO or file objects passed with an encoding\u001b[39;00m\n",
+      "\u001b[31mFileNotFoundError\u001b[39m: [Errno 2] No such file or directory: '../../../data/ccd_visit.parquet'"
+     ]
+    }
+   ],
+   "source": [
+    "import pandas as pd\n",
+    "\n",
+    "filename = \"../../../data/ccd_visit.parquet\"\n",
+    "survey_data = pd.read_parquet(filename)\n",
+    "survey_data.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "978d0700",
+   "metadata": {},
+   "source": [
+    "## Creating the ObsTable\n",
+    "\n",
+    "The `OpSim` class includes a method for building an `ObsTable` directly from a Rubin CCDVisists table.  It includes the schemas for both DP1 and DP2 data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b3fee58e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from lightcurvelynx.obstable.opsim import OpSim\n",
+    "\n",
+    "obs_table = OpSim.from_ccdvisit_table(survey_data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "976ed1fe",
+   "metadata": {},
+   "source": [
+    "This means that the function will automatically handle translating the column names to those expected by LightCurveLynx. By comparing the column names, we can see some of the renaminings (e.g. \"band\" -> \"filter\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "89b6a0c3",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Columns dropped from survey_data to obs_table:\n",
+      "{'skyBg', 'obsStartMJD', 'magLim', 'skyNoise', 'expTime', 'pixelScale', 'zeroPoint', 'band', 'skyRotation'}\n",
+      "Columns added to obs_table from defaults or calculations:\n",
+      "{'filter', 'skynoise', 'zp_mag', 'skybrightness', 'rotation', 'exptime', 'zp', 'time', 'pixel_scale', 'maglim'}\n"
+     ]
+    }
+   ],
+   "source": [
+    "cols1 = set(obs_table.columns.tolist())\n",
+    "cols2 = set(survey_data.columns.tolist())\n",
+    "\n",
+    "print(\"Columns dropped from survey_data to obs_table:\")\n",
+    "print(cols2 - cols1)\n",
+    "\n",
+    "print(\"Columns added to obs_table from defaults or calculations:\")\n",
+    "print(cols1 - cols2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a9c400b1",
+   "metadata": {},
+   "source": [
+    "We can plot the footprint of the survery using the `plot_footprint` function."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "22ab8097",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAkYAAAGyCAYAAAABNgv+AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjcsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvTLEjVAAAAAlwSFlzAAAPYQAAD2EBqD+naQAAKKJJREFUeJzt3Qd0FOX+//FvQhJCMQGSSO+d0EEwgCCCVGlXuEpXEUQEaReBo4IFRVAQJBTFC+gVAhypSgcR/vQuvV4ElCahhBBNINn/eZ777P4SQyCEJbPl/Tpn2Z2Zze6TyQ7z2aeNj81mswkAAADEl30AAADwPwQjAAAAg2AEAABgEIwAAAAMgpEH2rlzp8TGxlpdDMBl3blzR3r37i1Xr161uiiAy/vtt99k3Lhx4i18GJXmeUJCQuSpp56SxYsXW10UwCWpLw6PPfaYHDhwQCpWrGh1cQCXVrFiRTl06JB4yyB2aow8jPrwqm/Bw4cPt7oogEvXGCn+/v5WFwVweVOmTNH3kyZNEm9AjZGH6dixoyxbtkxiYmKsLgrgsq5cuSJhYWFy8uRJKVmypNXFAVyer6+vPP7443Lx4kXxdH5WF8DdJCUlyfnz53U1vI+Pj7ia5cuXy9NPP00wQqa7cOGCbNmyRTdPHT9+XM6ePSv9+/eXDh06uNxf49q1a/r+zz//dPtjZd68eTJ+/HgpUqSIlC1bVipVqiT16tWTggULWl00eJCCBQvqvkbufLyopsCbN29KgQIFdNBLCzVGD0h9MAoXLvywfx8AAGCBc+fOSaFChdLcTo3RA1I1RfYdGxQU9HB/HcCDJCQkSEBAgNXFAH8L4K5UbZeq2LCfx9NCMHpA9uYzFYoIRgAAuJf7dYNhVBoAAIBBMAIAADAIRgAAAAbBCAAAwCAYAQAAGAQjAAAAg2AEAABgEIwAAAAMghEAAIBBMAIAADAIRgAAAAbBCAAAwCAYAQAAGAQjAAAAg2AEAABgEIwAAAAMghEAAIBBMAIAADAIRgAAAAbBCAAAwCAYAQAAGAQjAAAAg2AEAABgEIwAAAAMghEAAIBBMAIAADAIRgAAAAbBCAAAwCAYAQAAGAQjAAAAg2AEAABgEIwAAAAMghEAAIBBMAIAADAIRgAAAAbBCAAAwCAYAQAAGAQjAAAAg2AEAABgEIwAAAAMghEAAIBBMAIAADAIRgAAAAbBCAAAwCAYAQAAGAQjAAAAg2AEAADgrsFo6tSpUrlyZQkKCtK3iIgIWbFihWP7X3/9JW+88YaEhIRIzpw55fnnn5dLly6leI2lS5dKmTJlpGzZsvLjjz9a8FsAAABX5GOz2WziRn744QfJkiWLlC5dWlTRv/nmG/n0009l7969Eh4eLq+//rosW7ZMZs2aJcHBwdK3b1/x9fWVzZs365+Pj4+XUqVKycyZM/XPv/LKK3Lq1CkJCAhI1/vHxMTo171x44YOZgAAwPWl9/ztdsHobvLkyaPDUfv27SUsLEzmzJmjHytHjx6V8uXLy9atW+XJJ5/UO0bVOO3atUtvf+KJJ2T//v3y2GOPpeu9CEYAALif9J6/3a4pLbnExESZO3eu3Lp1Szep7d69W27fvi2NGzd2PKdcuXJSpEgRHYwUtTNefvllyZ8/vxQoUEDXMKU3FAEAAM/mJ27owIEDOgip/kSqH9GiRYukQoUKsm/fPt0klitXrhTPz5s3r1y8eNGxPHLkSBkwYIBuYiMUAQAAtw5GqtO0CkGqOuz777+X7t27y4YNGx7oNVR1GgAAgNs3palaIdWBukaNGjJ69GipUqWKTJw4UfLlyycJCQly/fr1FM9Xo9LUtodtmxw8eLAUL178IUsPAACsUqJECRkyZIjExsZ6TjD6u6SkJD3aTAUlf39/WbdunWPbsWPH5OzZs7rpLSPOnDkj1apV081zX3zxhQ5hAADAPVWqVEkmTJig+xzXrFlTn+fduilt+PDh0rx5c92h+ubNm3oE2s8//yyrVq3SzWM9evSQQYMG6ZFq6pfu16+fDkVqRFpG5M6dW4euzz//XM+PFBcXRzMcAABuasmSJZI9e3Zd2TF9+nQ976FbD9dXwUfVCF24cEEHFDX0fujQofLss8/q7apDtmryioqK0oGmadOmMmXKlIduSrNjuD4AAO7Hq+YxykwEIwAA3I9XzGMEAADgTAQjAAAAg2AEAABgEIwAAAAMghEAAIBBMAIAADAIRgAAAAbBCAAAwCAYAQAAuOu10gAA1khMTJTo6Gh9uSU1e3DFihX5U8DjUGMEALivmTNnSsGChSRv3rz6It7qCuXdu3fX164EPAnXSntAXCsNgDdRNUO5cuW653PeeustGTNmTKaVCcgIrpUGAHhoU6ZMue9zxo4dK3v37mVvwyPQlAYASNNzzz2Xrr1z6tQp9iI8AsEIAJAm1ZfI39//vnsoa9as7EV4BIIRAOCepk+f7ngcUKCsFHzj21TPCQwMZC/CIxCMAAD35OPj43iccP6Y/D65W6rnEIzgKQhGAIB7atCgwX33ULly5diL8AgEIwDAPRUtWlTi4uJk//79kj17dsf68PBwGTFihFy7dk3CwsLYi/AIzHwNALivbNmy6Y7Yt27d0jNfBwQEpGhiAzwFwQgA8EAYgQZPRlMaAACAQTACAAAwCEYAAAAGwQgAAMAgGAEAABgEIwAAAINgBAAAYBCMAAAADIIRAACAQTACAAAwCEYAAAAGwQgAAMAgGAEAABgEIwAAAINgBAAAYBCMAAAADIIRAACAQTACAAAwCEYAAAAGwQgAAMAgGAEAABgEIwAAAINgBAAAYBCMAAAADIIRAACAQTACAAAwCEYAAAAGwQgAAMAgGAEAABgEIwAAAINgBAAAYBCMAAAADIIRAACAQTACAAAwCEYAAAAGwQgAAMAgGAEAABgEIwAAAINgBAAAYBCMAAAADIIRAACAQTACAAAwCEYAAAAGwQgAAMAgGAEAABgEIwAAAINgBAAAYBCMAAAADIIRAACAQTACAAAwCEYAAAAGwQgAAMAgGAEAABgEIwAAAINgBAAAYBCMAAAADIIRAACAQTACAAAwCEYAAAAGwQgAAMAgGAEAABgEIwAAAINgBAAAYBCMAAAADIIRAACAQTACAAAwCEYAAACeHowmT54sxYoVk8DAQKldu7bs2LHDse3YsWNSt25dKVSokIwaNcrScgIAANfhkcFo3rx5MmjQIBk5cqTs2bNHqlSpIk2bNpXLly/r7X379pUuXbrIkiVL9G3Lli1WFxkAALhrMBo9erTMmDEj1Xq1bsyYMWK18ePHS8+ePeXll1+WChUqyLRp0yR79uyOMl+7dk1q1KghlStXlgIFCsj169etLjIAAHDXYPTll19KuXLlUq0PDw/XIcRKCQkJsnv3bmncuLFjna+vr17eunWrXv7ggw/0sgpLapuqTYK1bt++zZ8AAOCewejixYuSP3/+VOvDwsLkwoULYqUrV65IYmKi5M2bN8V6tazKrbRo0UL++OMPOX/+vCxatEiyZMliUWmh3Lx5U0qXKSMVK1XSodtms7FjAADuE4wKFy4smzdvTrVerVNNU+4ga9asOsjBWqq/V1BQkJz59Vc5dPCg9O7dW9firVmzhj8NAMA9gpHqvzNgwACZOXOmnDlzRt9U/52BAwfqbVYKDQ3VNUCXLl1KsV4t58uX76Fee+nSpbpfEpzj7NmzevTg3TRp0oTdDABwOjUga/ny5c4NRkOGDJEePXpInz59pESJEvrWr18/efPNN2X48OFipYCAAN2xet26dY51SUlJejkiIiJDrxkVFaWH9rdp00a/PpwjLi7untvv3LnDrgYAOJWfn5+0bNlSihQpIgsWLEi13cf2EB06YmNj5ciRI5ItWzYpXbq0bp5yleH63bt31/1VatWqJRMmTJD58+fL0aNHU/U9Ss/JOzg4WHcsnz59upQtW1Yv37hxQzcBIeO+++476dq1q2O5QK/pEn/ugESv+ELvW7WPAQBwhpiYGMf5+9ChQ/Laa6/pDKOW1WAsO7+HeRPVmfnq1atSv359HYpUxvLx8RGrvfDCC7pz9YgRI3QZq1atKitXrnzgUKSonZV8p6kdC+dQzZJ5QkLlavQVvZxw6ZT8eWyTFCpSVI4dOcxuBgA8EqoFaf/+/bqCJ3koynCNUXR0tPzzn/+U9evX6yB04sQJ3Zz2yiuvSO7cuWXcuHHiDYmTGiPnDNNXfdP27vtFtmzepNf9+OOPupoTAIDMPn9nqI+ROpH5+/vrzrPJk5aqqVE1M0B6qc9RZGSkbN70/2Tfvn262ZNQBACwSoaa0lavXi2rVq3SHZKTU/2M1Ag1IKMjBdQNAACrZKjG6NatW6na5BTV38hVOmADAABkSjB66qmn5Ntvv3Usq35Gakj82LFjpWHDhhl5SQAAAPdsSlMBqFGjRrJr1y59bbK33npLD31TNUZ3mxEbAADAY2uMKlasKMePH5d69erpSQ9V09o//vEP2bt3r5QsWdL5pQQAAMgEDzXBozdiuD4AAJ57/k53U5qaCCm9uJ4YAABwR+kORmr2aNXJ+u+zW9srnJKvS0xMdHY5AQAAXKeP0enTp+W///2vvlcXXStevLhMmTJFT8qnbuqx6l90twuyAQAAeFSNUdGiRR2PO3ToIF988YW0aNEiRfNZ4cKF5d1335W2bds6v6QAAACuOCrtwIEDusbo79S6w4e5+CcAAPCiYFS+fHkZPXq0nsPITj1W69Q2AAAAr5ngcdq0adKqVSt9rTT7CDQ1ak11wP7hhx+cXUYAAADXnsdITeo4e/ZsOXr0qF5WNUWdOnWSHDlyiCdjHiMAANyP0+cx+jsVgHr16pXRHwcAAPCMPkZpuXDhgpw9e9aZLwkAAOCeweiZZ56562g1AAAAd5DhprS7+fbbbyUuLs6ZLwkAAOCeweiJJ55w5ssBAAC4b1MaAACA19UY5c6dO8VFY+/l6tWrGXkLAAAA9whG6npoo0aNkqZNm0pERIRet3XrVlm1apXelidPHmeXEwAAwDUneHz++eelYcOG0rdv3xTrIyMjZe3atbJ48WLxVEzwCACA556/M9THSNUMNWvWLNV6tU4FIwDwNomJifLzzz/rm/qPF4AXNaWFhITIkiVLZPDgwSnWq3VqGwB4Wyjy8/NL1b9S9ccE4AXB6P3335dXX31VfzOqXbu2Xrd9+3ZZuXKlTJ8+3dllBACXDkXdundPtV71tbxz545kyZLFknIByJgMNaW99NJLsnnzZt1Gt3DhQn1Tjzdt2qS3AYC3hKKu3bpJVNRcCW09NNX2t956y5JyAcjkztfejM7XAOySkpIcNUJBES9I0p8xErtvhWN7/gIF5fixo5IzZ052GuDJna+VU6dOyTvvvCOdOnWSy5cv63UrVqyQQ4cOZfQlAY+oQYD3SEhIcDyO2TovRShSpkyOJBQBbiZDwWjDhg1SqVIl3a9owYIFEhsbq9f/8ssvMnLkSGeXEXBpGzdulFq1autJT1UH3H79+gkVsd4hMDBQdu3aleb2okWLZmp5AFgUjIYNG6YneFyzZo0EBAQ41j/zzDOybds2JxQLcA9Lly6VBg0ayM6dO1LM5+Xr6ysHDx60tGzIHDVq1JBZs2alWq/WVatWjT8D4A3B6MCBA9KuXbtU6x9//HG5cuWKM8oFuIU2bdqkue3rr7/O1LLAOt27d5e4uDi5dOmSnDx5Ut+rdQC8JBjlypVLLly4kGr93r17pWDBgs4oF+Dy7E3IaZk4cSJNal4kW7Zs+sthyZIl9T0ALwpGL774ogwdOlQuXryo+1WokRlq+P6//vUv6datm/NLCbggNdKodevW93zOzZs3M608AACLgtHHH38s5cqVk8KFC+tvzRUqVJD69etLnTp19Eg1wFt07do1zW2q79G9hoQCADxsHqNz587p/kYqHKlOhqVLlxZPxzxGSE4dPn369JFp06alWD9nzhxp3769+Pv7s8MAwI3O30zw+Ih2LLxLfHy87nen7tWEf6VKlbK6SACADJy/M3SttLSoi8iqN6SfEbxN1qxZpVixYlYXAwDwkJxaY6T6HZ04ccKjZ/+lxggAAPdjSY3R0aNHnflyAAAAmSrD10oDAADwNBkKRitXrpRNmzY5lidPnixVq1bVF5S9du2aM8sHAADg2sFoyJAhuq1OUcP1Bw8eLC1atJDTp0/LoEGDnF1GAACATJGhPkYqAKlJHZUFCxbIc889pyd93LNnjw5IAAAAXlNjFBAQoC+YqKxdu1aaNGmiH+fJk8dRkwQAAOAVNUb16tXTTWZ169aVHTt2yLx58/T648ePS6FChZxdRgAAANetMYqMjBQ/Pz/5/vvvZerUqVKwYEG9fsWKFdKsWTNnlxEAACBTcEmQB8QEjwAAuJ9HPsGjmt168eLFcuTIEb0cHh4urVu31teJAgAA8JqmtJMnT0r58uX1NdEWLlyob126dNHh6NSpU84vJQDggS1atEjKlSsvffr0YWAM8Cib0tSQfPVjs2fP1iPRlOjoaB2OfH19ZdmyZeKpaEoD4A5UX9B+/fqlWOfES2MCbueRNqVt2LBBtm3b5ghFSkhIiHzyySd6pBoAwBoq/OTNm1f++OMPeaxmG7m5a4lj29atWyUiIoI/DeDsprSsWbPKzZs3U62PjY3VcxwBAKyhLtmkQpHiH1JYQp4b7Ng2cOBA/izAowhGaqbrXr16yfbt2/W3E3VTNUi9e/fWHbABANZQl2myu7oqUqJ/HOdYbtWqlUWlAjw8GH3xxRdSsmRJXSUbGBiob3Xq1JFSpUrJxIkTnV9KAEC6qEEwaXn22WfZi8CjnMdIjU47fPiwfqyunaaCkaej8zUAVzdjxkzp0eOVFOvWrFkjjRs3tqxMgLucvzMcjP7973/L559/LidOnNDLpUuXlgEDBsirr74qnoxgBMAd/Pbbb3pAjPovfsSIEbpDNuDNYh7lqDR1kI0fP14PBbWPcFCjHVTHvrNnz8oHH3yQ8ZIDAB6aum6lGrIP4MFkqMYoLCxM9zPq2LFjivVRUVE6LF25ckU8FTVGAAB47vk7Q52vb9++LTVr1ky1vkaNGnLnzp2MvCQAAIDlMhSMunbtKlOnTk21/quvvpLOnTs7o1wAAACZLsMXkVWdr1evXi1PPvmkXlZzGqn+Rer6aYMGDXI8T/VFAgAA8NhgdPDgQalevbp+bL9obGhoqL6pbXY+Pj7OKicAAIBrBqP169c7vyQAAADu2McIAADAExGMAAAADIIRAACAQTACAAAwCEYAAAAGwQgAAMAgGAEAABgEIwAAAINgBAAAYBCMAAAADIIRAACAQTACAAAwCEYAAAAGwQgAAMAgGAEAABgEIwAAAINgBAAAYBCMAAAADIIRAACAQTACAAAwCEYAAAAGwQgAAMAgGAEAABgEIwAAAINgBAAAYBCMAAAADIIRAACAQTACAAAwCEYAAACGn/0BAHgjm80mSUlJ+rGvr6/4+PhYXSQAFqLGCIBXq1mzpvj5+embCkbLly+3ukgALEQwAuC1GjRoIHv27EmxrmXLlpaVB4D1CEYAvFJkZKRs3Ljxrttmz56d6eUB4BoIRgC80tSpU9Pc1rt370wtCwDXQTAC4JUWLlyY5rZ27dplalkAuA6CEQCvVLZs2TS3de7cOVPLAsB1EIwAeK2jR4+mWtelSxdp2rSpJeUBYD3mMQLg1bVGK1eulP/85z96qH779u2ldevWVhcLgIV8bGp2M6RbTEyMBAcHy40bNyQoKIg9BwCAB52/aUoDAAAwCEYAAAAGwQgAAMAgGAEAABgEIwAAAINgBAAAYBCMAAAADIIRAACAQTACAAAwCEYAAAAGwQgAAMAgGAEAABgEIwAAAINgBAAAYBCMAAAADIIRAACAQTACAAAwCEYAAAAGwQgAAMAgGAEAABgEIwAAAINgBAAAYBCMAAAA3DEYtW7dWooUKSKBgYGSP39+6dq1q5w/fz7Fc/bv3y9PPfWUfk7hwoVl7NixKbYnJiZKnz599M+3aNFCLl++nMm/BQAAcFVuFYwaNmwo8+fPl2PHjsmCBQvk1KlT0r59e8f2mJgYadKkiRQtWlR2794tn376qbz33nvy1VdfOZ4zd+5cOXv2rKxatUqqV68u77zzjkW/DQAAcDV+4kYGDhzoeKzCz7Bhw6Rt27Zy+/Zt8ff3l9mzZ0tCQoLMmDFDAgICJDw8XPbt2yfjx4+XXr166Z+7du2aFCtWTCpWrChHjhzRAQsAAMDtglFyV69e1UGoTp06OhQpW7dulfr16+tQZNe0aVMZM2aMDkS5c+eWLl26SKNGjSRr1qySN29eWb58uYW/BQAAcCVu1ZSmDB06VHLkyCEhISG6SWzJkiWObRcvXtRhJzn7stqm5MqVSzeznTt3Ts6cOSOVK1fO5N8AAAC4KsuDkWoO8/Hxueft6NGjjucPGTJE9u7dK6tXr5YsWbJIt27dxGazPfD75suXT/88AACAyzSlDR48WF566aV7PqdEiRKOx6GhofpWpkwZKV++vB55tm3bNomIiNBh59KlSyl+1r6stjnDuHHjnPI6AADA9VgejMLCwvQtI5KSkvR9fHy8vlfh6O2333Z0xlbWrFkjZcuW1f2LHta3334rH3zwwUO/DgAAsIYakKVGrLtsU1p6bd++XSIjI/UoM9U36KeffpKOHTtKyZIldSBSOnXqpDte9+jRQw4dOiTz5s2TiRMnyqBBgx76/VXAUjVbzZs3d8JvAwAArPD+++9LVFSU+wej7Nmzy8KFC/WIMlUDpMKP6ji9YcMGPcJMCQ4O1n2PTp8+LTVq1NDNdCNGjHAM1c+o69ev68kg1bxHah4kAADgnho3bqxHqG/atOmu231sGem57IWmTp0qPXv2lLi4OB3Abty4IUFBQVYXCwAApIOaBFqdv9X0PWpqHzVZdHR0tOTMmdO1+hi5i9dff93qIgAAgIfk6+sru3bt0hUefw9FevvDvgEAAIA7Uf2R+/fvf9dtBCMAAACDYAQAAGAQjAAAAAyCEQAAgEEwAgAAMAhGAAAABsEIAADAIBgBAAAYBCMAAACDYAQAAGAQjAAAAAyCEQAAgEEwAgAAMAhGAAAABsEIAADAIBgBAAAYBCMAAACDYAQAAGAQjAAAAAyCEQAAgEEwAgAAMAhGAAAABsEIAADAIBgBAAAYBCMAAACDYAQAAGAQjAAAAAyCEQAAgEEwAgAAMAhGAAAABsEIAADAIBgBAAAYBCMAAACDYAQAAGAQjAAAAAyCEQAAgEEwAgAAMAhGAAAABsEIAADAIBgBAAAYBCMAAOB1kpKSZOPGjanWE4wAAIBXmTRpkgQFBUnz5s11QErOz7JSAQAAZLLSpUvL5cuXpVGjRjJnzhzx9U1ZR0QwAgAAXiNPnjyybt06qVix4l23E4wAAIDX2L59u25GSwt9jAAAAAyCEQAAgEEwSocTJ06k52kA4HLi4+MlNDRUfHx8JCoqyuriAC6PYHQfd+7ckfDwcMmXL598//33mfNXAQAn2L9/vwQGBkp0dLRe7tSpkxQrXlxiY2PZv0AaCEb34efnJ3v27JH8+fNLhw4ddEgCAFenhiFXqVIl1fozv/4qH3/8sSVlAtwBwSgd1JC+vXv3ypYtW/S3LwBwdcOHD09z2+HDRzK1LIA7IRg9gIiICNm9e/ej+2sAgJOULFkyzW3h4RXYz0AaCEYA4IH69Olz1/V9+/aVjz76KNPLA7gLghEAeKBWrVrpSx4kt3r1an2NKABpIxgBgAfKmjWrrF27VtavXy9DhgyRq1evyrPPPmt1sQCX52Oz2WxWF8KdxMTESHBwsNy4ceOeU4oDAAD3O39TYwQAAGAQjAAAAAyCEQAAgEEwAgAAMAhGAAAABsEIAADAIBgBAAAYBCMAAACDYAQAAGAQjAAAAAyCEQAAgEEwAgAAMAhGAAAAhp/9AdLHZrM5rtLr6pKSksTXl+wLAODcEWPO2/bzeFoIRg/o5s2b+r5w4cIcZwAAuOF5PDg4OM3tPrb7RSekqoU5f/68PPbYY+Lj4+PSe2fHjh3y9ttv63t/f39p1qyZREZGSq5cuawumsv65ptv5M0335QbN25YXRSPs2DBAunTp48kJibKuHHjpHv37uJKrl+/LkWLFtXHS9myZa0ujv4cqs+j8tprr8nYsWOtLpLHUyfLSZMmSbdu3cRbREdHS+/evWXdunX6/Fa7dm356KOPpGbNmuJpVNxRoahAgQL3bE0hGHkBVX04dOhQWbhwoZw4cUKCgoKsLpLL6tWrl8ybN49g9Ij89ddf0rZtW1m1apU0bNhQfvrpJ3EVd+7c0V8gtm3bpk8OVgoLC5MrV67oLzHqmA0NDbW0PN4UjF544QX56quvxJvOD+XKldO/94cffig5c+YUb0dTmhdQQWjq1Kn6hns7dOiQ5M+fn930iAQGBsrKlStlxYoV8ssvv7jUfvbz+99/h7GxsVYXRapUqaJvqmYNmSdfvnz6/wBvOz+oVhD8H4IRkMyZM2f0CQmPVvPmzfXNFbnCwIq1a9daXQSvVKpUKZcL7Mh8BCMgmffee0/KlCnDPvFSAwYMkKpVq1pdDFhEdTk4fvw4+9/L0ccIAADAYJIbL/Trr7965IgDuD5X/+y5cvn+XjZXLis8z69e9HkjGAEAABgEIy91+/ZtPY9M+fLl9TBNprMCnz3XPzaSl61v374uXVZ4ntte8nkjGLmhjRs3SqtWrfQkVWqSycWLF6fYPnr0aHniiSf0JJSPP/64njfm2LFjKZ5z5MgR3dHw8OHDcunSJdm0aVMm/xbwVGoCx3fffVeKFy8u2bJlk5IlS+r5Uez/ibrSZ++TTz7Rx5DqdG2XWeVL6zidPHmyFCtWTE9toOZTUhNOqnKq/Xnw4EFH2dQ8R+reVfYlXFt6zgt3++wl50rH7qNEMHJDt27d0kPK1Yf4bjZs2CBvvPGGnqhuzZo1OuU3adJE/5ydmtm3QoUK+qRQrVo13X4MOMOYMWP0nFlqlnX1H6laVrM2qxmFXemzt3PnTvnyyy+lcuXKKdZnVvnudpzWq1dPBg4cKCNHjpQ9e/bo47xRo0YyZcoUPQlf7ty5HWVT92reHVfYl3B99zsvqIltBw0alOKz17RpU7l8+bLjNVzl2H3UGK7vgXPAqAn0kps1a5b+hrB7926pX7++Xpc1a1bH9ixZsuhv+YAzbNmyRdq0aSMtW7bUy+obaFRUlP722bp1a5f47KlJHDt37izTp0+XUaNGpdiWWeVL6zht166dvPzyy3rdZ599JjNmzNDNFqq26OrVqynKZp+U8lGXFe7vfueF8ePHS8+ePR2fvWnTpsmyZcv052/YsGF6nSscu5mBGiMvYL/uV548eawuCrxAnTp19HWX7PPBqAnzVJW7K03oqL45q+DWuHFjcRV//PGHvm/QoIFjXb9+/fS8WvZtwKM4LyQkJOiAlPx48PX11ctbt271up1OjZGHUxcFVP0n6tatKxUrVrS6OPAC6tul/fpL9m+V6qKUqobGFare586dq5sKVFOaKx2n6qKxSq1atVKUU138efPmzS5/0Wq473lBXRJEHad58+ZN8Ty1fPToUfE2BCMPp74Zqyr45J3kVNPGrl27HMuquh5wlvnz58vs2bNlzpw5Eh4eLvv27dP/CavBAmpEi5WfvXPnzkn//v11HwvVwfTvrDo21HGavCNs8nJ+9913ep0qb8eOHR3PUc2AyXEc42HOC/dTzIvOGwQjD6aG8/744496FFuhQoWsLg68xJAhQ3St0YsvvqiXK1WqpK9Bp0bFqGBkJdVcoDqTVq9e3bFOfVNWx4jqLB4fH69ruaw4TtX10VSQVKN91M1eTvXtXlGj+qwsJzz3vBAaGqo/T+pzl5xaVh38vQ19jDyQ+g9UffgXLVokP/30kx7mC2SWuLg43T8hOfWfrv0EbyU1wuvAgQO6Fst+U7P5qmY+9Tgzw8bfj1M14qdGjRq6f5a9nKopLSwsTDezWVVOeP55ISAgwPHZs1PHq1qOiIgQb0ONkRtSI2pOnjzpWD59+rT+z1J1oitSpIiuJlXNGEuWLNFzVly8eFE/Lzg4WM8rAzxKao4t1adIfRZVDcjevXv1iJdXXnnF8h2vjoe/97XLkSOHhISEZHofvLsdp2of2UOQ6mukpjhQHWOHDx+uR6ZZUU54hvudF9RQfVWjW9N89iZMmKCH8ttHqXkVG9zO+vXr1Ux5qW7du3fX2++2Td1mzpxpddHhBWJiYmz9+/e3FSlSxBYYGGgrUaKE7e2337bFx8fbXFGDBg10eTNbWsdp586d9b4LCAiw1apVy7Zt2zZLywnPkJ7zwqRJk+762fM2Puofq8MZAACAK6CPEQAAgEEwAgAAMAhGAAAABsEIAADAIBgBAAAYBCMAAACDYAQAAEAwAgAASIkaIwAAAINgBAAAYBCMAAAADIIRAGSC27dvs58BN0AwAuBSnn76aenbt6++BQcHS2hoqLz77rtiv971tWvXpFu3bpI7d27Jnj27NG/eXE6cOOH4+TNnzkirVq309hw5ckh4eLgsX748zfeLj4+Xf/3rX1KwYEH9/Nq1a8vPP/+c4jmzZs2SIkWK6Pdr166djBs3TnLlypXma/7666/i4+Mj8+bNkwYNGkhgYKDMnj1boqOjpWPHjvq91GtVqlRJoqKinLLfADgHwQiAy/nmm2/Ez89PduzYIRMnTpTx48fL119/rbe99NJLsmvXLlm6dKls3bpVB6YWLVo4amTeeOMNHXY2btwoBw4ckDFjxkjOnDnTfC8VwNTrzJ07V/bv3y8dOnSQZs2aOcLW9u3bpUePHvp5+/btk4YNG8qoUaPS9XsMGzZM+vfvL0eOHJGmTZvKX3/9JTVq1JBly5bJwYMHpVevXtK1a1f9ewJwETYAcCENGjSwlS9f3paUlORYN3ToUL3u+PHjqtrItnnzZse2K1eu2LJly2abP3++Xq5UqZLtvffeS9d7nTlzxpYlSxbb77//nmJ9o0aNbMOHD9ePO3bsaGvRokWK7S+88IItODg4zdc9ffq0LueECRPuW4aWLVvaBg8enK7yAnj0qDEC4HKefPJJ3RRlFxERoWtwDh8+rGuSVHOXXUhIiJQtW1bXyihvvvmmrtGpW7eujBw5UtcCpUXVKCUmJkqZMmV0rZL9tmHDBjl16pR+jnrd5O9nL0961KxZM8Wyeq8PP/xQN6HlyZNHv9eqVavk7Nmz6dwzAB41v0f+DgCQiV599VXdbKWaq1avXi2jR4/WfYL69euX6rmxsbGSJUsW2b17t75P7l7Nb+ml+iwl9+mnn+qmwQkTJuhwpLYPGDBAEhISHvq9ADgHNUYAXI7q15Pctm3bpHTp0lKhQgW5c+dOiu2qQ/OxY8f0NrvChQtL7969ZeHChTJ48GCZPn36Xd+nWrVquhbn8uXLUqpUqRS3fPny6eeUL1/+ruXJiM2bN0ubNm2kS5cuUqVKFSlRooQcP348Q68F4NEgGAFwOappadCgQTrwqFFbkyZN0p2YVThSwaJnz56yadMm+eWXX3TIUKO81HpF1cCo5qnTp0/Lnj17ZP369Trc2JUrV04WLVqkH6smtM6dO+tRbipEqZ9RHaFVLZOqcbI3za1cuVI+++wz3ZwXGRmpl5NTP6Ne9/fff7/n76XKv2bNGtmyZYtuonvttdfk0qVLj2APAsgoghEAl6OCyp9//im1atXSo8xUKFIjuJSZM2fqkV3PPfec7uujRqWp4fj+/v56u6oBUj+jwpAaXabCz5QpUxyvrcLWjRs3HMvq9dT7qZol1Vepbdu2snPnTj08397fSdU4qSYwVcujmufeeeedFOWNi4vTr3u/uYrUz1WvXl039alpCVStlHo/AK7DR/XAtroQAGCnAkPVqlV1PxxXpeY1UjVT169ft7ooAJyMGiMAAACDYAQAAGDQlAYAAGBQYwQAAGAQjAAAAAyCEQAAgEEwAgAAMAhGAAAABsEIAADAIBgBAAAYBCMAAACDYAQAACD/8/8Bxh4DudiIIE8AAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "obs_table.plot_footprint()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6444f17d",
+   "metadata": {},
+   "source": [
+    "## Conclusion\n",
+    "\n",
+    "The `OpsSim` created from the visits table can be used like any other `ObsTable`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "34ce3854",
+   "metadata": {},
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "lightcurvelynx",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/lightcurvelynx/obstable/obs_table.py
+++ b/src/lightcurvelynx/obstable/obs_table.py
@@ -8,6 +8,7 @@ import warnings
 from pathlib import Path
 
 import astropy.units as u
+import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 from astropy.coordinates import Latitude, Longitude
@@ -19,6 +20,7 @@ from tqdm import tqdm
 from lightcurvelynx.astro_utils.coordinate_utils import dedup_coords, ra_dec_to_cartesian
 from lightcurvelynx.astro_utils.detector_footprint import DetectorFootprint
 from lightcurvelynx.astro_utils.mag_flux import mag2flux
+from lightcurvelynx.utils.io_utils import read_sqlite_table
 
 logger = logging.getLogger(__name__)
 
@@ -366,19 +368,7 @@ class ObsTable:
         FileNotFoundError if the file does not exist.
         ValueError if unable to load the table.
         """
-        if not Path(filename).is_file():
-            raise FileNotFoundError(f"db file {filename} not found.")
-        con = sqlite3.connect(f"file:{filename}?mode=ro", uri=True)
-
-        # Read the table.
-        try:
-            survey_data = pd.read_sql_query(sql_query, con)
-        except Exception:
-            raise ValueError("Database read failed.") from None
-
-        # Close the connection.
-        con.close()
-
+        survey_data = read_sqlite_table(filename, table_name=None, sql_query=sql_query)
         return cls(survey_data, **kwargs)
 
     @classmethod
@@ -510,6 +500,26 @@ class ObsTable:
                 moc = new_moc if moc is None else MOC.union(moc, new_moc)
 
         return moc
+
+    def plot_footprint(self, *, depth=14, fig=None, **kwargs):
+        """Plot the MOC footprint using matplotlib.
+
+        Parameters
+        ----------
+        depth : int, optional
+            The healpix depth to use for plotting.
+        fig : matplotlib.figure.Figure, optional
+            An existing matplotlib figure to use. If None, a new figure is created.
+        **kwargs : dict, optional
+            Additional keyword arguments to pass to the mocpy.MOC.fill() function.
+        """
+        moc = self.build_moc(max_depth=depth, use_footprint=True)
+
+        if fig is None:
+            fig = plt.figure()
+        wcs = moc.wcs(fig)
+        ax = fig.add_subplot(projection=wcs)
+        moc.fill(ax, wcs, **kwargs)
 
     def _build_kd_tree(self):
         """Construct the KD-tree from the ObsTable."""

--- a/src/lightcurvelynx/utils/io_utils.py
+++ b/src/lightcurvelynx/utils/io_utils.py
@@ -346,7 +346,7 @@ def read_lclib_data(input_file):
         # Try to open the file as a regular text file.
         with open(input_file, "r") as file_ptr:
             curves = _read_lclib_data_from_open_file(file_ptr)
-    else:
+    else:  # pragma: no cover
         raise ValueError(f"Unsupported file format: {suffix}.")
 
     return curves
@@ -387,7 +387,7 @@ def read_sqlite_table(db_path, table_name=None, sql_query=None):
     # Read the specified table into a DataFrame.
     try:
         df = pd.read_sql_query(sql_query, con)
-    except Exception as e:
+    except Exception as e:  # pragma: no cover
         raise RuntimeError(f"Error executing sql query '{sql_query}' from database {db_path}: {e}") from e
 
     # Close the database connection.

--- a/tests/lightcurvelynx/obstable/test_opsim.py
+++ b/tests/lightcurvelynx/obstable/test_opsim.py
@@ -1,4 +1,5 @@
 import tempfile
+import warnings
 from pathlib import Path
 
 import numpy as np
@@ -592,7 +593,7 @@ def test_opsim_from_ccdvisit():
     assert "dec" in opsim
     assert "filter" in opsim
     assert "zp" in opsim
-    assert "fiveSigmaDepth" in opsim
+    assert "maglim" in opsim
     assert "seeing" in opsim
     assert "skybrightness" in opsim
     assert "rotation" in opsim
@@ -613,6 +614,15 @@ def test_opsim_from_ccdvisit():
         make_detector_footprint=True,
     )
     assert opsim_with_footprint._detector_footprint is not None
+
+
+def test_opsim_plot_footprint(opsim_shorten):
+    """Test that we can plot the OpSim footprint."""
+    opsim = OpSim.from_db(opsim_shorten)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        opsim.plot_footprint(depth=12)
 
 
 def test_create_random_opsim():


### PR DESCRIPTION
With #703 we can now process multiple `ObsTable` inputs with slightly different schemas. This updates the `from_ccdvisit_table` to use this ability (instead of specifying a single colmap). Adds a notebook with an example.

Other updates include:
- Moving the function to read from a db file into a helper function so we can reuse it elsewhere.
- Adding a function to plot the footprint of a `ObsTable`
