### PR TITLE
Make JAX tests more robust to floating point errors

### DIFF
--- a/tests/lightcurvelynx/math_nodes/test_basic_math_node.py
+++ b/tests/lightcurvelynx/math_nodes/test_basic_math_node.py
@@ -178,7 +178,7 @@ def test_basic_math_node_autodiff_jax():
 
     gr_func = jax.value_and_grad(node.generate)
     values, gradients = gr_func(pytree)
-    assert values == 2.0
+    assert float(values) == pytest.approx(2.0)
     assert gradients["a_node"]["a"] > 0.0
     assert gradients["b_node"]["b"] < 0.0
 


### PR DESCRIPTION
When adding the EZTaoX tests, some of the other JAX tests can fail due to changes in the floating point precision. This PR adds a small buffer to the failing tests so they pass.