### PR TITLE
Fix a bug between pzflow and parallel processing

### DIFF
--- a/src/lightcurvelynx/astro_utils/pzflow_node.py
+++ b/src/lightcurvelynx/astro_utils/pzflow_node.py
@@ -106,11 +106,9 @@ class PZFlowNode(FunctionNode, CiteClass):
 
             samples = self.flow.sample(nsamples=1, conditions=input_df, seed=seed)
         else:
-            # Check that we have a positive number of samples.
-            if graph_state.num_samples < 1:
-                raise ValueError(f"num_samples must be a positive integer. Got {graph_state.num_samples}.")
-
-            samples = self.flow.sample(nsamples=graph_state.num_samples, seed=seed)
+            # Because pzflow does isinstance type checking, we need to make sure the
+            # number of samples is a python int (not np.int64, np.int32, etc.).
+            samples = self.flow.sample(int(graph_state.num_samples), seed=seed)
 
         # Parse out each output column in the flow samples as its own result vector.
         results = []

--- a/src/lightcurvelynx/astro_utils/pzflow_node.py
+++ b/src/lightcurvelynx/astro_utils/pzflow_node.py
@@ -108,7 +108,7 @@ class PZFlowNode(FunctionNode, CiteClass):
         else:
             # Because pzflow does isinstance type checking, we need to make sure the
             # number of samples is a python int (not np.int64, np.int32, etc.).
-            samples = self.flow.sample(int(graph_state.num_samples), seed=seed)
+            samples = self.flow.sample(nsamples=int(graph_state.num_samples), seed=seed)
 
         # Parse out each output column in the flow samples as its own result vector.
         results = []

--- a/src/lightcurvelynx/astro_utils/pzflow_node.py
+++ b/src/lightcurvelynx/astro_utils/pzflow_node.py
@@ -104,9 +104,13 @@ class PZFlowNode(FunctionNode, CiteClass):
                 input_params[col] = all_params[col]
             input_df = pd.DataFrame(input_params)
 
-            samples = self.flow.sample(1, conditions=input_df, seed=seed)
+            samples = self.flow.sample(nsamples=1, conditions=input_df, seed=seed)
         else:
-            samples = self.flow.sample(graph_state.num_samples, seed=seed)
+            # Check that we have a positive number of samples.
+            if graph_state.num_samples < 1:
+                raise ValueError(f"num_samples must be a positive integer. Got {graph_state.num_samples}.")
+
+            samples = self.flow.sample(nsamples=graph_state.num_samples, seed=seed)
 
         # Parse out each output column in the flow samples as its own result vector.
         results = []

--- a/src/lightcurvelynx/base_models.py
+++ b/src/lightcurvelynx/base_models.py
@@ -727,6 +727,10 @@ class ParameterizedNode:
         ValueError
             If the sampling encounters a problem with the order of dependencies.
         """
+        # Check that the number of samples is valid.
+        if num_samples < 1:
+            raise ValueError(f"num_samples must be a positive integer. Got {num_samples}.")
+
         # If the graph structure has never been set, do that now.
         if self.node_pos is None:
             nodes = set()

--- a/src/lightcurvelynx/utils/plotting.py
+++ b/src/lightcurvelynx/utils/plotting.py
@@ -1,6 +1,5 @@
 """A collection of functions for plotting and visualization."""
 
-
 import astropy.units as u
 import matplotlib.pyplot as plt
 import numpy as np

--- a/tests/lightcurvelynx/astro_utils/test_pzflow_node.py
+++ b/tests/lightcurvelynx/astro_utils/test_pzflow_node.py
@@ -76,7 +76,7 @@ def test_pzflow_node_chained():
     # Make sure that we only call the pzflow's sample() once during sampling of the node
     # (so all the outputs are consistent with each other). In other words, we do
     # not call compute once for each output variable.
-    def _mock_sample(self, nsamples=1, conditions=None, save_conditions=True, seed=None):
+    def _mock_sample(self=None, nsamples=1, conditions=None, save_conditions=True, seed=None):
         return pd.DataFrame({"a": [1], "b": [2]})
 
     with patch("pzflow.flow.Flow.sample", side_effect=_mock_sample) as mocked_sample:

--- a/tests/lightcurvelynx/astro_utils/test_pzflow_node.py
+++ b/tests/lightcurvelynx/astro_utils/test_pzflow_node.py
@@ -1,3 +1,6 @@
+import pickle
+import tempfile
+from pathlib import Path
 from unittest.mock import patch
 
 import numpy as np
@@ -131,3 +134,27 @@ def test_pzflow_node_citation(test_flow_filename):
     citations = find_in_citations("PZFlowNode")
     for citation in citations:
         assert "Crenshaw et. al. 2024" in citation
+
+
+def test_pzflow_node_pickle():
+    """Test that we can pickle and unpickle a PZFlowNode."""
+    flow = Flow(("x", "y"), Reverse())
+    pz_node = PZFlowNode(flow, node_label="pznode")
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        file_path = Path(tmpdir) / "test_pzflow_node.pkl"
+        assert not file_path.exists()
+
+        with open(file_path, "wb") as f:
+            pickle.dump(pz_node, f)
+        assert file_path.exists()
+
+        with open(file_path, "rb") as f:
+            loaded_pz_node = pickle.load(f)
+        assert loaded_pz_node is not None
+
+        # Sample a parameters.
+        state = loaded_pz_node.sample_parameters(num_samples=10)
+        assert len(state["pznode"]) == 2
+        assert len(state["pznode"]["x"]) == 10
+        assert len(state["pznode"]["y"]) == 10

--- a/tests/lightcurvelynx/test_base_models.py
+++ b/tests/lightcurvelynx/test_base_models.py
@@ -213,6 +213,10 @@ def test_parameterized_node(capsys):
     with pytest.raises(ValueError):
         _ = model1.get_local_params(None)
 
+    # We fail if we try to sample with an invalid num_samples.
+    with pytest.raises(ValueError):
+        _ = model1.sample_parameters(num_samples=0)
+
 
 def test_parameterized_node_label_collision():
     """Test that throw an error when two nodes use the same label."""


### PR DESCRIPTION
The main fix is that pzflow expects a `int` for the number of samples and distributed processing gives an `np.int64`.

This also adds some tests that I tried along the way and change `nsamples` to keyword instead of positional.
