### PR TITLE
Skip unneeded bandflux computations

### DIFF
--- a/src/lightcurvelynx/models/physical_model.py
+++ b/src/lightcurvelynx/models/physical_model.py
@@ -769,12 +769,12 @@ class SEDModel(BasePhysicalModel):
             # Compute the band fluxes for the times at which this filter is used.
             passband = passband_group[filter_name]
             filter_mask = filters == filter_name
-
-            # Compute the spectral fluxes at the same wavelengths used to define the passband.
-            # The evaluate function applies all effects (rest and observation frame) for the source
-            # as well as handling all the redshift conversions.
-            spectral_fluxes = self.evaluate_sed(times[filter_mask], passband.waves, state)
-            bandfluxes[filter_mask] = passband.fluxes_to_bandflux(spectral_fluxes)
+            if np.any(filter_mask):
+                # Compute the spectral fluxes at the same wavelengths used to define the passband.
+                # The evaluate function applies all effects (rest and observation frame) for the source
+                # as well as handling all the redshift conversions.
+                spectral_fluxes = self.evaluate_sed(times[filter_mask], passband.waves, state)
+                bandfluxes[filter_mask] = passband.fluxes_to_bandflux(spectral_fluxes)
         return bandfluxes
 
 
@@ -1033,11 +1033,12 @@ class BandfluxModel(BasePhysicalModel, ABC):
         bandfluxes = np.zeros(len(times))
         for filter_name in np.unique(filters):
             filter_mask = filters == filter_name
-            bandfluxes[filter_mask] = self.compute_bandflux_with_extrapolation(
-                times[filter_mask],
-                filter_name,
-                state,
-            )
+            if np.any(filter_mask):
+                bandfluxes[filter_mask] = self.compute_bandflux_with_extrapolation(
+                    times[filter_mask],
+                    filter_name,
+                    state,
+                )
 
         # Apply all effects. Note that BandfluxModel does not apply redshift, so all effects
         # are applied in observer frame.

--- a/tests/lightcurvelynx/models/test_static_sed_model.py
+++ b/tests/lightcurvelynx/models/test_static_sed_model.py
@@ -214,7 +214,7 @@ def test_multiple_static_seds_min_max():
 
 
 def test_single_static_bandflux() -> None:
-    """Test that we can create and sample a StaticBandfluxModel object with a single bandflux."""
+    """Test that we can create and sample a StaticBandfluxModel object with given bandfluxes."""
     bandflux = {"r": 10.0, "g": 20.0, "b": 30.0}
     model = StaticBandfluxModel(bandflux, node_label="test")
     assert len(model) == 1
@@ -223,6 +223,25 @@ def test_single_static_bandflux() -> None:
     times = np.array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
     filters = ["r", "r", "g", "b", "r", "g", "b", "g", "b", "r"]
     expected = np.array([10.0, 10.0, 20.0, 30.0, 10.0, 20.0, 30.0, 20.0, 30.0, 10.0])
+
+    state = model.sample_parameters(num_samples=1)
+    fluxes = model.evaluate_bandfluxes(None, times, filters, state)
+    assert len(fluxes) == 10
+    assert np.array_equal(fluxes, expected)
+
+
+def test_single_static_bandflux_partial() -> None:
+    """Test that we can create and sample a StaticBandfluxModel object even if we do not
+    query all the given bands.
+    """
+    bandflux = {"r": 10.0, "g": 20.0, "b": 30.0}
+    model = StaticBandfluxModel(bandflux, node_label="test")
+    assert len(model) == 1
+    assert len(model.list_effects()) == 0
+
+    times = np.array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+    filters = ["r", "r", "g", "g", "r", "g", "g", "g", "g", "r"]  # No "b" filters
+    expected = np.array([10.0, 10.0, 20.0, 20.0, 10.0, 20.0, 20.0, 20.0, 20.0, 10.0])
 
     state = model.sample_parameters(num_samples=1)
     fluxes = model.evaluate_bandfluxes(None, times, filters, state)


### PR DESCRIPTION
Very small optimization. Skip bandflux computations for filters that do not appear in the data.
