### PR TITLE
Fix test warning

### DIFF
--- a/tests/lightcurvelynx/astro_utils/test_passbands.py
+++ b/tests/lightcurvelynx/astro_utils/test_passbands.py
@@ -670,3 +670,4 @@ def test_passband_plot(tmp_path):
 
     # Test that we can plot the (unnormalized) transmission table.
     _ = a_band.plot(plot_transmission=True)
+    matplotlib.pyplot.close("all")

--- a/tests/lightcurvelynx/math_nodes/test_ra_dec_sampler.py
+++ b/tests/lightcurvelynx/math_nodes/test_ra_dec_sampler.py
@@ -358,6 +358,7 @@ def test_approximate_moc_sampler_plot():
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
         moc_sampler.plot_footprint(depth=12)
+        matplotlib.pyplot.close("all")
 
 
 def test_approximate_moc_sampler_from_file():

--- a/tests/lightcurvelynx/models/test_lightcurve_template_model.py
+++ b/tests/lightcurvelynx/models/test_lightcurve_template_model.py
@@ -689,6 +689,9 @@ def test_lightcurve_plot() -> None:
     lc_model.plot_lightcurves()
     lc_model.plot_sed_basis()
 
+    # Close all the open figures.
+    matplotlib.pyplot.close("all")
+
 
 def test_create_multilightcurve_template_model() -> None:
     """Test that we can create a simple MultiLightcurveTemplateModel object."""

--- a/tests/lightcurvelynx/obstable/test_opsim.py
+++ b/tests/lightcurvelynx/obstable/test_opsim.py
@@ -2,6 +2,7 @@ import tempfile
 import warnings
 from pathlib import Path
 
+import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import pytest
@@ -583,6 +584,7 @@ def test_opsim_plot_footprint(opsim_shorten):
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
         opsim.plot_footprint(depth=12)
+        plt.close("all")
 
 
 def test_create_random_opsim():

--- a/tests/lightcurvelynx/utils/test_plotting.py
+++ b/tests/lightcurvelynx/utils/test_plotting.py
@@ -57,7 +57,9 @@ def test_plot_lightcurves():
     # - figure (matplotlib figure object)
     fig, ax = plt.subplots()
     plot_lightcurves(fluxes, times, fluxerrs=fluxerrs, filters=filters, ax=ax, figure=fig, title=title)
-    plt.close(fig)
+
+    # Close all the open figures.
+    plt.close("all")
 
 
 def test_plot_bandflux_lightcurves():
@@ -75,7 +77,9 @@ def test_plot_bandflux_lightcurves():
     fig, ax = plt.subplots()
     title = "Test Title"
     plot_bandflux_lightcurves(bandfluxes, times=times, ax=ax, figure=fig, title=title)
-    plt.close(fig)
+
+    # Close all the open figures.
+    plt.close("all")
 
 
 def test_plot_flux_spectrogram():
@@ -93,4 +97,6 @@ def test_plot_flux_spectrogram():
     fig, ax = plt.subplots()
     title = "Test Title"
     plot_flux_spectrogram(fluxes, times=times, ax=ax, figure=fig, title=title)
-    plt.close(fig)
+
+    # Close all the open figures.
+    plt.close("all")


### PR DESCRIPTION
We were getting test warnings because matplotlib was opening too many plots without closing them. This PR adds logic to close the plots after each test.