### PR TITLE
Add links to SkyMapper notebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,12 +69,10 @@ Notes:
    [pre-commit](https://lincc-ppt.readthedocs.io/en/latest/practices/precommit.html)
 
 
-## Disclaimers
+## Advisories
 
 This project is under active development and may see API changes.
 
-The team is consistently adding support for new packages and surveys. Not all of these have
-been used in detailed scientific analysis yet.
 **Users should always carefully validate the science outputs for their use case.**
 Please reach out to the team if you find any problems.
 

--- a/README.md
+++ b/README.md
@@ -13,8 +13,6 @@ A Fast and Nimble Package for Time Domain Astronomy
 [![Read the Docs](https://img.shields.io/readthedocs/lightcurvelynx)](https://lightcurvelynx.readthedocs.io/)
 
 
-**NOTE:** This project was recently renamed from TDAstro to LightCurveLynx. Users will need to update their import statements and dependencies to reflect the new name.
-
 ## Introduction
 
 Realistic light curve simulations are essential to many time-domain problems. 
@@ -69,6 +67,17 @@ Notes:
    that a set of tests will be run prior to completing a local commit. For more
    information, see the Python Project Template documentation on 
    [pre-commit](https://lincc-ppt.readthedocs.io/en/latest/practices/precommit.html)
+
+
+## Disclaimers
+
+This project is under active development and may see API changes.
+
+The team is consistently adding support for new packages and surveys. Not all of these have
+been used in detailed scientific analysis yet.
+**Users should always carefully validate the science outputs for their use case.**
+Please reach out to the team if you find any problems.
+
 
 ## Acknowledgements
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,9 +5,6 @@
 LightCurveLynx - A fast and nimble package for realistic time-domain light curve simulations
 ========================================================================================
 
-**NOTE:** This project was recently renamed from TDAstro to LightCurveLynx. See the
-details for updating your code below.
-
 Time-Domain Forward-Modeling for the Rubin Era
 -------------------------------------------------------------------------------
 
@@ -155,6 +152,15 @@ update your code:
    * If you have installed from PyPI or conda-forge, uninstall `tdastro` and install `lightcurvelynx` instead.
 
 If you run into any problems or have any questions, please reach out to the team. We are happy to help!
+
+Advisories
+-------------------------------------------------------------------------------
+
+This project is under active development and may see API changes.
+
+Not all wrapped packages, features, and surveys have been used in detailed scientific analysis yet.
+**Users should always carefully validate the science outputs for their use case.**
+Please reach out to the team if you find any problems.
 
 
 Acknowledgements

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -158,7 +158,6 @@ Advisories
 
 This project is under active development and may see API changes.
 
-Not all wrapped packages, features, and surveys have been used in detailed scientific analysis yet.
 **Users should always carefully validate the science outputs for their use case.**
 Please reach out to the team if you find any problems.
 

--- a/docs/notebooks.rst
+++ b/docs/notebooks.rst
@@ -74,6 +74,17 @@ in roughly alphabetical order of simulation package or simulation type).
     Synphot-based Models <notebooks/pre_executed/synphot_example>
 
 
+Other Surveys
+-----------------------------------------------------------------------------------------
+
+The following notebooks provide example simulations using non-Rubin surveys.
+
+.. toctree::
+    :maxdepth: 1
+
+    Argus Survey (prototype development)<notebooks/pre_executed/argus_example>
+    SkyMapper Survey <notebooks/pre_executed/skymapper_example>
+
 
 Extending LightCurveLynx
 -----------------------------------------------------------------------------------------

--- a/docs/survey_data.rst
+++ b/docs/survey_data.rst
@@ -3,6 +3,10 @@ Survey Data
 
 In order to generate a simulation, the simulator needs information on whether the telescope is pointing and the noise characteristics at the time. As you can imagine, the available data and its format varies significantly from survey to survey (and even between data releases of the same survey). `LightCurveLynx` uses an object-based model to encapsulate the survey information and provide a common interface.
 
+`LightCurveLynx` includes built-in support for a range of instruments and surveys. The characteristics of these
+instruments and surveys are generally derived from published values and data releases (see comments in the code
+for specific details). However, **users should always carefully validate the science outputs for their use case.**
+
 
 ObsTable
 -------------------------------------------------------------------------------
@@ -50,6 +54,13 @@ Roman Simulated Data (RomanObsTable)
 The ``RomanObsTable`` class stores pointing and noise information from the `Nancy Grace Roman Space Telescope <https://roman.gsfc.nasa.gov>`__'s simulated survey data. The survey-specific constants are set to the values defined in the `Roman documentation <https://roman-docs.stsci.edu/>`__ and the `Roman GitHub repository <https://github.com/RomanSpaceTelescope>`__. 
 
 Special preprocessing is needed to handle the spectra observations (spectra simulation within LightCurveLynx is in early testing). Please contact the LightCurveLynx team if you need help with this.
+
+
+SkyMapper Data (SkyMapperObsTable)
+-------------------------------------------------------------------------------
+The ``SkyMapperObsTable`` class stores pointing and noise information from the `SkyMapper Southern Survey <https://skymapper.anu.edu.au/>`__.
+
+See the (:doc:`SkyMapper Example Notebook <notebooks/pre_executed/skymapper_example>`) for an example of how to load SkyMapper data using the ``SkyMapperObsTable`` class.
 
 
 ZTF Data (ZTFObsTable)


### PR DESCRIPTION
Add links to the SkyMapper notebook along with top-level advisories to always validate the scientific outputs.
