### PR TITLE
Closes 765

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug_report.md
+++ b/.github/ISSUE_TEMPLATE/1-bug_report.md
@@ -23,6 +23,6 @@ FILL IN YOUR STACK TRACE HERE
 Please check the following:
 
 - [ ] I have described the situation in which the bug arose, including what code was executed, and any applicable data others will need to reproduce the problem.
-- [ ] I have included information about my environment, including the version of this package (e.g. `lightcurvelynx.__version__`)
+- [ ] I have included information about my environment, including the version of this package.
 - [ ] I have included available evidence of the unexpected behavior (including error messages, screenshots, and/or plots) as well as a description of what I expected instead.
 - [ ] If I have a solution in mind, I have provided an explanation and/or pseudocode and/or task list.


### PR DESCRIPTION
Closes #765 

Remove the example of `lightcurvelynx.__version__` from the text.
