### PR TITLE
Fix multivariate_normal

### DIFF
--- a/docs/notebooks/sampling.ipynb
+++ b/docs/notebooks/sampling.ipynb
@@ -275,6 +275,59 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "`NumpyRandomFunc` node can also be used to draw from multivariate distributions where each sample is a vector of values. In the following example each sample consists of a two dimensional point with the x value drawn uniformly (0.0, 10) and the y value drawn uniformly (5.0, 15.0). Note that in this case each entry for example sample is generated *independently* (see the `NumpyMultivariateNormalFunc` for correlated output)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "low = [0.0, 10.0]\n",
+    "high = [5.0, 15.0]\n",
+    "np_node = NumpyRandomFunc(\"uniform\", low=low, high=high, node_label=\"xy\", size=2)\n",
+    "\n",
+    "# Sample the multivariate normal distribution\n",
+    "graph_state = np_node.sample_parameters(num_samples=100)\n",
+    "x = graph_state[\"xy\"][\"function_node_result\"][:, 0]\n",
+    "y = graph_state[\"xy\"][\"function_node_result\"][:, 1]\n",
+    "_ = plt.scatter(x, y, marker=\".\", linewidth=0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "There are a few functions that are unsupported by the `NumpyRandomFunc` node as vectorized sampling requires a slightly different format. We provide alternative implementations:\n",
+    "\n",
+    "   * The \"choice\" sampling is implemented by the `GivenValueSampler` node.\n",
+    "   * The \"multivariate_normal\" sampling is implemented by the `NumpyMultivariateNormalFunc` node."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from lightcurvelynx.math_nodes.np_random import NumpyMultivariateNormalFunc\n",
+    "\n",
+    "mean = [1.0, 1.0]\n",
+    "cov = [[1.0, 0.5], [0.5, 1.0]]\n",
+    "np_node = NumpyMultivariateNormalFunc(mean=mean, cov=cov, node_label=\"xy\")\n",
+    "\n",
+    "# Sample the multivariate normal distribution\n",
+    "graph_state = np_node.sample_parameters(num_samples=100)\n",
+    "x = graph_state[\"xy\"][\"function_node_result\"][:, 0]\n",
+    "y = graph_state[\"xy\"][\"function_node_result\"][:, 1]\n",
+    "_ = plt.scatter(x, y, marker=\".\", linewidth=0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Function Nodes\n",
     "\n",
     "Sampling functions, such as those provided by numpy, are only one type of function that we might want to use to generate parameters. We might want to sample from other functions or apply a mathematical transform to multiple input parameters to compute a new parameter. For example consider the case of computing the `distmod` parameter from `redshift`. We can do this using the information about the cosmology, such as provided by astropy's `FlatLambdaCDM` class:"
@@ -595,7 +648,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.4"
+   "version": "3.13.8"
   }
  },
  "nbformat": 4,

--- a/src/lightcurvelynx/math_nodes/np_random.py
+++ b/src/lightcurvelynx/math_nodes/np_random.py
@@ -56,6 +56,11 @@ class NumpyRandomFunc(FunctionNode):
         # list 2, etc.).
         if func_name == "choice":
             raise ValueError("The 'choice' function is not supported. Use GivenValueSampler instead.")
+        if func_name == "multivariate_normal":
+            raise ValueError(
+                "The 'multivariate_normal' function is not supported. "
+                "Use NumpyMultivariateNormalFunc instead."
+            )
 
         # Convert the given size into a tuple of dimensions or None for a single value per sample.
         if size is None or size == 1:
@@ -145,5 +150,97 @@ class NumpyRandomFunc(FunctionNode):
 
         # Generate the values. Then save and return the results.
         results = func(**args, size=size_param)
+        self._save_results(results, graph_state)
+        return results
+
+
+class NumpyMultivariateNormalFunc(FunctionNode):
+    """As specific wrapper for the multivariate normal function. This is needed because it does not
+    support vectorizing over multiple input parameters (lists of means) in the same way.
+
+    Only a single mean and covariance matrix can be provided (instead of one per sample).
+
+    Attributes
+    ----------
+    func_name : str
+        The name of the random function to use.
+    _rng : numpy.random._generator.Generator
+        This object's random number generator.
+    sample_size : tuple
+        The shape of the array to generate for each sample. The actual returned value
+        will be (num_samples, *size). If an empty tuple will generate a single value per sample.
+
+    Parameters
+    ----------
+    mean : array-like
+        A length D array with the mean of the distribution for each sample.
+    cov : array-like
+        A D x D array with the covariance matrix of the distribution for each sample.
+    seed : int, optional
+        The seed to use.
+
+    Examples
+    --------
+    # Create a uniform random number generator between 100.0 and 150.0
+    func_node = NumpyRandomFunc("uniform", low=100.0, high=150.0)
+
+    # Create a normal random number generator with mean=5.0 and std=1.0
+    func_node = NumpyRandomFunc("normal", loc=5.0, scale=1.0)
+    """
+
+    def __init__(self, mean, cov, seed=None, **kwargs):
+        self.dims = len(mean)
+        if self.dims == 0:  # pragma: no cover
+            raise ValueError(f"Mean must be a non-empty array. Received {mean}.")
+
+        self.mean = np.asarray(mean)
+        self.cov = np.asarray(cov)
+        if self.mean.shape != (self.dims,):  # pragma: no cover
+            raise ValueError(f"Mean must be a single 1D array. Received {self.mean}.")
+        if self.cov.shape != (self.dims, self.dims):  # pragma: no cover
+            raise ValueError(f"Covariance matrix must be a 2D array with shape ({self.dims}, {self.dims}).")
+
+        # Get a default random number generator for this object, using the
+        # given seed if one is provided.
+        if seed is None:
+            seed = int.from_bytes(urandom(4), "big")
+        self._rng = np.random.default_rng(seed=seed)
+
+        # We use a non-function, since all the work is done in the compute function.
+        super().__init__(self._non_func, **kwargs)
+
+    def set_seed(self, new_seed):
+        """Update the random number generator's seed to a given value.
+
+        Parameters
+        ----------
+        new_seed : int
+            The given seed
+        """
+        self._rng = np.random.default_rng(seed=new_seed)
+
+    def compute(self, graph_state, rng_info=None, **kwargs):
+        """Sample from the multivariate normal distribution.
+
+        Parameters
+        ----------
+        graph_state : GraphState
+            An object mapping graph parameters to their values. This object is modified
+            in place as it is sampled.
+        rng_info : numpy.random._generator.Generator, optional
+            A given numpy random number generator to use for this computation. If not
+            provided, the function uses the node's random number generator.
+        **kwargs : dict, optional
+            Additional function arguments.
+
+        Returns
+        -------
+        results : np.ndarray
+            The result of the computation. If num_samples > 1, this will be an array of shape
+            (num_samples, dims). Otherwise it will be a 1D array of length dims.
+        """
+        rng = self._rng if rng_info is None else rng_info
+        num_samples = graph_state.num_samples if graph_state.num_samples > 1 else None
+        results = rng.multivariate_normal(mean=self.mean, cov=self.cov, size=num_samples)
         self._save_results(results, graph_state)
         return results


### PR DESCRIPTION
PR #728 was only a partial fix and the test for multivariate_normal doesn't cover all the cases. When using the sample function, we run into a problem multivariate_normal only being able to take a single mean/cov (not a vector). To fix this, we need to break that sampling type to its own object.
