### PR TITLE
Build MOCs from a sample of points

### DIFF
--- a/src/lightcurvelynx/astro_utils/coordinate_utils.py
+++ b/src/lightcurvelynx/astro_utils/coordinate_utils.py
@@ -1,4 +1,8 @@
+import astropy.units as u
 import numpy as np
+from astropy.coordinates import SkyCoord
+from cdshealpix import skycoord_to_healpix
+from mocpy import MOC
 from scipy.spatial import KDTree
 
 
@@ -84,3 +88,30 @@ def dedup_coords(ra, dec, threshold=1e-5):
     unique_ra = ra[unique_indices]
     unique_dec = dec[unique_indices]
     return unique_ra, unique_dec, unique_indices
+
+
+def build_moc_from_coords(ra, dec, depth=8):
+    """
+    Build a MOC at a given depth from RA and Dec coordinates, such that each
+    point is covered by the MOC.
+
+    Parameters
+    ----------
+    ra: numpy.ndarray
+        Array of right ascension values in degrees.
+    dec: numpy.ndarray
+        Array of declination values in degrees.
+    depth: int
+        Maximum depth of the MOC. Higher values give finer resolution but larger MOC size.
+
+    Returns
+    -------
+    moc: MOC
+        MOC object representing the sky coverage of the input coordinates.
+    """
+    if len(ra) != len(dec):
+        raise ValueError("RA and Dec arrays must have the same length.")
+    coords = SkyCoord(ra=ra * u.deg, dec=dec * u.deg, frame="icrs")
+    hpix = skycoord_to_healpix(coords, depth)
+    unique_hpix = np.unique(hpix)
+    return MOC.from_healpix_cells(unique_hpix, depth=depth, max_depth=depth)

--- a/src/lightcurvelynx/math_nodes/ra_dec_sampler.py
+++ b/src/lightcurvelynx/math_nodes/ra_dec_sampler.py
@@ -10,7 +10,7 @@ from cdshealpix.nested import healpix_to_skycoord
 from citation_compass import CiteClass, cite_inline
 from mocpy import MOC
 
-from lightcurvelynx.astro_utils.coordinate_utils import dedup_coords
+from lightcurvelynx.astro_utils.coordinate_utils import build_moc_from_coords, dedup_coords
 from lightcurvelynx.math_nodes.given_sampler import TableSampler
 from lightcurvelynx.math_nodes.np_random import NumpyRandomFunc
 from lightcurvelynx.obstable.obs_table import ObsTable
@@ -614,6 +614,34 @@ class ApproximateMOCSampler(NumpyRandomFunc, CiteClass):
             )
             moc = moc.intersection(next_moc)
 
+        return cls(moc, depth=depth, **kwargs)
+
+    @classmethod
+    def from_ra_dec_lists(cls, ra_list, dec_list, *, depth=6, **kwargs):
+        """Create an ApproximateMOCSampler from lists of RA and dec values. This method is useful
+        when the survey contains many small pointings, such as CCD-level information.
+
+        The depth parameter controls the approximation level. Higher depths provide
+        better accuracy but require more memory and computation time.
+
+        Parameters
+        ----------
+        ra_list : list or np.ndarray
+            The list of RA values in degrees.
+        dec_list : list or np.ndarray
+            The list of dec values in degrees.
+        depth : int, optional
+            The healpix depth to use as an approximation. Must be [2, 29].
+            Default: 12
+        **kwargs : dict, optional
+            Additional keyword arguments to pass to the constructor.
+
+        Returns
+        -------
+        ApproximateMOCSampler
+            The created ApproximateMOCSampler object.
+        """
+        moc = build_moc_from_coords(ra_list, dec_list, depth=depth)
         return cls(moc, depth=depth, **kwargs)
 
     def plot_footprint(

--- a/tests/lightcurvelynx/astro_utils/test_coordinate_utils.py
+++ b/tests/lightcurvelynx/astro_utils/test_coordinate_utils.py
@@ -1,6 +1,11 @@
+import astropy.units as u
 import numpy as np
 import pytest
-from lightcurvelynx.astro_utils.coordinate_utils import dedup_coords, ra_dec_to_cartesian
+from lightcurvelynx.astro_utils.coordinate_utils import (
+    build_moc_from_coords,
+    dedup_coords,
+    ra_dec_to_cartesian,
+)
 
 
 def test_ra_dec_to_cartesian():
@@ -44,3 +49,25 @@ def test_dedup_coords():
     np.testing.assert_array_equal(unique_indices, expected_inds)
     np.testing.assert_allclose(unique_ra, pts[expected_inds, 0], atol=1e-8)
     np.testing.assert_allclose(unique_dec, pts[expected_inds, 1], atol=1e-8)
+
+
+def test_build_moc_from_coords():
+    """Test building a MOC from coordinates."""
+    ra = np.array([0, 90, 180, 270, 45])
+    dec = np.array([0, 0, 0, 0, 30])
+    moc = build_moc_from_coords(ra, dec, depth=8)
+    assert len(moc.flatten()) == 5
+
+    # Test that the MOC covers the input points
+    for r, d in zip(ra, dec, strict=False):
+        assert moc.contains_lonlat(r * u.deg, d * u.deg)
+
+    # Duplicates are naturally dropped when we dedup the healpix ids.
+    ra_dup = np.array([0, 90, 180, 270, 45, 0, 0.0001, 45.0001])
+    dec_dup = np.array([0, 0, 0, 0, 30, 0, 0.0001, 29.9999])
+    moc_dup = build_moc_from_coords(ra_dup, dec_dup, depth=8)
+    assert len(moc_dup.flatten()) == 5
+
+    # We fail if the lists are different lengths.
+    with pytest.raises(ValueError):
+        _ = build_moc_from_coords([0, 90], [0])

--- a/tests/lightcurvelynx/math_nodes/test_ra_dec_sampler.py
+++ b/tests/lightcurvelynx/math_nodes/test_ra_dec_sampler.py
@@ -556,6 +556,31 @@ def test_approximate_moc_sampler_from_intersection_obstable():
         _ = ApproximateMOCSampler.from_obstable_intersection(ops_tables, depth=10, radii=[1.0], seed=45)
 
 
+def test_approximate_moc_sampler_from_list():
+    """Test that we can create and sample from an ApproximateMOCSampler
+    from a list of RA and dec values."""
+    moc_sampler = ApproximateMOCSampler.from_ra_dec_lists(
+        ra_list=[15.0, 90.0, 110.0, 15.000001, 89.999999],
+        dec_list=[-10.0, 0.0, -25.0, -9.999999, 0.000001],
+        depth=10,
+        seed=100,
+    )
+    assert len(moc_sampler.healpix_list) == 3  # The last two points should be deduplicated.
+
+    # Test we can generate many observations
+    num_samples = 10_000
+    ra, dec = moc_sampler.generate(num_samples=num_samples)
+
+    # We should sample roughly uniformly from the three regions.
+    is_first_pointing = (ra > 14.0) & (ra < 16.0) & (dec > -11.0) & (dec < -9.0)
+    is_second_pointing = (ra > 89.0) & (ra < 91.0) & (dec > -1.0) & (dec < 1.0)
+    is_third_pointing = (ra > 109.0) & (ra < 111.0) & (dec > -26.0) & (dec < -24.0)
+    assert np.all(is_first_pointing | is_second_pointing | is_third_pointing)
+    assert np.sum(is_first_pointing) > 0.25 * num_samples
+    assert np.sum(is_second_pointing) > 0.25 * num_samples
+    assert np.sum(is_third_pointing) > 0.25 * num_samples
+
+
 def test_catalog_ra_dec_sampler():
     """Test that we can sample from a catalog of RA and dec values."""
     values = {


### PR DESCRIPTION
Add helper functions that construct MOCs from a sample of points. This is needed for SkyMapper ObsTable where the data is provided on the CCD level and constructing cones from each CCD, time pairing is too expensive.