### PR TITLE
Add a page to the documentation about different survey types

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -31,7 +31,8 @@ The main simulation components in LightCurveLynx include:
 * A model that defines the properties of the time-domain light source, which can
   also include a host-galaxy model, and is used to generate the noise-free light curves.
 * ``ObsTable`` contains the survey information such as survey strategy and observing
-  conditions. It is used to specify the observing times and bands.
+  conditions. It is used to specify the observing times and bands. For more information
+  see the :doc:`survey data documentation page <survey_data>`.
 * A set of predefined effects, such as dust extinction and detector noise, are applied to
   the noise-free light curves to produce realistic light curves.
 * The ``PassbandGroup`` contains the filter information of the telescope and is used
@@ -167,6 +168,7 @@ This project is supported by Schmidt Sciences.
 
    Home page <self>
    Simulations <simulations>
+   Survey Data <survey_data>
    Custom Models and Effects <custom_models>
    Results and Output <results_and_output>
    Notebooks <notebooks>

--- a/docs/notebooks/opsim_notebook.ipynb
+++ b/docs/notebooks/opsim_notebook.ipynb
@@ -8,7 +8,7 @@
     "\n",
     "A critical aspect to producing realistic simulations of time varying phenomena is correctly modeling the cadence at which the objects will be observed and capturing the relevant physical details about the observation. LightCurveLynx provides an `OpSim` module that can load a Rubin opsim file and use that to filter observations based on location, associate observations with their filter, apply detector noise, etc. `OpSim` objects are subclasses of the more general `ObsTable` data structures and a lot of the same concepts apply to `ObsTable`s for different surveys.\n",
     "\n",
-    "This notebook provides an introduction to using opsim data in the simulations. For an example of how to load a CCD Visit table from actual runs, such as DP1, see the [corresponding notebook](https://lightcurvelynx.readthedocs.io/en/latest/notebooks/pre_executed/rubin_ccdvisit.html)."
+    "**NOTE:** This notebook provides an introduction to using opsim data in the simulations. Actual observations from LSSTCam are provided in a different format and should be loaded using the `LSSTObsTable` class. For an example of how to load a CCD Visit table from actual runs, such as DP1, see the [corresponding notebook](https://lightcurvelynx.readthedocs.io/en/latest/notebooks/pre_executed/rubin_ccdvisit.html)."
    ]
   },
   {
@@ -17,7 +17,7 @@
    "source": [
     "## OpSim Class\n",
     "\n",
-    "The `OpSim` object provides a wrapper for loading and querying survey-specific information including pointings and survey information. The required information is:\n",
+    "The `OpSim` object provides a wrapper for loading and querying simulated Rubin survey data, including pointings and survey information. The required information is:\n",
     "  * the pointing data (RA, dec, and times for each pointing), and\n",
     "  * the zero point information for each pointing (a zero point column or the information needed to derive it)\n",
     "\n",

--- a/docs/notebooks/pre_executed/rubin_ccdvisit.ipynb
+++ b/docs/notebooks/pre_executed/rubin_ccdvisit.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Working with Rubin CCDVisit Table Data\n",
     "\n",
-    "In this notebook we look at how we can import data from the Rubin CCDVisit table such as [DP1](https://dp1.lsst.io/products/index.html), the [Science Validation DB](https://survey-strategy.lsst.io/progress/sv_status/sv_20250930.html) or [DP2 CCDVisits Table](https://sdm-schemas.lsst.io/lsstcam.html#CcdVisit).\n",
+    "In this notebook we look at how we can import data from the Rubin CCDVisit table such as [DP1](https://dp1.lsst.io/products/index.html), the [Science Validation DB](https://survey-strategy.lsst.io/progress/sv_status/sv_20250930.html) or [DP2 CCDVisits Table](https://sdm-schemas.lsst.io/lsstcam.html#CcdVisit). The observed LSST data uses the `LSSTObsTable` class instead of the `OpSim` class (which should only be used for simulated data).\n",
     "\n",
     "Note that the lsst packages are not installed as part of the default LightCurveLynx installation. Users will need to manually install them via in order to run this notebook (e.g. `pip install lsst-rsp`)"
    ]

--- a/docs/simulations.rst
+++ b/docs/simulations.rst
@@ -22,7 +22,8 @@ step includes the following components:
   also include a host-galaxy model, and is used to generate the noise-free light curves (given
   the sampled parameters).
 * ``ObsTable`` contains the survey information such as survey strategy and observing
-  conditions. It is used to specify the observing times and bands.
+  conditions. It is used to specify the observing times and bands. For more information
+  see the :doc:`survey data documentation page <survey_data>`.
 * A set of predefined effects, such as dust extinction and detector noise, are applied to
   the noise-free light curves to produce realistic light curves.
 * The ``PassbandGroup`` contains the filter information of the telescope and is used

--- a/docs/survey_data.rst
+++ b/docs/survey_data.rst
@@ -1,7 +1,7 @@
 Survey Data
 ========================================================================================
 
-In order to generate a simulation, the simulator needs information on whether the telescope is pointing and the noise characteristics at the time. As you can imagine, the available data and its format varies significantly from survey to survey (and even between data releases of the same survey). `LightCurveLynx` uses a an object-based model to encapsulate the survey information and provide a common interface.
+In order to generate a simulation, the simulator needs information on whether the telescope is pointing and the noise characteristics at the time. As you can imagine, the available data and its format varies significantly from survey to survey (and even between data releases of the same survey). `LightCurveLynx` uses an object-based model to encapsulate the survey information and provide a common interface.
 
 
 ObsTable
@@ -34,33 +34,29 @@ The ``LSSTObsTable`` class stores actual pointing and noise information from the
 
 The survey-specific constants are set to [published values](https://lsstcam.lsst.io/index.html).
 
+See the (:doc:`Rubin CCDVisit Notebook <notebooks/pre_executed/rubin_ccdvisit>`) for an example of how to load Rubin data using the ``LSSTObsTable`` class.
+
 
 OpSim Data (OpSim)
 -------------------------------------------------------------------------------
 
 The ``OpSim`` class stores pointing and noise information from the Rubin Observatory's simulated survey data (OpSim).  The survey-specific constants are set to [the values defined in the simulator](https://smtn-002.lsst.io/v/OPSIM-1171/index.html).
 
+See the (:doc:`Rubin OpSim Notebook <notebooks/opsim_notebook>`) for an example of how to load simulated Rubin data using the ``OpSim`` class. This notebook also provides an overview of the functionality of the ``ObsTable`` class.
+
 
 Roman Simulated Data (RomanObsTable)
 -------------------------------------------------------------------------------
-The ``RomanObsTable`` class stores pointing and noise information from the Roman Space Telescope's simulated survey data. The survey-specific constants are set to the values defined in the [Roman documentation](https://roman-docs.stsci.edu/) and the [Roman Github repository](https://github.com/RomanSpaceTelescope). 
+The ``RomanObsTable`` class stores pointing and noise information from the [Nancy Grace Roman Space Telescope](https://roman.gsfc.nasa.gov)'s simulated survey data. The survey-specific constants are set to the values defined in the [Roman documentation](https://roman-docs.stsci.edu/) and the [Roman Github repository](https://github.com/RomanSpaceTelescope). 
 
-Special preprocessing is needed to handle the spectra information. Please contact the LightCurveLynx team if you need help with this.
+Special preprocessing is needed to handle the spectra observations (spectra simulation within LightCurveLynx is in early testing). Please contact the LightCurveLynx team if you need help with this.
 
 
 ZTF Data (ZTFObsTable)
 -------------------------------------------------------------------------------
-The ``ZTFObsTable`` class stores pointing and noise information from the Zwicky Transient Facility (ZTF) visit information.
+The ``ZTFObsTable`` class stores pointing and noise information from the [Zwicky Transient Facility (ZTF)](https://www.ztf.caltech.edu/) visit information.
 
 
 Argus Data (ArgusObsTable)
 -------------------------------------------------------------------------------
-The ``ArgusObsTable`` class stores pointing and noise information from the Argus simulations. This class is still being validated and may change. Please contact the LightCurveLynx team if you want to use this class or have suggestions for improvement.
-
-
-
-
-
-
-
-
+The ``ArgusObsTable`` class stores pointing and noise information from simulations of the upcoming [Argus Array](https://www.argusarray.org/). This class is still being validated and may change. Please contact the LightCurveLynx team if you want to use this class or have suggestions for improvement.

--- a/docs/survey_data.rst
+++ b/docs/survey_data.rst
@@ -1,0 +1,66 @@
+Survey Data
+========================================================================================
+
+In order to generate a simulation, the simulator needs information on whether the telescope is pointing and the noise characteristics at the time. As you can imagine, the available data and its format varies significantly from survey to survey (and even between data releases of the same survey). `LightCurveLynx` uses a an object-based model to encapsulate the survey information and provide a common interface.
+
+
+ObsTable
+-------------------------------------------------------------------------------
+
+The ``ObsTable`` parent class is top level interface for storing and manipulating survey data. At a minimum, it requires the pointing information (RA, dec, and time for image). In addition it can store a wide range of per-visit information (e.g. airmass, exposure time, filter, etc.) and or survey-specific constants (e.g. pixel scale and saturation magnitudes).
+
+In addition to a common API, ``ObsTable`` includes common processing that is used across many different types of surveys, including:
+
+    * Column name mapping (for users trying to load data from custom tables),
+    * Filtering rows by index or mask (``filter_rows``),
+    * Addition and querying of pixel-level detector footprints (e.g., ``set_detector_footprint``),
+    * Construction and use of spatial data structures for fast search including built-in cone search (``range_search``)
+    * Application of saturation thresholds,
+    * Plotting the survey's footprint on the sky (``plot_footprint``),
+    * Construction of a [multi-order coverage map (MOC)](https://www.ivoa.net/documents/MOC/) of the survey (``build_moc``), 
+    * Resampling the table (``make_resampled_table``), and
+    * Writing the observation information to disk.
+
+Users do not work with the ``ObsTable`` class directly, but instead use one of the child classes that are designed for specific surveys. We discuss some of these below.
+
+
+LSST Data (LSSTObsTable)
+-------------------------------------------------------------------------------
+
+The ``LSSTObsTable`` class stores actual pointing and noise information from the Rubin Observatory data releases. It includes functions to read from the currently defined data formats, including:
+
+    * [DP1](https://sdm-schemas.lsst.io/dp1.html#CcdVisit) and [DP2+](https://sdm-schemas.lsst.io/lsstcam.html#CcdVisit) as CCDVisit tables, using the ``from_ccdvisit_table`` method, and
+    * [Science Validation](https://survey-strategy.lsst.io/progress/sv_status/sv_20250930.html) as the released DB file, using the ``from_sv_visits_table`` method.
+
+The survey-specific constants are set to [published values](https://lsstcam.lsst.io/index.html).
+
+
+OpSim Data (OpSim)
+-------------------------------------------------------------------------------
+
+The ``OpSim`` class stores pointing and noise information from the Rubin Observatory's simulated survey data (OpSim).  The survey-specific constants are set to [the values defined in the simulator](https://smtn-002.lsst.io/v/OPSIM-1171/index.html).
+
+
+Roman Simulated Data (RomanObsTable)
+-------------------------------------------------------------------------------
+The ``RomanObsTable`` class stores pointing and noise information from the Roman Space Telescope's simulated survey data. The survey-specific constants are set to the values defined in the [Roman documentation](https://roman-docs.stsci.edu/) and the [Roman Github repository](https://github.com/RomanSpaceTelescope). 
+
+Special preprocessing is needed to handle the spectra information. Please contact the LightCurveLynx team if you need help with this.
+
+
+ZTF Data (ZTFObsTable)
+-------------------------------------------------------------------------------
+The ``ZTFObsTable`` class stores pointing and noise information from the Zwicky Transient Facility (ZTF) visit information.
+
+
+Argus Data (ArgusObsTable)
+-------------------------------------------------------------------------------
+The ``ArgusObsTable`` class stores pointing and noise information from the Argus simulations. This class is still being validated and may change. Please contact the LightCurveLynx team if you want to use this class or have suggestions for improvement.
+
+
+
+
+
+
+
+

--- a/src/lightcurvelynx/obstable/opsim.py
+++ b/src/lightcurvelynx/obstable/opsim.py
@@ -1,4 +1,4 @@
-"""A module to store and manipulate OpSim observation tables."""
+"""A module to store and manipulate Rubin's simulated survey data (OpSim)."""
 
 from __future__ import annotations  # "type1 | type2" syntax in Python <3.10
 
@@ -79,7 +79,7 @@ Calculated with syseng_throughputs v1.9
 
 
 class OpSim(ObsTable):
-    """A wrapper class around the opsim table with cached data for efficiency.
+    """A wrapper class around the Rubin's simulated data Opsim.
 
     Parameters
     ----------


### PR DESCRIPTION
Adds an overview page about different survey types and clarifies the documentation on some of the other pages (e.g. explicitly noting that that `OpSim` is just for the simulated data sets).
