### PR TITLE
Fix a small bug

### DIFF
--- a/src/lightcurvelynx/obstable/obs_table_params.py
+++ b/src/lightcurvelynx/obstable/obs_table_params.py
@@ -172,7 +172,7 @@ class ParamDeriver(ABC):
                 values = obs_table[param].to_numpy()
             elif param in obs_table.survey_values:
                 values = obs_table.survey_values[param]
-                if type(values) is dict and filters is not None:
+                if isinstance(values, dict) and filters is not None:
                     # Unpack the per-band dictionary into an array of values.
                     values = np.array([values.get(band, None) for band in filters])
             else:

--- a/src/lightcurvelynx/obstable/obs_table_params.py
+++ b/src/lightcurvelynx/obstable/obs_table_params.py
@@ -161,7 +161,10 @@ class ParamDeriver(ABC):
             The observation table from which to initialize parameters.
         """
         # Get the filter row so we can unpack dictionaries if needed.
-        filters = obs_table["filter"]
+        if "filter" not in obs_table.columns:
+            filters = None
+        else:
+            filters = obs_table["filter"]
 
         # Load each parameter from the ObsTable if it exists and is valid.
         for param in self.parameters:
@@ -169,7 +172,8 @@ class ParamDeriver(ABC):
                 values = obs_table[param].to_numpy()
             elif param in obs_table.survey_values:
                 values = obs_table.survey_values[param]
-                if type(values) is dict:
+                if type(values) is dict and filters is not None:
+                    # Unpack the per-band dictionary into an array of values.
                     values = np.array([values.get(band, None) for band in filters])
             else:
                 values = None


### PR DESCRIPTION
Parameter derivation can crash in cases where no filter column is present. This avoids that problem.