### PR TITLE
Issue769

### DIFF
--- a/docs/notebooks/passband-demo.ipynb
+++ b/docs/notebooks/passband-demo.ipynb
@@ -105,6 +105,23 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Or you can download ALL the filters for a facility and instrument by just providing that information to `PassbandGroup.from_svo()`. Under the hood, this function uses `astroquery.svo_fps.SvoFps.get_filter_list()` which takes a facility and instrument. So the string should be \"{FACILITY}/{INSTRUMENT}\"."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pbg = PassbandGroup.from_svo(\"Palomar/ZTF\")\n",
+    "pbg.plot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Manually specified passbands\n",
     "\n",
     "For testing, we might want to manually specify the passband information. We can do this by creating a 2-dimensional numpy array where the first column is wavelength and the second column is transmission values. The wavelength column can take data in either angstroms or nanometers. Angstroms are assumed by default, but can be overridden using the units parameter (`units=\"nm\"`). The values in the transmission column are relative and there is no need for the user to normalize them."

--- a/docs/notebooks/passband-demo.ipynb
+++ b/docs/notebooks/passband-demo.ipynb
@@ -86,7 +86,7 @@
     "\n",
     "_Note_: Throughout this notebook, we use the hardcoded test directory path to retrieve pre-downloaded files so the notebook does not have external dependencies. In most cases, users will want to use the default table directory (data/passbands) and let LightCurveLynx handle the downloads and caching.\n",
     "\n",
-    "A special case of the file download is retrieving passbands from the [SVO filter profile service](https://svo2.cab.inta-csic.es/theory/fps/).  LightCurveLynx includes a built in function `Passband.from_svo()` that takes the SVO identifier, constructs the appropriate URL, and downloads the file if does not already exist.\n",
+    "A special case of the file download is retrieving passbands from the [SVO filter profile service](https://svo2.cab.inta-csic.es/theory/fps/).  LightCurveLynx includes a built in function `Passband.from_svo()` that takes the SVO identifier and uses [astroquery](https://astroquery.readthedocs.io/en/latest/svo_fps/svo_fps.html) to download the data.\n",
     "\n",
     "Let's look at the 'g' filter from the ZTF survey."
    ]
@@ -97,11 +97,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ztf_g = Passband.from_svo(\n",
-    "    \"Palomar/ZTF.g\",  # SVO identifier of the form \"{observatory}/{camera}.{filter}\"\n",
-    "    table_dir=table_dir,  # The directory for caching the passband files\n",
-    "    force_download=False,  # Do not force a download if the file already exists\n",
-    ")\n",
+    "ztf_g = Passband.from_svo(\"Palomar/ZTF.g\")\n",
     "ztf_g.plot()"
    ]
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dynamic = ["version"]
 requires-python = ">=3.11"
 dependencies = [
     "astropy",
+    "astroquery",
     "cdshealpix",
     "citation-compass>=0.0.3",
     "matplotlib",

--- a/src/lightcurvelynx/astro_utils/passbands.py
+++ b/src/lightcurvelynx/astro_utils/passbands.py
@@ -12,6 +12,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import scipy.integrate
+from astropy import units as u
 from astropy.io.votable import parse
 from astroquery.svo_fps import SvoFps
 from citation_compass import cite_function
@@ -992,6 +993,10 @@ class Passband:
 
         # Use astroquery to download the filter.
         data = SvoFps.get_transmission_data(full_filter_name)
+
+        # If the wavelength is given in anything other than Angstroms, convert it to Angstroms.
+        if data["Wavelength"].unit is not None and data["Wavelength"].unit != u.AA:
+            data["Wavelength"] = data["Wavelength"].to(u.AA)
 
         # The data is returned as a table with columns "Wavelength" and "Transmission", each
         # of which can be masked. We convert this to a 2D numpy array, dropping the masked values.

--- a/src/lightcurvelynx/astro_utils/passbands.py
+++ b/src/lightcurvelynx/astro_utils/passbands.py
@@ -13,6 +13,7 @@ import numpy as np
 import pandas as pd
 import scipy.integrate
 from astropy.io.votable import parse
+from astroquery.svo_fps import SvoFps
 from citation_compass import cite_function
 
 from lightcurvelynx import _LIGHTCURVELYNX_BASE_DATA_DIR
@@ -427,12 +428,11 @@ class PassbandGroup:
         *,
         delta_wave: float | None = 5.0,
         trim_quantile: float | None = 1e-3,
-        table_dir: Union[str, Path] | None = None,
-        force_download: bool = False,
         **kwargs,
     ):
         """Create a PassbandGroup object from the SVO Filter Profile Service given a list
-        of full filter names in the form of "{OBSERVATORY}/{CAMERA}.{FILTER}".
+        of full filter names in the form of "{FACILITY}/{INSTRUMENT}.{FILTER}" or a single
+        string of the form "{FACILITY}/{INSTRUMENT}" to download all filters.
 
         References
         ----------
@@ -444,9 +444,11 @@ class PassbandGroup:
 
         Parameters
         ----------
-        all_filters : list[str]
-            A list of full filter names to load from the SVO Filter Profile Service in the
-            form of "{OBSERVATORY}/{CAMERA}.{FILTER}". This can include filters from multiple surveys.
+        all_filters : str or list[str]
+            A string of the form "{FACILITY}/{INSTRUMENT}" to download all filters for a given
+            facility and instrument or a list of full filter names to load from the SVO Filter
+            Profile Service in the FORM "{FACILITY}/{INSTRUMENT}.{FILTER}" to download a subset
+            of filters. If a list is provided, it can include filters from multiple surveys.
         delta_wave : float or None, optional
             The grid step of the wave grid, in angstroms.
             It is typically used to downsample transmission using linear interpolation.
@@ -455,24 +457,36 @@ class PassbandGroup:
             The quantile to trim the transmission table by. For example, if trim_quantile is 1e-3, the
             transmission table will be trimmed to include only the central 99.8% of the area under the
             transmission curve.
-        table_dir : str, optional
-            The path to the base directory in which to store cached passband tables. If the passband
-            exists in this directory, it will be loaded from there; otherwise it will be downloaded
-            and saved in that directory.
-        force_download : bool, optional
-            If True, the transmission table will be downloaded even if it already exists locally. Default is
-            False.
         **kwargs
             Additional keyword arguments to pass to the Passband constructor.
         """
+        if isinstance(all_filters, str):
+            # If we are given a string, we assume it is of the form "{FACILITY}/{INSTRUMENT}"
+            # and we want to download all filters for that facility and instrument.
+            if "/" not in all_filters:
+                raise ValueError(
+                    f"Expected a string of the form '{{FACILITY}}/{{INSTRUMENT}}' to download "
+                    f"all those filters, but got {all_filters}"
+                )
+            if "." in all_filters:
+                raise ValueError(
+                    f"Expected a string of the form '{{FACILITY}}/{{INSTRUMENT}}' to download "
+                    f"all those filters, but got {all_filters}. If you want to specify a single filter, "
+                    f"please provide a list of one filter."
+                )
+
+            # Do the actual downloading.
+            facility, instrument = all_filters.split("/")
+            all_filter_data = SvoFps.get_filter_list(facility=facility, instrument=instrument)
+            all_filters = all_filter_data["filterID"].tolist()
+
+        # Download and pre-process each passband.
         passband_list = []
         for full_filter_name in all_filters:
             pb = Passband.from_svo(
                 full_filter_name,
                 delta_wave=delta_wave,
                 trim_quantile=trim_quantile,
-                table_dir=table_dir,
-                force_download=force_download,
                 **kwargs,
             )
             passband_list.append(pb)
@@ -941,8 +955,6 @@ class Passband:
         *,
         delta_wave: float | None = 5.0,
         trim_quantile: float | None = 1e-3,
-        table_dir: Union[str, Path] | None = None,
-        force_download: bool = False,
         **kwargs,
     ):
         """Create a Passband object from the SVO Filter Profile Service.
@@ -959,7 +971,7 @@ class Passband:
         ----------
         full_filter_name : str
             The full name of the survey and filter in the SVO database in the form of
-            "{OBSERVATORY}/{CAMERA}.{FILTER}", e.g., "SLOAN/SDSS.u".
+            "{FACILITY}/{INSTRUMENT}.{FILTER}", e.g., "SLOAN/SDSS.u".
         delta_wave : float or None, optional
             The grid step of the wave grid, in angstroms.
             It is typically used to downsample transmission using linear interpolation.
@@ -968,10 +980,6 @@ class Passband:
             The quantile to trim the transmission table by. For example, if trim_quantile is 1e-3, the
             transmission table will be trimmed to include only the central 99.8% of the area under the
             transmission curve.
-        table_dir : str, optional
-            The path to the base directory in which to store cached passband tables. If the passband
-            exists in this directory, it will be loaded from there; otherwise it will be downloaded
-            and saved in that directory.
         force_download : bool, optional
             If True, the transmission table will be downloaded even if it already exists locally. Default is
             False.
@@ -982,21 +990,22 @@ class Passband:
         # path and URL to the SVO database.
         survey, filter = full_filter_name.split(".")
 
-        if table_dir is None:
-            table_dir = Path(_LIGHTCURVELYNX_BASE_DATA_DIR, "passbands", survey)
-        else:
-            table_dir = Path(table_dir) / survey
-        table_path = Path(table_dir, f"{filter}.xml")
-        table_url = f"https://svo2.cab.inta-csic.es/svo/theory/fps3/fps.php?ID={full_filter_name}"
+        # Use astroquery to download the filter.
+        data = SvoFps.get_transmission_data(full_filter_name)
 
-        return cls.from_file(
+        # The data is returned as a table with columns "Wavelength" and "Transmission", each
+        # of which can be masked. We convert this to a 2D numpy array, dropping the masked values.
+        waves = data["Wavelength"].filled(np.nan).data
+        trans = data["Transmission"].filled(np.nan).data
+        valid = ~np.isnan(waves) & ~np.isnan(trans)
+        table_data = np.vstack([waves[valid], trans[valid]]).T
+
+        return cls(
+            table_data,
             survey=survey,
             filter_name=filter,
             delta_wave=delta_wave,
             trim_quantile=trim_quantile,
-            table_path=table_path,
-            table_url=table_url,
-            force_download=force_download,
             **kwargs,
         )
 

--- a/tests/lightcurvelynx/astro_utils/test_passband_groups.py
+++ b/tests/lightcurvelynx/astro_utils/test_passband_groups.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 
 import numpy as np
 import pytest
+from astropy import units as u
 from astropy.table import Table
 from lightcurvelynx.astro_utils.passbands import Passband, PassbandGroup
 from lightcurvelynx.models.sed_template_model import SEDTemplateModel
@@ -465,7 +466,7 @@ def test_passband_group_from_svo():
         """Return a predefined AstroPyTable object instead of downloading the transmission table."""
         table = Table(
             {
-                "Wavelength": [6000.0, 6005.0, 6010.0],
+                "Wavelength": [6000.0, 6005.0, 6010.0] * u.AA,
                 "Transmission": [0.5, 0.6, 0.7],
             },
             masked=True,

--- a/tests/lightcurvelynx/astro_utils/test_passband_groups.py
+++ b/tests/lightcurvelynx/astro_utils/test_passband_groups.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 
 import numpy as np
 import pytest
+from astropy.table import Table
 from lightcurvelynx.astro_utils.passbands import Passband, PassbandGroup
 from lightcurvelynx.models.sed_template_model import SEDTemplateModel
 from sncosmo import Bandpass
@@ -458,19 +459,21 @@ def test_passband_ztf_preset():
 def test_passband_group_from_svo():
     """Test that we can load a PassbandGroup from the SVO database."""
 
-    # Mock the Passband.from_svo method to return a predefined Passband object.
-    # This function is already tested in test_passband.py.
+    # Mock the astroquery.svo_fps.SvoFps.get_transmission_data method to return
+    # an AstroPy Table instead of downloading it.
     def _mock_from_svo(full_filter_name, *args, **kwargs):
-        """Return a predefined Passband object instead of downloading the transmission table."""
-        survey, filter = full_filter_name.split(".")
-        return Passband(
-            np.array([[6000, 0.5], [6005, 0.6], [6010, 0.7]]),
-            survey=survey,
-            filter_name=filter,
+        """Return a predefined AstroPyTable object instead of downloading the transmission table."""
+        table = Table(
+            {
+                "Wavelength": [6000.0, 6005.0, 6010.0],
+                "Transmission": [0.5, 0.6, 0.7],
+            },
+            masked=True,
         )
+        return table
 
     # Mock the get_bandpass portion of the download method
-    with patch("lightcurvelynx.astro_utils.passbands.Passband.from_svo", side_effect=_mock_from_svo):
+    with patch("astroquery.svo_fps.SvoFps.get_transmission_data", side_effect=_mock_from_svo):
         group = PassbandGroup.from_svo(
             ["SLOAN/SDSS.u", "SLOAN/SDSS.g", "SLOAN/SDSS.r", "SLOAN/SDSS.i", "SLOAN/SDSS.z"]
         )
@@ -480,6 +483,37 @@ def test_passband_group_from_svo():
         assert "SLOAN/SDSS_r" in group
         assert "SLOAN/SDSS_i" in group
         assert "SLOAN/SDSS_z" in group
+
+    # Add a second mocking function to load the list of filters.
+    def _mock_filters(facility, instrument):
+        """Return a predefined list of filters for the SVO database."""
+        filters = ["u", "g", "r", "i"]
+        filterid = [f"{facility}/{instrument}.{filter}" for filter in filters]
+        table = Table(
+            {
+                "filterID": filterid,
+                "some_data_column": [1, 2, 3, 4],
+                "other_data_column": [5, 6, 7, 8],
+            },
+            masked=True,
+        )
+        return table
+
+    with patch("astroquery.svo_fps.SvoFps.get_transmission_data", side_effect=_mock_from_svo):
+        with patch("astroquery.svo_fps.SvoFps.get_filter_list", side_effect=_mock_filters):
+            group = PassbandGroup.from_svo("MYOBS/MYINT")
+            assert len(group) == 4
+            assert "MYOBS/MYINT_u" in group
+            assert "MYOBS/MYINT_g" in group
+            assert "MYOBS/MYINT_r" in group
+            assert "MYOBS/MYINT_i" in group
+
+    with pytest.raises(ValueError):
+        # Not in the form of "FACILITY/INSTRUMENT"
+        _ = PassbandGroup.from_svo("BAD_STRING")
+    with pytest.raises(ValueError):
+        # Can't pass a string with just one filter name.
+        _ = PassbandGroup.from_svo("SLOAN/SDSS.u")
 
 
 def test_passband_invalid_preset():

--- a/tests/lightcurvelynx/astro_utils/test_passbands.py
+++ b/tests/lightcurvelynx/astro_utils/test_passbands.py
@@ -9,6 +9,7 @@ from unittest.mock import patch
 import numpy as np
 import pytest
 import scipy.integrate
+from astropy.table import Table
 from lightcurvelynx.astro_utils.passbands import Passband
 from lightcurvelynx.models.sed_template_model import SEDTemplateModel
 from sncosmo import Bandpass
@@ -324,15 +325,32 @@ def test_passband_from_sncosmo(passbands_dir):
         _ = Passband.from_sncosmo("ZTF", "g", None)
 
 
-def test_passband_from_svo(passbands_dir):
+def test_passband_from_svo():
     """Test that we can load data from SVO passbands."""
-    pb = Passband.from_svo("Palomar/ZTF.g", table_dir=passbands_dir, force_download=False)
+
+    # Mock the astroquery.svo_fps.SvoFps.get_transmission_data method to return
+    # an AstroPy Table instead of downloading it.
+    def _mock_from_svo(full_filter_name, *args, **kwargs):
+        """Return a predefined AstroPyTable object instead of downloading the transmission table."""
+        table = Table(
+            {
+                "Wavelength": [6000.0, 6005.0, 6010.0],
+                "Transmission": [0.5, 0.6, 0.7],
+            },
+            masked=True,
+        )
+        return table
+
+    # Mock the get_bandpass portion of the download method
+    with patch("astroquery.svo_fps.SvoFps.get_transmission_data", side_effect=_mock_from_svo):
+        pb = Passband.from_svo("Palomar/ZTF.g")
+
     assert pb.survey == "Palomar/ZTF"
     assert pb.filter_name == "g"
     assert pb.full_name == "Palomar/ZTF_g"
 
 
-def test_process_transmission_table(passbands_dir, tmp_path):
+def test_process_transmission_table(tmp_path, passbands_dir):
     """Test the process_transmission_table method of the Passband class; check correct methods are called."""
     transmission_table = "100 0.5\n200 0.75\n300 0.25\n"
     a_band = create_toy_passband(tmp_path, transmission_table)

--- a/tests/lightcurvelynx/astro_utils/test_passbands.py
+++ b/tests/lightcurvelynx/astro_utils/test_passbands.py
@@ -9,6 +9,7 @@ from unittest.mock import patch
 import numpy as np
 import pytest
 import scipy.integrate
+from astropy import units as u
 from astropy.table import Table
 from lightcurvelynx.astro_utils.passbands import Passband
 from lightcurvelynx.models.sed_template_model import SEDTemplateModel
@@ -334,7 +335,7 @@ def test_passband_from_svo():
         """Return a predefined AstroPyTable object instead of downloading the transmission table."""
         table = Table(
             {
-                "Wavelength": [6000.0, 6005.0, 6010.0],
+                "Wavelength": [6000.0, 6005.0, 6010.0] * u.AA,
                 "Transmission": [0.5, 0.6, 0.7],
             },
             masked=True,


### PR DESCRIPTION
Closes #769 

Replace the internal downloader for SVO with astroquery. This allows us to also add an option to download all filters for the combination of facility and instrument. The PR also changes the terminology (e.g. observatory->facility) to be consistent with astroquery.