### PR TITLE
Add the ability to simulate spectra

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -63,3 +63,20 @@ a few demo notebooks to illustrate various approachs, including:
 
 The LightCurveLynx team is also happy to help you wrap your favorite package. Please
 reach out if you have questions or need assistance.
+
+
+Can I Combine Multiple Surveys in a Single Simulation?
+-------------------------------------------------------------------------------
+
+Yes. LightCurveLynx allows you to combine multiple surveys in a single simulation by passing
+in multiple observation tables and corresponding passband groups. See the 
+:doc:`multiple surveys demo notebook <notebooks/multiple_surveys_demo>` for an example of how to do this.
+
+
+Can I Simulate Spectra?
+--------------------------------------------------------------------------------
+
+Yes with some caveats. LightCurveLynx has built-in support for simulating spectra, but it is currently
+in an early stage of development and does not yet add noise to the measurements. In addition, spectra
+simulation is **only** compaible with models that generate data on the spectral level (not bandflux-only
+models).  For more detail see :doc:`the spectrograph demo notebook <notebooks/spectrograph_demo>`.

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -41,4 +41,6 @@ Glossary
 
 **SEDModel**: ``SEDModel`` is a subclass of the ``BasePhysicalModel`` class that specifically represents flux density of a physical source as a function of time and wavelength.
 
+**Spectrograph**: A spectrograph is an instrument that measures the flux density of a source as a function of wavelength.
+
 **Wavelength**: Photon wavelength, in angstroms.

--- a/docs/notebooks.rst
+++ b/docs/notebooks.rst
@@ -28,6 +28,7 @@ features and models of the LightCurveLynx package.
     Using Rubin CCD Visit Table in Simulations <notebooks/pre_executed/rubin_ccdvisit>
     Sampling Object Positions <notebooks/sampling_positions>
     Passband Demo <notebooks/passband-demo>
+    Simulating Spectra <notebooks/spectrograph_demo>
     Adding New Model Types <notebooks/adding_models>
     Debugging Models <notebooks/debugging>
     Combining Models (including Hosts/Sources) <notebooks/host_source_models>

--- a/docs/notebooks/multiple_surveys.ipynb
+++ b/docs/notebooks/multiple_surveys.ipynb
@@ -172,6 +172,63 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Adding Spectra\n",
+    "\n",
+    "The list of \"PassbandGroups\" can also include `Spectrograph` objects in order to evalue spectra. Let's add a third survey with a spectrograph. Since spectographic surveys use different information, we can use the simpler `SpectrographObsTable`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from lightcurvelynx.astro_utils.spectrograph import Spectrograph\n",
+    "from lightcurvelynx.obstable.spectrograph_table import SpectrographObsTable\n",
+    "\n",
+    "obsdata3 = {\n",
+    "    \"time\": [0.0, 1.0, 2.0, 3.0],\n",
+    "    \"ra\": [0.0, 0.0, 180.0, 180.0],\n",
+    "    \"dec\": [10.0, 10.0, -10.0, -10.0],\n",
+    "}\n",
+    "obstable3 = SpectrographObsTable(obsdata3)\n",
+    "spectograph = Spectrograph(np.arange(4000, 8000, 100))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We add the spectrograph information as another survey and \"passbandgroup\"."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "results2 = simulate_lightcurves(\n",
+    "    model,\n",
+    "    1,\n",
+    "    [obstable1, obstable2, obstable3],\n",
+    "    [passband_group1, passband_group2, spectograph],\n",
+    "    obstable_save_cols=[\"zp\"],\n",
+    ")\n",
+    "results2.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The results now have two nested columns. As before, the 'lightcurve' column contains all of the light curve points from all of the (non-spectrographic) surveys. A new 'spectrograph' column contains each recorded spectra."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## FAQ\n",
     "\n",
     "### Can we use multiple surveys and parallelization?\n",

--- a/docs/notebooks/spectrograph_demo.ipynb
+++ b/docs/notebooks/spectrograph_demo.ipynb
@@ -1,0 +1,217 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Spectrograph Demo\n",
+    "\n",
+    "In addition to supporting simulations with that apply filters to provide bandfluxes, LightCurveLynx also provides the ability to generate spectra at different time steps.\n",
+    "\n",
+    "## Spectrograph\n",
+    "\n",
+    "The core class used for generating spectra is the `Spectrograph` class, which defines information on the bins and sensitivity of the instrument. A user defines a spectrograph instrument by passing an array of bin centers (wavelength in Angstroms) and an optional array of per-bin scales."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "\n",
+    "from lightcurvelynx.astro_utils.spectrograph import Spectrograph\n",
+    "\n",
+    "bin_centers = np.arange(4000, 8000, 100)\n",
+    "my_spectrograph = Spectrograph(bin_centers)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The spectrograph's `evaluate()` function is then used to turn a model's SED into spectrograph readings.\n",
+    "\n",
+    "Let's look at a concrete function where we evaluate the spectrograph of [sncosmo](https://sncosmo.readthedocs.io/en/stable/)'s SALT2 model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from lightcurvelynx.models.sncosmo_models import SncosmoWrapperModel\n",
+    "\n",
+    "model = SncosmoWrapperModel(\n",
+    "    \"salt2-h17\",  # Model name\n",
+    "    t0=53370.5,\n",
+    "    x0=100.0,\n",
+    "    x1=0.01,\n",
+    "    c=0.001,\n",
+    "    ra=0.0,\n",
+    "    dec=0.0,\n",
+    "    redshift=0.05,\n",
+    "    node_label=\"source\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can evaluate the modeled SEDs at a few times (2 days before t0, t0, 2 days after t0, 5 days after t0). We use the bin's wavelength centers as our evaluation points."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "times = 53370.5 + np.array([-5.0, 0.0, 5.0, 10.0])\n",
+    "seds = model.evaluate_sed(times, my_spectrograph.waves)\n",
+    "spectra = my_spectrograph.evaluate(seds)\n",
+    "\n",
+    "plt.plot(my_spectrograph.waves, spectra[0], marker=\".\", linestyle=\":\", label=\"t=-5.0\")\n",
+    "plt.plot(my_spectrograph.waves, spectra[1], marker=\".\", linestyle=\":\", label=\"t=0.0\")\n",
+    "plt.plot(my_spectrograph.waves, spectra[2], marker=\".\", linestyle=\":\", label=\"t=5.0\")\n",
+    "plt.plot(my_spectrograph.waves, spectra[3], marker=\".\", linestyle=\":\", label=\"t=10.0\")\n",
+    "plt.xlabel(\"Wavelength (Angstrom)\")\n",
+    "plt.ylabel(\"Flux\")\n",
+    "plt.title(\"Spectral Energy Distribution of SN at Different Times\")\n",
+    "_ = plt.legend()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Using in Simulations \n",
+    "\n",
+    "We can include spectrograph readings into our normal simulation workflow by adding an `ObsTable` with the spectrograph's pointings and a \"PassbandGroup\" that is just the spectrograph instrument itself. While any `ObsTable` subclass can be used (all that matters is the pointing information), we have provided a minimal `SpectrographObsTable` that uses a tighter radius and does not require zero point or filter information.\n",
+    "\n",
+    "We start by creating a fake observation table that includes points at our object and away from our object."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from lightcurvelynx.obstable.spectrograph_table import SpectrographObsTable\n",
+    "\n",
+    "data = {\n",
+    "    \"ra\": [0.0, 10.0, 0.0, 0.0, 10.0, 0.0],\n",
+    "    \"dec\": [0.0, -10.0, 0.0, 0.0, -10.0, 0.0],\n",
+    "    \"time\": 53370.5 + np.array([-5.0, -2.0, 0.0, 5.0, 7.0, 10.0]),\n",
+    "}\n",
+    "osbtable = SpectrographObsTable(data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can then just pass the model, survey information, and spectrograph to the simulation function."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from lightcurvelynx.simulate import simulate_lightcurves\n",
+    "\n",
+    "results = simulate_lightcurves(\n",
+    "    model,  # The model we are simulating.\n",
+    "    1,  # The number of simulations to run,\n",
+    "    osbtable,  # The observation table\n",
+    "    my_spectrograph,  # the spectrograph to use for the simulation\n",
+    ")\n",
+    "results.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The results look like the table for a normal simulation, but contain an additional \"spectra\" nested column. Each row of the nested data contains the time, instrument, list of wavelengths, and list of measured values.\n",
+    "\n",
+    "Out of the six observations in our fake table, four of them part pointed at the object. So the results include 4 spectra."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "row_0_spectra_table = results.iloc[0][\"spectra\"]\n",
+    "row_0_spectra_table"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can plot the resulting spectra. As expected, they are identical to the manually generated spectra."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "row_0_spectra_table = results.iloc[0][\"spectra\"]\n",
+    "for row_idx in range(len(row_0_spectra_table)):\n",
+    "    plt.plot(\n",
+    "        row_0_spectra_table.iloc[row_idx][\"waves\"],\n",
+    "        row_0_spectra_table.iloc[row_idx][\"measured_flux\"],\n",
+    "        marker=\".\",\n",
+    "        linestyle=\":\",\n",
+    "        label=f\"t={row_0_spectra_table.iloc[row_idx]['mjd']:.2f}\",\n",
+    "    )\n",
+    "plt.xlabel(\"Wavelength (Angstrom)\")\n",
+    "plt.ylabel(\"Flux\")\n",
+    "plt.title(\"Spectral Energy Distribution of SN at Different Times\")\n",
+    "_ = plt.legend()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Caveats\n",
+    "\n",
+    "The spectrograph code is still in development and does not simulate noise yet. "
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "lightcurvelynx",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/docs/notebooks/spectrograph_demo.ipynb
+++ b/docs/notebooks/spectrograph_demo.ipynb
@@ -178,7 +178,7 @@
     "        label=f\"t={row_0_spectra_table.iloc[row_idx]['mjd']:.2f}\",\n",
     "    )\n",
     "plt.xlabel(\"Wavelength (Angstrom)\")\n",
-    "plt.ylabel(\"Flux\")\n",
+    "plt.ylabel(\"Flux (nJy)\")\n",
     "plt.title(\"Spectral Energy Distribution of SN at Different Times\")\n",
     "_ = plt.legend()"
    ]

--- a/src/lightcurvelynx/obstable/spectrograph_table.py
+++ b/src/lightcurvelynx/obstable/spectrograph_table.py
@@ -1,0 +1,64 @@
+"""A class for storing and working with simple spectrograph observation tables"""
+
+from __future__ import annotations  # "type1 | type2" syntax in Python <3.10
+
+import numpy as np
+import pandas as pd
+
+from lightcurvelynx.obstable.obs_table import ObsTable
+
+
+class SpectrographObsTable(ObsTable):
+    """An ObsTable for simple spectrograph observations.
+
+    Parameters
+    ----------
+    table : dict or pandas.core.frame.DataFrame
+        The table with all the spectrograph observation information.
+    colmap : dict
+        A mapping of standard column names to a list of possible names in the input table.
+        Each value in the dictionary can be a string or a list of strings.
+        Defaults to the Rubin CCDVisit column names, stored in _default_colnames.
+    **kwargs : dict
+        Additional keyword arguments to pass to the constructor.
+    """
+
+    _required_names = ["ra", "dec", "time"]
+
+    # By default we do not need any column mapping.
+    _default_colnames = {}
+
+    # By default there are no survey values.
+    _default_survey_values = {
+        "radius": 10.0 / 3600.0,  # degrees, corresponds to a 10 arcsec radius
+    }
+
+    # Class constants for the column names.
+    def __init__(
+        self,
+        table,
+        colmap=None,
+        **kwargs,
+    ):
+        # If the input table is a dictionary, convert it to a DataFrame.
+        if isinstance(table, dict):  # pragma: no cover
+            table = pd.DataFrame(table)
+        colmap = self._default_colnames if colmap is None else colmap
+
+        # Fill in a dummy filter value if none is given. This will not be used, but
+        # is required for the ObsTable constructor.
+        if "filter" not in table.columns and (
+            "filter" not in colmap or colmap["filter"] not in table.columns
+        ):
+            table["filter"] = "spectra"  # Name does not actually matter.
+
+        super().__init__(table, colmap=colmap, **kwargs)
+
+    def _assign_zero_points(self):
+        """Assign instrumental zero points in nJy (which produces 1 e-) to the LSSTObsTable tables."""
+        if "zp" in self._table.columns:
+            return  # Nothing to do
+
+        # Add a fake zero point column if we have no information to compute it. This column is not
+        # used for spectrographs.
+        self.add_column("zp", 0.05 * np.ones(len(self._table)), overwrite=True)

--- a/src/lightcurvelynx/simulate.py
+++ b/src/lightcurvelynx/simulate.py
@@ -263,6 +263,9 @@ def _simulate_lightcurves_batch(simulation_info):
     """Generate a number of simulations of the given model and information
     from one or more surveys.
 
+    This is a very large function, but the vast majority of the code is just tracking
+    the results in three different dictionaries to assemble the final NestedFrame.
+
     Parameters
     ----------
     simulation_info : SimulationInfo

--- a/src/lightcurvelynx/simulate.py
+++ b/src/lightcurvelynx/simulate.py
@@ -31,7 +31,7 @@ class SimulationInfo:
         The number of samples.
     obstable : ObsTable or List of ObsTable
         The ObsTable(s) from which to extract information for the samples.
-    integrators : PassbandGroup, Spectrograph or List of (PassbandGroup, Spectrograph)
+    passbands : PassbandGroup, Spectrograph or List of (PassbandGroup, Spectrograph)
         The information for transforming a models SED into a bandflux (PassbandGroup) or
         spectra (Spectrograph).
     obs_time_window_offset : tuple(float, float), optional
@@ -74,7 +74,7 @@ class SimulationInfo:
         model,
         num_samples,
         obstable,
-        integrators,
+        passbands,
         *,
         obstable_save_cols=None,
         param_cols=None,
@@ -89,7 +89,7 @@ class SimulationInfo:
         self.model = model
         self.num_samples = num_samples
         self.obstable = obstable
-        self.integrators = integrators
+        self.passbands = passbands
         self.obs_time_window_offset = obs_time_window_offset
         self.rest_time_window_offset = rest_time_window_offset
         self.obstable_save_cols = obstable_save_cols
@@ -174,7 +174,7 @@ class SimulationInfo:
                 model=self.model,
                 num_samples=batch_num_samples,
                 obstable=self.obstable,
-                integrators=self.integrators,
+                passbands=self.passbands,
                 obstable_save_cols=self.obstable_save_cols,
                 param_cols=self.param_cols,
                 obs_time_window_offset=self.obs_time_window_offset,
@@ -286,7 +286,7 @@ def _simulate_lightcurves_batch(simulation_info):
     model = simulation_info.model
     num_samples = simulation_info.num_samples
     obstable = simulation_info.obstable
-    integrators = simulation_info.integrators
+    passbands = simulation_info.passbands
     obstable_save_cols = simulation_info.obstable_save_cols
     rng = simulation_info.rng
 
@@ -304,11 +304,11 @@ def _simulate_lightcurves_batch(simulation_info):
     # If we are given information for a single survey, make it into a list.
     if not isinstance(obstable, list):
         obstable = [obstable]
-    if not isinstance(integrators, list):
-        integrators = [integrators]
+    if not isinstance(passbands, list):
+        passbands = [passbands]
     num_surveys = len(obstable)
-    if num_surveys != len(integrators):
-        raise ValueError("Number of surveys must match number of integrators.")
+    if num_surveys != len(passbands):
+        raise ValueError("Number of surveys must match number of passbands.")
 
     # We do not currently support bandflux models with multiple surveys because
     # a bandflux model is defined relative to a single survey.
@@ -407,11 +407,11 @@ def _simulate_lightcurves_batch(simulation_info):
             nobs = len(obs_times)
 
             # Split on whether we are evaluating bandfluxes or spectra.
-            if isinstance(integrators[survey_idx], Spectrograph):
+            if isinstance(passbands[survey_idx], Spectrograph):
                 # This is a spectrograph, so we compute the spectra for the spectra column.
-                sg_waves = integrators[survey_idx].waves
+                sg_waves = passbands[survey_idx].waves
                 sed = model.evaluate_sed(obs_times, sg_waves, state, rng_info=rng)
-                measured_flux = integrators[survey_idx].evaluate(sed)
+                measured_flux = passbands[survey_idx].evaluate(sed)
 
                 # TODO: Simulate spectrograph noise.
 
@@ -420,7 +420,7 @@ def _simulate_lightcurves_batch(simulation_info):
                     spectra_dict["mjd"].append(obs_time)
                     spectra_dict["waves"].append(sg_waves)
                     spectra_dict["measured_flux"].append(measured_flux[obs_idx])
-                    spectra_dict["instrument"].append(integrators[survey_idx].instrument)
+                    spectra_dict["instrument"].append(passbands[survey_idx].instrument)
 
                 # Add the new entries to the spectra_index.
                 spectra_index.extend([idx] * nobs)
@@ -428,7 +428,7 @@ def _simulate_lightcurves_batch(simulation_info):
                 # This is a PassbandGroup integrator, so we compute the bandfluxes for the lightcurves column.
                 # Compute the bandfluxes and errors over just the given filters.
                 bandfluxes_perfect = model.evaluate_bandfluxes(
-                    integrators[survey_idx],
+                    passbands[survey_idx],
                     obs_times,
                     obs_filters,
                     state,
@@ -470,7 +470,7 @@ def _simulate_lightcurves_batch(simulation_info):
                     obs_filters = np.asarray(obs_filters)
                     full_filter_names = np.empty_like(obs_filters, dtype=object)
                     for filter_name in np.unique(obs_filters):
-                        pb_obj = integrators[survey_idx][filter_name]
+                        pb_obj = passbands[survey_idx][filter_name]
                         full_filter_names[obs_filters == filter_name] = pb_obj.full_name
                     nested_dict["full_filter_name"].extend(list(full_filter_names))
 
@@ -536,7 +536,7 @@ def simulate_lightcurves(
     model,
     num_samples,
     obstable,
-    integrators,
+    passbands,
     *,
     obstable_save_cols=None,
     param_cols=None,
@@ -568,8 +568,8 @@ def simulate_lightcurves(
         The number of samples.
     obstable : ObsTable or List of ObsTable
         The ObsTable(s) from which to extract information for the samples.
-    integrators : PassbandGroup, Spectrograph, or List of (PassbandGroup, Spectrograph)
-        The integrators to use for generating the bandfluxes or spectra.
+    passbands : PassbandGroup, Spectrograph, or List of (PassbandGroup, Spectrograph)
+        The passbands to use for generating the bandfluxes or spectra.
     obs_time_window_offset : tuple(float, float), optional
         A tuple specifying the observer-frame time window offset (start, end) relative
         to t0 in days. This is used to filter the observations to only those within the
@@ -627,7 +627,7 @@ def simulate_lightcurves(
         model=model,
         num_samples=num_samples,
         obstable=obstable,
-        integrators=integrators,
+        passbands=passbands,
         rng=rng,
         obs_time_window_offset=obs_time_window_offset,
         rest_time_window_offset=rest_time_window_offset,

--- a/tests/lightcurvelynx/obstable/test_spectograph_table.py
+++ b/tests/lightcurvelynx/obstable/test_spectograph_table.py
@@ -1,0 +1,26 @@
+import numpy as np
+import pandas as pd
+import pytest
+from lightcurvelynx.obstable.spectrograph_table import SpectrographObsTable
+
+
+def test_create_spectrograph_obstable():
+    """Test initializing SpectrographObsTable."""
+    data = {
+        "ra": [0.0, 10.0, 0.0, 0.0, 10.0, 0.0],
+        "dec": [0.0, -10.0, 0.0, 0.0, -10.0, 0.0],
+        "time": 53370.5 + np.array([-5.0, -2.0, 0.0, 5.0, 7.0, 10.0]),
+    }
+    survey_data_table = pd.DataFrame(data)
+    survey_data = SpectrographObsTable(table=survey_data_table)
+
+    assert np.all(survey_data["ra"] == data["ra"])
+    assert np.all(survey_data["dec"] == data["dec"])
+    assert np.all(survey_data["time"] == data["time"])
+
+    # We fill in fake zp and filter columns. These are not used for anything.
+    assert np.all(survey_data["filter"] == "spectra")
+    assert np.all(survey_data["zp"] == 0.05)
+
+    # We have all the attributes set at their default values.
+    assert survey_data.survey_values["radius"] == pytest.approx(10.0 / 3600.0)

--- a/tests/lightcurvelynx/test_simulate.py
+++ b/tests/lightcurvelynx/test_simulate.py
@@ -7,6 +7,7 @@ import pandas as pd
 import pytest
 from lightcurvelynx.astro_utils.mag_flux import mag2flux
 from lightcurvelynx.astro_utils.passbands import Passband, PassbandGroup
+from lightcurvelynx.astro_utils.spectrograph import Spectrograph
 from lightcurvelynx.graph_state import GraphState
 from lightcurvelynx.math_nodes.basic_math_node import BasicMathNode
 from lightcurvelynx.math_nodes.given_sampler import GivenValueList, TableSampler
@@ -133,7 +134,7 @@ def test_simulation_info():
         model=model,
         num_samples=100,
         obstable=ops_data,
-        passbands=pb_group,
+        integrators=pb_group,
         obs_time_window_offset=(-5.0, 10.0),  # A keyword argument to test
         rng=np.random.default_rng(12345),
     )
@@ -185,7 +186,7 @@ def test_simulation_info():
             model=model,
             num_samples=-10,
             obstable=ops_data,
-            passbands=pb_group,
+            integrators=pb_group,
             obs_time_window_offset=(-5.0, 10.0),  # A keyword argument to test
             rng=np.random.default_rng(12345),
         )
@@ -224,6 +225,9 @@ def test_simulate_lightcurves(test_data_dir):
         param_cols=["source.brightness"],
     )
     assert len(results) == 5
+    assert "lightcurve" in results
+    assert "spectra" not in results
+
     assert np.all(results["nobs"].values >= 1)
     assert np.allclose(results["ra"].values, opsim_db["ra"].values[0:5])
     assert np.allclose(results["dec"].values, opsim_db["dec"].values[0:5])
@@ -718,6 +722,8 @@ def test_simulate_multiple_surveys(test_data_dir):
     )
     assert len(results) == 1
     assert results["nobs"][0] == 4
+    assert "lightcurve" in results
+    assert "spectra" not in results
 
     # Check that the light curve was simulated correctly, including saving the zeropoint information
     # from each ObsTable.
@@ -844,6 +850,82 @@ def test_simulate_multiple_surveys_diff_filters():
         lightcurve["full_filter_name"],
         ["survey1_r", "survey1_r", "survey1_r", "survey2_r", "survey2_r", "survey2_r"],
     )
+
+
+def test_simulate_multiple_surveys_spectra(test_data_dir):
+    """Test an end to end run of simulating a single light curve from multiple surveys
+    where one of the instruments is a spectrograph."""
+    # The first survey points at two locations in the sky in the "g" and "r" bands.
+    obsdata1 = {
+        "time": [0.0, 1.0, 2.0, 3.0],
+        "ra": [0.0, 0.0, 180.0, 180.0],
+        "dec": [10.0, 10.0, -10.0, -10.0],
+        "filter": ["g", "r", "g", "r"],
+        "zp": [0.4, 0.5, 0.6, 0.7],
+        "seeing": [1.12, 1.12, 1.12, 1.12],
+        "skybrightness": [20.0, 20.0, 20.0, 20.0],
+        "exptime": [29.2, 29.2, 29.2, 29.2],
+        "nexposure": [2, 2, 2, 2],
+        "custom_col": [1, 1, 1, 1],
+    }
+    obstable1 = OpSim(obsdata1)
+    passband_group1 = PassbandGroup.from_preset(
+        preset="LSST",
+        table_dir=test_data_dir / "passbands",
+        filters=["g", "r"],
+    )
+
+    # The second survey points at two locations on the sky and uses a spectrograph.
+    obsdata2 = {
+        "time": [0.5, 1.5, 2.5, 3.5],
+        "ra": [0.0, 90.0, 0.0, 90.0],
+        "dec": [10.0, -10.0, 10.0, -10.0],
+        "filter": ["spectra", "spectra", "spectra", "spectra"],
+        "zp": [0.05, 0.1, 0.2, 0.3],
+        "seeing": [1.12, 1.12, 1.12, 1.12],
+        "skybrightness": [20.0, 20.0, 20.0, 20.0],
+        "exptime": [29.2, 29.2, 29.2, 29.2],
+        "nexposure": [2, 2, 2, 2],
+    }
+    obstable2 = OpSim(obsdata2)
+    spectrograph = Spectrograph.from_regular_grid(2000.0, 10000.0, 100.0, instrument="survey2")
+
+    # Create a constant SED model with known brightnesses and RA, dec values that
+    # match the (0.0, 10.0) pointing.
+    model = ConstantSEDModel(brightness=100.0, t0=0.0, ra=0.0, dec=10.0, redshift=0.0, node_label="source")
+    results = simulate_lightcurves(
+        model,
+        1,
+        [obstable1, obstable2],
+        [passband_group1, spectrograph],
+    )
+    assert len(results) == 1
+    assert results["nobs"][0] == 4
+    assert "lightcurve" in results
+    assert "spectra" in results
+
+    # Check that the light curve was simulated correctly, including saving the zeropoint information
+    # from each ObsTable.
+    lightcurve = results["lightcurve"][0]
+    assert np.allclose(lightcurve["mjd"], np.array([0.0, 1.0]))
+    assert np.array_equal(lightcurve["filter"], np.array(["g", "r"]))
+    assert np.array_equal(lightcurve["survey_idx"], np.array([0, 0]))
+
+    # Check that the spectra were simulated correctly. Waves and measured fluxes should have
+    # an array per-nested entry.
+    spectra = results.iloc[0]["spectra"]
+    assert np.allclose(spectra["mjd"], np.array([0.5, 2.5]))
+    assert np.shape(spectra.iloc[0]["waves"]) == (80,)
+    assert np.shape(spectra.iloc[1]["waves"]) == (80,)
+    assert np.shape(spectra.iloc[0]["measured_flux"]) == (80,)
+    assert np.shape(spectra.iloc[1]["measured_flux"]) == (80,)
+    assert np.array_equal(spectra["instrument"], ["survey2", "survey2"])
+
+    # Check that we can save the full results to a file.
+    with tempfile.TemporaryDirectory() as tmpdir:
+        base_path = Path(tmpdir) / "test_spectra_results.parquet"
+        results.to_parquet(base_path)
+        assert base_path.exists()
 
 
 def test_compute_noise_free_lightcurves_single(test_data_dir):

--- a/tests/lightcurvelynx/test_simulate.py
+++ b/tests/lightcurvelynx/test_simulate.py
@@ -134,7 +134,7 @@ def test_simulation_info():
         model=model,
         num_samples=100,
         obstable=ops_data,
-        integrators=pb_group,
+        passbands=pb_group,
         obs_time_window_offset=(-5.0, 10.0),  # A keyword argument to test
         rng=np.random.default_rng(12345),
     )
@@ -186,7 +186,7 @@ def test_simulation_info():
             model=model,
             num_samples=-10,
             obstable=ops_data,
-            integrators=pb_group,
+            passbands=pb_group,
             obs_time_window_offset=(-5.0, 10.0),  # A keyword argument to test
             rng=np.random.default_rng(12345),
         )


### PR DESCRIPTION
Another step to #710 

Adds (noise free) spectra simulation into the program flow. Provides a new spectrographic `ObsTable` type and incorporates the functionality into multiple demo notebooks.