### PR TITLE
Add ability to squash pooch output

### DIFF
--- a/src/lightcurvelynx/utils/data_download.py
+++ b/src/lightcurvelynx/utils/data_download.py
@@ -10,7 +10,12 @@ from lightcurvelynx.utils.io_utils import SquashLogging
 logger = logging.getLogger(__name__)
 
 
-def download_data_file_if_needed(data_path, data_url, force_download=False):
+def download_data_file_if_needed(
+    data_path,
+    data_url,
+    force_download=False,
+    silent=False,
+):
     """Download a data file from a URL and save it to a specified path.
 
     Parameters
@@ -21,6 +26,8 @@ def download_data_file_if_needed(data_path, data_url, force_download=False):
         The URL to download the data file.
     force_download : bool, optional
         If True, the file will be downloaded even if it already exists. Default is False.
+    silent : bool, optional
+        If True, suppress print statements from the download process. Default is False.
 
     Returns
     -------
@@ -36,7 +43,8 @@ def download_data_file_if_needed(data_path, data_url, force_download=False):
     # Check that there is a valid URL for the download.
     if data_url is None or len(data_url) == 0:
         raise ValueError("No URL given for table download.")
-    logger.info(f"Downloading data file from {data_url} to {data_path}")
+    if not silent:
+        print(f"Downloading data file from {data_url} to {data_path}")
 
     # Create the directory in which to save the file if it does not already exist.
     data_path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/lightcurvelynx/utils/data_download.py
+++ b/src/lightcurvelynx/utils/data_download.py
@@ -5,6 +5,8 @@ from pathlib import Path
 
 import pooch
 
+from lightcurvelynx.utils.io_utils import SquashLogging
+
 logger = logging.getLogger(__name__)
 
 
@@ -40,14 +42,17 @@ def download_data_file_if_needed(data_path, data_url, force_download=False):
     data_path.parent.mkdir(parents=True, exist_ok=True)
 
     # Use pooch to download the data files and extract them to the data directory.
-    full_path = pooch.retrieve(
-        url=data_url,
-        known_hash=None,
-        fname=data_path.name,
-        path=data_path.parent,
-    )
+    # We use SquashLogging to suppress the INFO output from pooch, which is not
+    # often useful to the user.
+    with SquashLogging(logger=pooch.utils.get_logger(), level=logging.WARNING):
+        full_path = pooch.retrieve(
+            url=data_url,
+            known_hash=None,
+            fname=data_path.name,
+            path=data_path.parent,
+        )
 
     if full_path is None or not Path(full_path).exists():
-        logger.error(f"Transmission table not downloaded from {data_url}.")
+        logger.error(f"Data file not downloaded from {data_url}.")
         return False
     return True

--- a/src/lightcurvelynx/utils/io_utils.py
+++ b/src/lightcurvelynx/utils/io_utils.py
@@ -13,37 +13,123 @@ from astropy.table import Table
 class SquashOutput:
     """Context manager to temporarily squash all output to stdout and stderr.
 
+    Optionally, stdout can be redirected to a logger instead of being suppressed.
+
+    Parameters
+    ----------
+    stdout_to_log : bool, optional
+        If True, stdout and stderr will be redirected to the logger instead of
+        being suppressed.
+        Default is False.
+    logger : logging.Logger, optional
+        The logger to which to redirect the output if stdout_to_log is True.
+        If None, the root logger will be used. Default is None.
+    log_level : int, optional
+        The logging level to use when redirecting stdout and stderr to the logger.
+        Default is logging.DEBUG.
+
     Example
     -------
     with SquashOutput():
         # Code that produces unwanted output
         ...
+
+    with SquashOutput(stdout_to_log=True):
+        # Printed output is sent to logger.debug
+        ...
     """
 
-    def __init__(self):
+    class _LoggerWriter:
+        """File-like wrapper that forwards writes to a logger."""
+
+        def __init__(self, logger, level=logging.DEBUG):
+            self._logger = logger
+            self._level = level
+
+        def write(self, message):
+            for line in message.rstrip().splitlines():
+                if line:
+                    self._logger.log(self._level, line)
+            return len(message)
+
+        def flush(self):
+            return None
+
+    def __init__(self, stdout_to_log=False, logger=None, log_level=logging.DEBUG):
+        self._stdout_to_log = stdout_to_log
+        self._log_level = log_level
+        self._logger = logger if logger is not None else logging.getLogger()
         self._original_stdout = None
         self._original_stderr = None
         self._null_file = None
+        self._stdout_logger = None
 
     def __enter__(self):
-        if self._null_file is None:
-            self._null_file = open(os.devnull, "w")  # noqa: SIM115
-
         # Save the original stdout and stderr streams.
         self._original_stdout = sys.stdout
         self._original_stderr = sys.stderr
 
-        # Redirect stdout and stderr to the null file.
-        sys.stdout = self._null_file
-        sys.stderr = self._null_file
+        # Redirect output streams.
+        if self._stdout_to_log:
+            # Create a log writter if needed, and redirect stdout and stderr to it.
+            if self._stdout_logger is None:
+                self._stdout_logger = SquashOutput._LoggerWriter(
+                    self._logger,
+                    level=self._log_level,
+                )
+            sys.stdout = self._stdout_logger
+            sys.stderr = self._stdout_logger
+        else:
+            # Open the null file if we haven't already, and redirect stdout and stderr to it.
+            if self._null_file is None:
+                self._null_file = open(os.devnull, "w")  # noqa: SIM115
+            sys.stdout = self._null_file
+            sys.stderr = self._null_file
 
     def __exit__(self, exc_type, exc_value, traceback):
         # Restore the original stdout and stderr streams.
         sys.stdout = self._original_stdout
         sys.stderr = self._original_stderr
 
-        # Close the null file.
-        self._null_file.close()  # noqa: SIM115
+        # Close the null file (if we opened one).
+        if self._null_file is not None:
+            self._null_file.close()  # noqa: SIM115
+            self._null_file = None
+
+
+class SquashLogging:
+    """A context manager to temporarily squash all logging (below a certain level)
+    to a logger.
+
+    Parameters
+    ----------
+    logger : logging.Logger, optional
+        The logger to which to redirect the logging output. If None, the root
+        logger will be used. Default: None
+    level : int, optional
+        The logging level below which to suppress logging output. Default: logging.ERROR
+
+    Example
+    -------
+    with SquashLogging(level=logging.ERROR):
+        # Code that produces unwanted logging at any level below logging.ERROR
+        ...
+    """
+
+    def __init__(self, logger=None, level=logging.ERROR):
+        self._logger = logger if logger is not None else logging.getLogger()
+        self._old_level = None
+        self._new_level = level
+
+    def __enter__(self):
+        # Save the original logging level and set the new level.
+        self._old_level = self._logger.level
+        self._logger.setLevel(self._new_level)
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        # Restore the original logging level.
+        self._logger.setLevel(self._old_level)
 
 
 def write_results_as_hats(base_catalog_path, results, *, catalog_name=None, overwrite=False):

--- a/src/lightcurvelynx/utils/io_utils.py
+++ b/src/lightcurvelynx/utils/io_utils.py
@@ -103,9 +103,8 @@ class SquashLogging:
 
     Parameters
     ----------
-    logger : logging.Logger, optional
-        The logger to which to redirect the logging output. If None, the root
-        logger will be used. Default: None
+    logger : logging.Logger
+        The logger to which to redirect the logging output.
     level : int, optional
         The logging level below which to suppress logging output. Default: logging.ERROR
 
@@ -116,8 +115,10 @@ class SquashLogging:
         ...
     """
 
-    def __init__(self, logger=None, level=logging.ERROR):
-        self._logger = logger if logger is not None else logging.getLogger()
+    def __init__(self, logger, level=logging.ERROR):
+        if logger is None:
+            raise ValueError("Logger must be provided to SquashLogging.")
+        self._logger = logger
         self._old_level = None
         self._new_level = level
 

--- a/src/lightcurvelynx/utils/io_utils.py
+++ b/src/lightcurvelynx/utils/io_utils.py
@@ -110,7 +110,7 @@ class SquashLogging:
 
     Example
     -------
-    with SquashLogging(level=logging.ERROR):
+    with SquashLogging(logger=logging.getLogger(), level=logging.ERROR):
         # Code that produces unwanted logging at any level below logging.ERROR
         ...
     """

--- a/tests/lightcurvelynx/utils/test_data_download.py
+++ b/tests/lightcurvelynx/utils/test_data_download.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 from lightcurvelynx.utils.data_download import download_data_file_if_needed
 
 
-def test_download_data_file_if_needed(tmp_path):
+def test_download_data_file_if_needed(tmp_path, capsys):
     """Test the functionality of downloading a data file using pooch."""
     data_url = "mock"
 
@@ -26,9 +26,13 @@ def test_download_data_file_if_needed(tmp_path):
             assert f.read() == "Test"
 
         # If we force the download, it should overwrite the existing file.
-        assert download_data_file_if_needed(data_path_1, data_url, force_download=True)
+        assert download_data_file_if_needed(data_path_1, data_url, force_download=True, silent=True)
         with open(data_path_1, "r") as f:
             assert f.read() == "Mock data"
+
+        # With silent=True, we not should see print statements from the download process.
+        captured = capsys.readouterr()
+        assert "Downloading data file from" not in captured.out
 
         # Create a second data file that does not exist.
         data_path_2 = tmp_path / "test_data_2.dat"
@@ -38,3 +42,7 @@ def test_download_data_file_if_needed(tmp_path):
         assert download_data_file_if_needed(data_path_2, data_url, force_download=False)
         with open(data_path_2, "r") as f:
             assert f.read() == "Mock data"
+
+        # With silent=False, we should see print statements from the download process.
+        captured = capsys.readouterr()
+        assert "Downloading data file from" in captured.out

--- a/tests/lightcurvelynx/utils/test_io_utils.py
+++ b/tests/lightcurvelynx/utils/test_io_utils.py
@@ -51,10 +51,12 @@ def test_squash_logging(caplog):
     """Test that SquashLogging suppresses lower-level logs and restores the logger level."""
     logger = logging.getLogger("lightcurvelynx.tests.squash_logging")
     logger.setLevel(logging.INFO)
+    assert logger.level == logging.INFO
 
     with caplog.at_level(logging.DEBUG, logger=logger.name):
         logger.info("before context")
         with SquashLogging(logger=logger, level=logging.ERROR):
+            assert logger.level == logging.ERROR
             logger.info("suppressed info")
             logger.error("kept error")
         logger.info("after context")
@@ -63,6 +65,25 @@ def test_squash_logging(caplog):
     assert "after context" in caplog.text
     assert "kept error" in caplog.text
     assert "suppressed info" not in caplog.text
+    assert logger.level == logging.INFO
+
+    # Check that if we use a different logger, its output is not squashed.
+    other_logger = logging.getLogger("lightcurvelynx.tests.squash_logging_other")
+    other_logger.setLevel(logging.DEBUG)
+    with caplog.at_level(logging.DEBUG, logger=other_logger.name):
+        assert other_logger.level == logging.DEBUG
+
+        with SquashLogging(logger=logger, level=logging.ERROR):
+            assert other_logger.level == logging.DEBUG
+            assert logger.level == logging.ERROR
+            other_logger.info("kept debug")
+            other_logger.info("kept info")
+            other_logger.error("kept error")
+
+    assert "kept debug" in caplog.text
+    assert "kept info" in caplog.text
+    assert "kept error" in caplog.text
+    assert other_logger.level == logging.DEBUG
     assert logger.level == logging.INFO
 
 

--- a/tests/lightcurvelynx/utils/test_io_utils.py
+++ b/tests/lightcurvelynx/utils/test_io_utils.py
@@ -1,7 +1,10 @@
+import logging
+
 import numpy as np
 import pandas as pd
 import pytest
 from lightcurvelynx.utils.io_utils import (
+    SquashLogging,
     SquashOutput,
     read_grid_data,
     read_lclib_data,
@@ -28,6 +31,39 @@ def test_squash_output(capfd):
     print("This is a test.")
     captured = capfd.readouterr()
     assert "This is a test." in captured.out
+
+
+def test_squash_output_stdout_to_log(capfd, caplog):
+    """Test that stdout can be redirected to debug logging."""
+    logger = logging.getLogger("lightcurvelynx.tests.squash")
+
+    with caplog.at_level(logging.DEBUG, logger=logger.name):
+        with SquashOutput(stdout_to_log=True, logger=logger):
+            print("This should go to debug log")
+
+    captured = capfd.readouterr()
+    assert captured.out == ""
+    assert captured.err == ""
+    assert "This should go to debug log" in caplog.text
+
+
+def test_squash_logging(caplog):
+    """Test that SquashLogging suppresses lower-level logs and restores the logger level."""
+    logger = logging.getLogger("lightcurvelynx.tests.squash_logging")
+    logger.setLevel(logging.INFO)
+
+    with caplog.at_level(logging.DEBUG, logger=logger.name):
+        logger.info("before context")
+        with SquashLogging(logger=logger, level=logging.ERROR):
+            logger.info("suppressed info")
+            logger.error("kept error")
+        logger.info("after context")
+
+    assert "before context" in caplog.text
+    assert "after context" in caplog.text
+    assert "kept error" in caplog.text
+    assert "suppressed info" not in caplog.text
+    assert logger.level == logging.INFO
 
 
 def test_read_write_numpy_data(tmp_path):


### PR DESCRIPTION
Closes #750 

This PR adds multiple options for squashing output in order to silence Pooch's warnings about the SHA hash during download.
- `SquashLogging` is a context manager that temporarily changes the logging output level of a given logger. This is what actually squashes the Pooch messages.
- `SquashOutput` is extended to have the ability to redirect the stdout/stderr to logs. I added this when I thought Pooch was using stdout for the messages. Although this is not needed for the Pooch change, it is useful for general output squashing (without dropping the output altogether).
