### PR TITLE
Fix citation

### DIFF
--- a/src/lightcurvelynx/astro_utils/passbands.py
+++ b/src/lightcurvelynx/astro_utils/passbands.py
@@ -906,7 +906,7 @@ class Passband:
         )
 
     @classmethod
-    @cite_function("https://sncosmo.readthedocs.io/en/stable/api/sncosmo.Bandpass.html")
+    @cite_function
     def from_sncosmo(cls, survey: str, filter_name: str, bandpass=None, **kwargs):
         """Create a Passband object from an sncosmo.Bandpass object.
 


### PR DESCRIPTION
Remove the manual label to support an upcoming change in citation compass and make the annotation consistent with the rest of LightCurveLynx. The string gets parsed from the docstring.