### PR TITLE
Fix the extrapolation for redback models

### DIFF
--- a/src/lightcurvelynx/models/redback_models.py
+++ b/src/lightcurvelynx/models/redback_models.py
@@ -46,6 +46,16 @@ class RedbackWrapperModel(SEDModel, CiteClass):
         The redback model's Bilby priors.
     parameters : dict, optional
         A dictionary of parameter setters to pass to the source function.
+    minphase : float, optional
+        The minimum supported phase of the model in days relative to t0. This allows users
+        to manually cut off the model at a certain phase (e.g. if the model is not valid
+        outside of that phase) and instead apply extrapolation.
+        The default is None, which means the model does not have a defined minimum phase.
+    maxphase : float, optional
+        The maximum supported phase of the model in days relative to t0. This allows users
+        to manually cut off the model at a certain phase (e.g. if the model is not valid
+        outside of that phase) and instead apply extrapolation.
+        The default is None, which means the model does not have a defined maximum phase.
     **kwargs : dict, optional
         Any additional keyword arguments.
     """
@@ -59,6 +69,8 @@ class RedbackWrapperModel(SEDModel, CiteClass):
         *,
         priors=None,
         parameters=None,
+        minphase=None,
+        maxphase=None,
         **kwargs,
     ):
         # Check that the parameters passed in the dictionary and keyword arguments
@@ -118,10 +130,13 @@ class RedbackWrapperModel(SEDModel, CiteClass):
         if hasattr(self.source, "citation"):
             cite_inline("redback model", self.source.citation)
 
+        # Set the phase range.
+        self.set_phase_range(minphase, maxphase)
+
         # Redback models already handle redshift, so we do not want to double apply it.
         self.apply_redshift = False
 
-        # We save a cahced version of the last computed SED.
+        # We save a cached version of the last computed SED.
         self._last_sed = None
 
     @property
@@ -170,6 +185,59 @@ class RedbackWrapperModel(SEDModel, CiteClass):
         if self._last_sed is not None:
             return self._last_sed.maxwave()
         return None
+
+    def minphase(self, **kwargs):
+        """Get the minimum supported phase of the model in days.
+
+        Parameters
+        ----------
+        **kwargs : dict
+            Additional keyword arguments, not used in this method.
+
+        Returns
+        -------
+        minphase : float or None
+            The minimum phase of the model (in days) or None
+            if the model does not have a defined minimum phase.
+        """
+        return self._minphase
+
+    def maxphase(self, **kwargs):
+        """Get the maximum supported phase of the model in days.
+
+        Parameters
+        ----------
+        **kwargs : dict
+            Additional keyword arguments, not used in this method.
+
+        Returns
+        -------
+        maximum : float or None
+            The maximum phase of the model (in days) or None
+            if the model does not have a defined maximum phase.
+        """
+        return self._maxphase
+
+    def set_phase_range(self, minphase, maxphase):
+        """Set the minimum and maximum supported phase of the model in days.
+
+        We allow the user to manually set the minimum and maximum phase of the model, because
+        redback models might have a limited valid phase range, but we cannot automatically
+        extract that from the redback function.
+
+        Parameters
+        ----------
+        minphase : float or None
+            The minimum phase of the model (in days) or None
+            if the model does not have a defined minimum phase.
+        maxphase : float or None
+            The maximum phase of the model (in days) or None
+            if the model does not have a defined maximum phase.
+        """
+        if minphase is not None and maxphase is not None and minphase > maxphase:
+            raise ValueError("Minimum phase cannot be greater than maximum phase.")
+        self._minphase = minphase
+        self._maxphase = maxphase
 
     def compute_sed(self, times, wavelengths, graph_state=None, **kwargs):
         """Draw effect-free observations for this object.

--- a/src/lightcurvelynx/models/redback_models.py
+++ b/src/lightcurvelynx/models/redback_models.py
@@ -46,16 +46,6 @@ class RedbackWrapperModel(SEDModel, CiteClass):
         The redback model's Bilby priors.
     parameters : dict, optional
         A dictionary of parameter setters to pass to the source function.
-    minphase : float, optional
-        The minimum supported phase of the model in days relative to t0. This allows users
-        to manually cut off the model at a certain phase (e.g. if the model is not valid
-        outside of that phase) and instead apply extrapolation.
-        The default is None, which means the model does not have a defined minimum phase.
-    maxphase : float, optional
-        The maximum supported phase of the model in days relative to t0. This allows users
-        to manually cut off the model at a certain phase (e.g. if the model is not valid
-        outside of that phase) and instead apply extrapolation.
-        The default is None, which means the model does not have a defined maximum phase.
     **kwargs : dict, optional
         Any additional keyword arguments.
     """
@@ -69,8 +59,6 @@ class RedbackWrapperModel(SEDModel, CiteClass):
         *,
         priors=None,
         parameters=None,
-        minphase=None,
-        maxphase=None,
         **kwargs,
     ):
         # Check that the parameters passed in the dictionary and keyword arguments
@@ -130,14 +118,12 @@ class RedbackWrapperModel(SEDModel, CiteClass):
         if hasattr(self.source, "citation"):
             cite_inline("redback model", self.source.citation)
 
-        # Set the phase range.
-        self.set_phase_range(minphase, maxphase)
-
         # Redback models already handle redshift, so we do not want to double apply it.
         self.apply_redshift = False
 
-        # We save a cached version of the last computed SED.
-        self._last_sed = None
+        # We save a cached version of the last computed SED. This starts as None
+        # since we have not computed any SEDs yet.
+        self._cached_data = {}
 
     @property
     def param_names(self):
@@ -159,11 +145,7 @@ class RedbackWrapperModel(SEDModel, CiteClass):
             The minimum wavelength of the model (in angstroms) or None
             if the model does not have a defined minimum wavelength.
         """
-        # The minwave of the redback model depends on the result of the
-        # last computed SED.
-        if self._last_sed is not None:
-            return self._last_sed.minwave()
-        return None
+        return self._cached_data.get("minwave", None)
 
     def maxwave(self, graph_state=None):
         """Get the maximum wavelength of the model.
@@ -180,11 +162,7 @@ class RedbackWrapperModel(SEDModel, CiteClass):
             The maximum wavelength of the model (in angstroms) or None
             if the model does not have a defined maximum wavelength.
         """
-        # The maxwave of the redback model depends on the result of the
-        # last computed SED.
-        if self._last_sed is not None:
-            return self._last_sed.maxwave()
-        return None
+        return self._cached_data.get("maxwave", None)
 
     def minphase(self, **kwargs):
         """Get the minimum supported phase of the model in days.
@@ -200,7 +178,7 @@ class RedbackWrapperModel(SEDModel, CiteClass):
             The minimum phase of the model (in days) or None
             if the model does not have a defined minimum phase.
         """
-        return self._minphase
+        return self._cached_data.get("minphase", None)
 
     def maxphase(self, **kwargs):
         """Get the maximum supported phase of the model in days.
@@ -216,28 +194,96 @@ class RedbackWrapperModel(SEDModel, CiteClass):
             The maximum phase of the model (in days) or None
             if the model does not have a defined maximum phase.
         """
-        return self._maxphase
+        return self._cached_data.get("maxphase", None)
 
-    def set_phase_range(self, minphase, maxphase):
-        """Set the minimum and maximum supported phase of the model in days.
+    def _do_bounds_precomputation(self, times, wavelengths, graph_state=None, **kwargs):
+        """Precompute the SED model for the given times and wavelengths.
 
-        We allow the user to manually set the minimum and maximum phase of the model, because
-        redback models might have a limited valid phase range, but we cannot automatically
-        extract that from the redback function.
+        This is needed for redback models because bounds [minwave, maxwave] and
+        [minphase, maxphase] depend on the last computed SED.
 
         Parameters
         ----------
-        minphase : float or None
-            The minimum phase of the model (in days) or None
-            if the model does not have a defined minimum phase.
-        maxphase : float or None
-            The maximum phase of the model (in days) or None
-            if the model does not have a defined maximum phase.
+        times : numpy.ndarray
+            A length T array of rest frame timestamps (MJD).
+        wavelengths : numpy.ndarray, optional
+            A length N array of wavelengths (in angstroms).
+        graph_state : GraphState
+            An object mapping graph parameters to their values.
+        **kwargs : dict, optional
+           Any additional keyword arguments.
         """
-        if minphase is not None and maxphase is not None and minphase > maxphase:
-            raise ValueError("Minimum phase cannot be greater than maximum phase.")
-        self._minphase = minphase
-        self._maxphase = maxphase
+        # Check that the cached data is empty.
+        if len(self._cached_data) != 0:  # pragma: no cover
+            raise RuntimeError(
+                "Cached data should be empty before precomputation. This indicates a bug "
+                " in the code where the cached data is not being cleared after use."
+            )
+
+        # Build the function arguments from the parameter values.
+        params = self.get_local_params(graph_state)
+        fn_args = {}
+        for name in self.source_param_names:
+            fn_args[name] = params[name]
+
+        # Compute the shifted times.
+        t0 = params.get("t0", 0.0)
+        if t0 is None:
+            t0 = 0.0
+        shifted_times = times - t0
+
+        # Call the source function to get the RedbackTimeSeriesSource object.
+        # We create this object with each call, because it depends on the parameters (fn_args).
+        rb_result = self.source(
+            shifted_times,
+            output_format="sncosmo_source",
+            **fn_args,
+        )
+
+        # Save the computed RedbackTimeSeriesSource and the bounds.
+        self._cached_data["minwave"] = rb_result.minwave()
+        self._cached_data["maxwave"] = rb_result.maxwave()
+        self._cached_data["minphase"] = rb_result.minphase()
+        self._cached_data["maxphase"] = rb_result.maxphase()
+        self._cached_data["last_sed"] = rb_result
+
+    def compute_sed_with_extrapolation(self, times, wavelengths, graph_state, **kwargs):
+        """Draw effect-free observations for this object, extrapolating
+        to times and wavelengths where the model is not defined.
+
+        We override this method because the extrapolation bounds will depend on the materialized
+        RedbackTimeSeriesSource object, so we need to do the precomputation to get that object.
+        We will cache the object so we don't perform the computation twice.
+
+        Parameters
+        ----------
+        times : numpy.ndarray
+            A length T array of rest frame timestamps.
+        wavelengths : numpy.ndarray, optional
+            A length N array of wavelengths (in angstroms).
+        graph_state : GraphState
+            An object mapping graph parameters to their values.
+        **kwargs : dict, optional
+           Any additional keyword arguments.
+
+        Returns
+        -------
+        flux_density : numpy.ndarray
+            A length T x N matrix of SED values (in nJy).
+        """
+        # Do any precomputation that is needed to set the bounds. This generates
+        # cached data that will be used in the compute_sed method to avoid redundant
+        # computation.
+        self._do_bounds_precomputation(times, wavelengths, graph_state, **kwargs)
+
+        # Call the superclass method to do the extrapolation. This will call compute_sed,
+        # which will use the cached data to avoid redundant computation.
+        sed = super().compute_sed_with_extrapolation(times, wavelengths, graph_state, **kwargs)
+
+        # Clear the cached data values.
+        self._cached_data.clear()
+
+        return sed
 
     def compute_sed(self, times, wavelengths, graph_state=None, **kwargs):
         """Draw effect-free observations for this object.
@@ -258,29 +304,27 @@ class RedbackWrapperModel(SEDModel, CiteClass):
         flux_density : numpy.ndarray
             A length T x N matrix of SED values (in nJy).
         """
+        if self._cached_data.get("last_sed") is None:
+            # If we have not computed the result object for the current parameters, do so now.
+            self._do_bounds_precomputation(times, wavelengths, graph_state, **kwargs)
+            created_cache = True
+        else:
+            created_cache = False
+
+        # Load the RedbackTimeSeriesSource we need for this computation.
+        rb_result = self._cached_data["last_sed"]
+
+        # Compute the shifted times. Note these might be different from the times used in
+        # precomputation because of the applied phase bounds.
+        # times used for precomputation.
         params = self.get_local_params(graph_state)
-
-        # Build the function arguments from the parameter values.
-        fn_args = {}
-        for name in self.source_param_names:
-            fn_args[name] = params[name]
-
-        # Compute the shifted times.
         t0 = params.get("t0", 0.0)
         if t0 is None:
             t0 = 0.0
         shifted_times = times - t0
 
-        # Call the source function to get the RedbackTimeSeriesSource object.
-        # We create this object with each call, because it depends on the parameters (fn_args).
-        rb_result = self.source(
-            shifted_times,
-            output_format="sncosmo_source",
-            **fn_args,
-        )
-        self._last_sed = rb_result
-
-        # Query the model and convert the output to nJy.
+        # Query the RedbackTimeSeriesSource at the given times and wavelengths.
+        # Then convert the output to nJy.
         model_flam = rb_result.get_flux_density(shifted_times, wavelengths)
         model_fnu = flam_to_fnu(
             model_flam,
@@ -290,7 +334,8 @@ class RedbackWrapperModel(SEDModel, CiteClass):
             fnu_unit=uu.nJy,
         )
 
-        # Clear the cached SED value since we have now evaluated it.
-        self._last_sed = None
+        # Clear the cached data values if we created them locally.
+        if created_cache:
+            self._cached_data.clear()
 
         return model_fnu

--- a/src/lightcurvelynx/utils/plotting.py
+++ b/src/lightcurvelynx/utils/plotting.py
@@ -1,6 +1,5 @@
 """A collection of functions for plotting and visualization."""
 
-
 import astropy.units as u
 import matplotlib.pyplot as plt
 import numpy as np

--- a/tests/lightcurvelynx/models/test_redback_models.py
+++ b/tests/lightcurvelynx/models/test_redback_models.py
@@ -5,6 +5,8 @@ import pytest
 from citation_compass import find_in_citations
 from lightcurvelynx.math_nodes.given_sampler import GivenValueList
 from lightcurvelynx.models.redback_models import RedbackWrapperModel
+from lightcurvelynx.utils.extrapolate import ConstantPadding
+from sncosmo.models import TimeSeriesSource
 
 
 class ToySNModel:
@@ -32,6 +34,14 @@ class ToySNModel:
     def maxwave(self):
         """Get the maximum wavelength of the model."""
         return np.inf
+
+    def minphase(self):
+        """Get the minimum phase of the model."""
+        return None
+
+    def maxphase(self):
+        """Get the maximum phase of the model."""
+        return None
 
     def get_flux_density(self, times, wavelengths):
         """A toy flux function that depends on time and wave.
@@ -168,17 +178,37 @@ def test_redback_models_chained_toy() -> None:
 
 def _toy_redback_function(times, param1=None, param2=None, output_format=None, **kwargs):
     """A no-op function that mimics the signature of a redback model function."""
-    return None
+    assert output_format == "sncosmo_source"
+
+    # The model is only defined on times -5.0 to 10.0 and wavelengths 4000 to 8000 A.
+    eval_phase = np.arange(-5.0, 10.0, 1.0)
+    eval_waves = np.arange(4000.0, 8000.0, 1000.0)
+    source = TimeSeriesSource(
+        eval_phase,
+        eval_waves,
+        np.zeros((len(eval_phase), len(eval_waves))),  # flux is not important
+    )
+
+    # Attach a get_flux_density method to mimic the RedbackTimeSeriesSource.
+    def _get_flux_density(times, wavelengths):
+        return np.zeros((len(times), len(wavelengths)))
+
+    source.get_flux_density = _get_flux_density
+
+    return source
 
 
-def test_redback_model_from_function() -> None:
-    """Test that we can create a RedbackWrapperModel from a function."""
+def test_redback_model_extrapolation() -> None:
+    """Test that we can create a RedbackWrapperModel from a function
+    and extrapolate for points outside the wavelength or phase bounds."""
     t0 = 64350.0
     model = RedbackWrapperModel(
         _toy_redback_function,
         parameters={"param1": 1.0, "param2": 2.0},
         t0=t0,
         node_label="source",
+        wave_extrapolation=(ConstantPadding(1.0), ConstantPadding(2.0)),
+        time_extrapolation=(ConstantPadding(3.0), ConstantPadding(4.0)),
     )
     assert model.source_name == "_toy_redback_function"
     assert set(model.source_param_names) == {"param1", "param2"}
@@ -191,29 +221,20 @@ def test_redback_model_from_function() -> None:
     assert state["source"]["param1"] == 1.0
     assert state["source"]["param2"] == 2.0
 
+    times = np.array([-10.0, 1.0, 2.0, 20.0]) + t0
+    waves_ang = np.array([3000.0, 5000.0, 6000.0, 7000.0, 9000.0])
+    fluxes = model.evaluate_sed(times, waves_ang, state)
+    assert fluxes.shape == (4, 5)
 
-def test_redback_models_min_max_phase() -> None:
-    """Test that we can set and get the minimum and maximum phase of the model."""
-    t0 = 64350.0
-    minphase = -5.0
-    maxphase = 20.0
+    # Time is extrapolated after wavelength, so we start with everything in bounds
+    # and move outward through the layers of extrapolation.
+    assert np.all(fluxes[1:3, 1:4] == 0.0)  # in bounds
+    assert np.all(fluxes[1:3, 0] == 1.0)  # wavelength extrapolation on the left
+    assert np.all(fluxes[1:3, 4] == 2.0)  # wavelength extrapolation on the right
+    assert np.all(fluxes[0, :] == 3.0)  # time extrapolation on the left
+    assert np.all(fluxes[3, :] == 4.0)  # time extrapolation on the right
 
-    model = RedbackWrapperModel(
-        _toy_redback_function,
-        parameters={"param1": 5.0, "param2": 6.0},
-        t0=t0,
-        minphase=minphase,
-        maxphase=maxphase,
-        node_label="source",
-    )
-    assert model.source_name == "_toy_redback_function"
-    assert set(model.source_param_names) == {"param1", "param2"}
-    assert model.minwave() is None
-    assert model.maxwave() is None
-    assert model.minphase() == minphase
-    assert model.maxphase() == maxphase
-
-    # We can override the phase range using the set_phase_range method.
-    model.set_phase_range(-10.0, 30.0)
-    assert model.minphase() == -10.0
-    assert model.maxphase() == 30.0
+    # If we call compute_sed directly the caching logic still works and the code will
+    # bypass the extrapolation logic and just query the spline directly (all zeros).
+    direct_fluxes = model.compute_sed(times, waves_ang, state)
+    assert np.all(direct_fluxes == 0.0)

--- a/tests/lightcurvelynx/models/test_redback_models.py
+++ b/tests/lightcurvelynx/models/test_redback_models.py
@@ -164,3 +164,56 @@ def test_redback_models_chained_toy() -> None:
     # The returned fluxes should all be different since height is changing.
     assert fluxes.shape == (3, 1, 1)
     assert len(np.unique(fluxes)) == 3
+
+
+def _toy_redback_function(times, param1=None, param2=None, output_format=None, **kwargs):
+    """A no-op function that mimics the signature of a redback model function."""
+    return None
+
+
+def test_redback_model_from_function() -> None:
+    """Test that we can create a RedbackWrapperModel from a function."""
+    t0 = 64350.0
+    model = RedbackWrapperModel(
+        _toy_redback_function,
+        parameters={"param1": 1.0, "param2": 2.0},
+        t0=t0,
+        node_label="source",
+    )
+    assert model.source_name == "_toy_redback_function"
+    assert set(model.source_param_names) == {"param1", "param2"}
+    assert model.minwave() is None
+    assert model.maxwave() is None
+    assert model.minphase() is None
+    assert model.maxphase() is None
+
+    state = model.sample_parameters(num_samples=1)
+    assert state["source"]["param1"] == 1.0
+    assert state["source"]["param2"] == 2.0
+
+
+def test_redback_models_min_max_phase() -> None:
+    """Test that we can set and get the minimum and maximum phase of the model."""
+    t0 = 64350.0
+    minphase = -5.0
+    maxphase = 20.0
+
+    model = RedbackWrapperModel(
+        _toy_redback_function,
+        parameters={"param1": 5.0, "param2": 6.0},
+        t0=t0,
+        minphase=minphase,
+        maxphase=maxphase,
+        node_label="source",
+    )
+    assert model.source_name == "_toy_redback_function"
+    assert set(model.source_param_names) == {"param1", "param2"}
+    assert model.minwave() is None
+    assert model.maxwave() is None
+    assert model.minphase() == minphase
+    assert model.maxphase() == maxphase
+
+    # We can override the phase range using the set_phase_range method.
+    model.set_phase_range(-10.0, 30.0)
+    assert model.minphase() == -10.0
+    assert model.maxphase() == 30.0


### PR DESCRIPTION
As an intermediate step, the `RedbackWrapperModel` computes and queries a `RedbackTimeSeriesSource`, which uses a 2d spline to represent the model. This spline is only valid within the range of times and wavelengths on which it was created. Extrapolation outside this range can lead to non-physical results.

This PR precomputes the `RedbackTimeSeriesSource` and uses its bounds for LightCurveLynx's extrapolation. The user can then provide custom extrapolation functions like any other model. If they don't and query points are outside the range, they will get a warning (already handled by the superclass).