### PR TITLE
reST and Docstring cleanup

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -46,7 +46,7 @@ simulation will be reproducible.
 Can I Use a Random Seed with Parallelization?
 -------------------------------------------------------------------------------
 
-Yes. See the :doc:`parallelization notebook <notebooks/parallelization>` for details.
+Yes. See the :doc:`parallelization notebook <notebooks/parallel_runs>` for details.
 
 
 How Do I Use an External Simulation Package?
@@ -70,7 +70,7 @@ Can I Combine Multiple Surveys in a Single Simulation?
 
 Yes. LightCurveLynx allows you to combine multiple surveys in a single simulation by passing
 in multiple observation tables and corresponding passband groups. See the 
-:doc:`multiple surveys demo notebook <notebooks/multiple_surveys_demo>` for an example of how to do this.
+:doc:`multiple surveys demo notebook <notebooks/multiple_surveys>` for an example of how to do this.
 
 
 Can I Simulate Spectra?

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,9 +1,5 @@
-
-.. lightcurvelynx documentation main file.
-   You can adapt this file completely to your liking, but it should at least
-   contain the root `toctree` directive.
 LightCurveLynx - A fast and nimble package for realistic time-domain light curve simulations
-========================================================================================
+============================================================================================
 
 Time-Domain Forward-Modeling for the Rubin Era
 -------------------------------------------------------------------------------

--- a/docs/simulations.rst
+++ b/docs/simulations.rst
@@ -266,7 +266,7 @@ so they may be memory intensive.
 **NOTE**: Not all subpackages work with distributed computation yet. If you get an error about
 not being able to pickle an object, please let the LightCurveLynx team know so we can investigate.
 
-The :doc:`parallelization notebook <notebooks/parallelization>` provides an example of how to use
+The :doc:`parallelization notebook <notebooks/parallel_runs>` provides an example of how to use
 LightCurveLynx to run simulations in parallel including using dask and ray.
 
 

--- a/src/lightcurvelynx/astro_utils/black_body.py
+++ b/src/lightcurvelynx/astro_utils/black_body.py
@@ -23,8 +23,8 @@ def black_body_luminosity_density_per_solid(temperature, radius, wavelengths):
         A length N array of luminosity density values.
         Output is in CGS units of erg/s/Hz/steradian.
 
-    Notes
-    -----
+    Note
+    ----
     lightcurvelynx adopts nJy as the unit of flux density, so the output of this
     function may need to be converted to compatible units,
     e.g. multiply by 10^32.

--- a/src/lightcurvelynx/astro_utils/noise_model.py
+++ b/src/lightcurvelynx/astro_utils/noise_model.py
@@ -49,22 +49,20 @@ def poisson_bandflux_std(
     array_like
         Simulated bandflux noise, in the same units as the input bandflux.
 
-    Notes
-    -----
-
+    Note
+    ----
     1. We do not specify units for the input parameters, but they
-    should be consistent with each other.
-
+       should be consistent with each other.
     2. Here we assume that the sky and source photon noises follow
-    Poisson statistics in the limit of large number of photons,
-    e.g. they are both considered to be normal distributed with
-    variance equal to the number of photons. Readout noise is
-    assumed to be Poisson distributed with variance (squared mean)
-    equal to the square of the given value. Dark current is assumed
-    to be Poisson distributed with variance (squared mean) equal
-    to the product of the given value and the exposure time.
-    The output is Poisson standard deviation of the sum of all
-    these noises converted to the flux units.
+       Poisson statistics in the limit of large number of photons,
+       e.g. they are both considered to be normal distributed with
+       variance equal to the number of photons. Readout noise is
+       assumed to be Poisson distributed with variance (squared mean)
+       equal to the square of the given value. Dark current is assumed
+       to be Poisson distributed with variance (squared mean) equal
+       to the product of the given value and the exposure time.
+       The output is Poisson standard deviation of the sum of all
+       these noises converted to the flux units.
     """
     # Get variances, in electrons^2
 

--- a/src/lightcurvelynx/astro_utils/passbands.py
+++ b/src/lightcurvelynx/astro_utils/passbands.py
@@ -921,8 +921,8 @@ class Passband:
         **kwargs
             Additional keyword arguments (unused)
 
-        Reference
-        ---------
+        References
+        ----------
         snocosmo.Bandpass:
         https://sncosmo.readthedocs.io/en/stable/api/sncosmo.Bandpass.html
         """
@@ -958,15 +958,17 @@ class Passband:
         trim_quantile: float | None = 1e-3,
         **kwargs,
     ):
-        """Create a Passband object from the SVO Filter Profile Service.
+        """Create a Passband object from the SVO [1]_, [2]_, [3]_ Filter Profile Service.
 
         References
         ----------
-        This research has made use of the SVO Filter Profile Service "Carlos Rodrigo",
-        funded by MCIN/AEI/10.13039/501100011033/ through grant PID2023-146210NB-I00
-        * Rodrigo, C., Cruz, P., Aguilar, J.F., et al. 2024; https://ui.adsabs.harvard.edu/abs/2024A%26A...689A..93R/abstract
-        * Rodrigo, C., Solano, E., Bayo, A., 2012; https://ui.adsabs.harvard.edu/abs/2012ivoa.rept.1015R/abstract
-        * Rodrigo, C., Solano, E., 2020; https://ui.adsabs.harvard.edu/abs/2020sea..confE.182R/abstract
+        .. [1] Rodrigo, C., Cruz, P., Aguilar, J.F., et al. 2024; 
+           https://ui.adsabs.harvard.edu/abs/2024A%26A...689A..93R/abstract
+
+        .. [2] Rodrigo, C., Solano, E., Bayo, A., 2012; 
+           https://ui.adsabs.harvard.edu/abs/2012ivoa.rept.1015R/abstract
+
+        .. [3] Rodrigo, C., Solano, E., 2020; https://ui.adsabs.harvard.edu/abs/2020sea..confE.182R/abstract
 
         Parameters
         ----------

--- a/src/lightcurvelynx/astro_utils/passbands.py
+++ b/src/lightcurvelynx/astro_utils/passbands.py
@@ -962,10 +962,10 @@ class Passband:
 
         References
         ----------
-        .. [1] Rodrigo, C., Cruz, P., Aguilar, J.F., et al. 2024; 
+        .. [1] Rodrigo, C., Cruz, P., Aguilar, J.F., et al. 2024;
            https://ui.adsabs.harvard.edu/abs/2024A%26A...689A..93R/abstract
 
-        .. [2] Rodrigo, C., Solano, E., Bayo, A., 2012; 
+        .. [2] Rodrigo, C., Solano, E., Bayo, A., 2012;
            https://ui.adsabs.harvard.edu/abs/2012ivoa.rept.1015R/abstract
 
         .. [3] Rodrigo, C., Solano, E., 2020; https://ui.adsabs.harvard.edu/abs/2020sea..confE.182R/abstract

--- a/src/lightcurvelynx/astro_utils/redshift.py
+++ b/src/lightcurvelynx/astro_utils/redshift.py
@@ -44,8 +44,8 @@ def obs_to_rest_times_waves(observer_frame_times, observer_frame_wavelengths, re
 def rest_to_obs_flux(flux_density, redshift):
     """Convert rest-frame flux to obs-frame flux.
     The (1+redshift) factor is applied to preserve bolometric flux.
-    The rest-frame flux is defined as F_nu = L_nu / 4*pi*D_L**2,
-    where D_L is the luminosity distance.
+    The rest-frame flux is defined as ``F_nu = L_nu / 4*pi*D_L**2``,
+    where ``D_L`` is the luminosity distance.
 
     Parameters
     ----------

--- a/src/lightcurvelynx/astro_utils/snia_utils.py
+++ b/src/lightcurvelynx/astro_utils/snia_utils.py
@@ -50,10 +50,12 @@ def num_snia_per_redshift_bin(
     """
     Calculate the number of SNe Ia in each redshift bin based on rates.
 
-    r_v(z) = dN/dz
-    V = comoving volume
-    T = length of survey in years
-    N = int r_v(z)dz * dV * dT
+    Calculated using::
+
+        r_v(z) = dN/dz
+        V = comoving volume
+        T = length of survey in years
+        N = int r_v(z)dz * dV * dT
 
     Parameters
     ----------

--- a/src/lightcurvelynx/astro_utils/zeropoint.py
+++ b/src/lightcurvelynx/astro_utils/zeropoint.py
@@ -57,8 +57,8 @@ def magnitude_electron_zeropoint(
     ndarray of float
         AB mags that produces 1 electron.
 
-    Notes
-    -----
+    Note
+    ----
     Typically, zeropoints are defined as the magnitude of a source
     which would produce 1 count in a 1 second exposure -
     here we use *electron* counts, not ADU counts.
@@ -128,19 +128,21 @@ def calculate_zp_from_maglim(
 ):
     """Calculate zero points based on the 5-sigma mag limit.
 
-    snr = flux/fluxerr
-    fluxerr = sqrt(flux + sky*npix*gain + readnoise**2*nexposure*npix + darkcurrent*npix*exptime*nexposure)
-    5 = flux/fluxerr
-    25 = flux**2/(flux + sky*npix*Gain + readnoise**2*nexposure*npix + darkcurrent*npix*exptime*nexposure)
-    flux**2 - 25*flux -25*( sky*npix*Gain
-                            + readnoise**2*nexposure*npix
-                            + darkcurrent*npix*exptime*nexposure)
-                        = 0
-    flux = 12.5 + 0.5*sqrt(625
-                            + 100( sky*npix*Gain
-                            + readnoise**2*nexposure*npix
-                            + darkcurrent*npix*exptime*nexposure) )
-    zp = 2.5*log10(flux) + maglim
+    Calculated according to formulas::
+
+        snr = flux/fluxerr
+        fluxerr = sqrt(flux + sky*npix*gain + readnoise**2*nexposure*npix + darkcurrent*npix*exptime*nexposure)
+        5 = flux/fluxerr
+        25 = flux**2/(flux + sky*npix*Gain + readnoise**2*nexposure*npix + darkcurrent*npix*exptime*nexposure)
+        flux**2 - 25*flux -25*( sky*npix*Gain
+                                + readnoise**2*nexposure*npix
+                                + darkcurrent*npix*exptime*nexposure)
+                            = 0
+        flux = 12.5 + 0.5*sqrt(625
+                                + 100( sky*npix*Gain
+                                + readnoise**2*nexposure*npix
+                                + darkcurrent*npix*exptime*nexposure) )
+        zp = 2.5*log10(flux) + maglim
 
     Parameters
     ----------

--- a/src/lightcurvelynx/astro_utils/zeropoint.py
+++ b/src/lightcurvelynx/astro_utils/zeropoint.py
@@ -131,17 +131,19 @@ def calculate_zp_from_maglim(
     Calculated according to formulas::
 
         snr = flux/fluxerr
-        fluxerr = sqrt(flux + sky*npix*gain + readnoise**2*nexposure*npix + darkcurrent*npix*exptime*nexposure)
+        fluxerr = sqrt( flux + sky*npix*gain + readnoise**2*nexposure*npix
+                        + darkcurrent*npix*exptime*nexposure)
         5 = flux/fluxerr
-        25 = flux**2/(flux + sky*npix*Gain + readnoise**2*nexposure*npix + darkcurrent*npix*exptime*nexposure)
+        25 = flux**2/( flux + sky*npix*Gain + readnoise**2*nexposure*npix
+                       + darkcurrent*npix*exptime*nexposure)
         flux**2 - 25*flux -25*( sky*npix*Gain
                                 + readnoise**2*nexposure*npix
                                 + darkcurrent*npix*exptime*nexposure)
                             = 0
         flux = 12.5 + 0.5*sqrt(625
                                 + 100( sky*npix*Gain
-                                + readnoise**2*nexposure*npix
-                                + darkcurrent*npix*exptime*nexposure) )
+                                       + readnoise**2*nexposure*npix
+                                       + darkcurrent*npix*exptime*nexposure) )
         zp = 2.5*log10(flux) + maglim
 
     Parameters

--- a/src/lightcurvelynx/base_models.py
+++ b/src/lightcurvelynx/base_models.py
@@ -436,7 +436,7 @@ class ParameterizedNode:
         Some parameters may be set as a constant value while others may be set by
         evaluating a function that depends on other parameters.
 
-        Notes
+        Note
         -----
         * Does NOT set an initial value for the model parameter. The user must
           sample the parameters for this to be set.
@@ -524,8 +524,8 @@ class ParameterizedNode:
     def add_parameter(self, name, value=None, allow_gradient=None, description=None, **kwargs):
         """Add a single *new* parameter to the ParameterizedNode.
 
-        Notes
-        -----
+        Note
+        ----
         * Checks multiple sources in the following order: Manually specified value,
           an entry in kwargs, or None.
         * Does NOT set an initial value for the model parameter. The user must
@@ -881,17 +881,14 @@ class FunctionNode(ParameterizedNode):
         a single model parameter result.
     fixed_params : dict, optional
         A dictionary mapping a parameter name in the function to its fixed value.
-    **kwargs : dict, optional
+    **kwargs
         Any additional keyword arguments.
 
     Examples
     --------
-
-    ::
-
-        my_func = TDFunc(random.randint, a=1, b=10)
-        value1 = my_func()      # Sample from default range
-        value2 = my_func(b=20)  # Sample from extended range
+    >>> my_func = TDFunc(random.randint, a=1, b=10)
+    >>> value1 = my_func()      # Sample from default range
+    >>> value2 = my_func(b=20)  # Sample from extended range
 
     Note
     ----

--- a/src/lightcurvelynx/base_models.py
+++ b/src/lightcurvelynx/base_models.py
@@ -886,9 +886,9 @@ class FunctionNode(ParameterizedNode):
 
     Examples
     --------
-    >>> my_func = TDFunc(random.randint, a=1, b=10)
-    >>> value1 = my_func()      # Sample from default range
-    >>> value2 = my_func(b=20)  # Sample from extended range
+    >>> my_func = TDFunc(random.randint, a=1, b=10)                # doctest: +SKIP
+    >>> value1 = my_func()      # Sample from default range        # doctest: +SKIP
+    >>> value2 = my_func(b=20)  # Sample from extended range       # doctest: +SKIP
 
     Note
     ----

--- a/src/lightcurvelynx/consts.py
+++ b/src/lightcurvelynx/consts.py
@@ -17,8 +17,8 @@ GAUSS_EFF_AREA2FWHM_SQ = np.pi / (2 * np.log(2))  # ~2.266
 It is roughly 2.266, see
 https://smtn-002.lsst.io/v/OPSIM-1171/index.html.
 
-Notes
------
+Note
+----
 This is derived from two facts for a symmetric 2D Gaussian:
 
 1. FWHM² = 8 * ln(2) * sigma², where sigma is the standard deviation.
@@ -69,6 +69,6 @@ lsst_filter_plot_colors = {
 }
 """The default colors for plotting to match.
 
-We provide values for the filters with and without the "LSST_" prefix.
+We provide values for the filters with and without the ``"LSST_"`` prefix.
 https://community.lsst.org/t/lsst-filter-profiles/1463
 """

--- a/src/lightcurvelynx/effects/microlensing.py
+++ b/src/lightcurvelynx/effects/microlensing.py
@@ -17,7 +17,7 @@ class Microlensing(EffectModel, CiteClass):
     but they can be in the future.
 
     Values that should be parametrized are:
-    
+
     * lens_mass (M_L)
     * lens_distance (D_L)
     * source_distance (D_S)

--- a/src/lightcurvelynx/effects/microlensing.py
+++ b/src/lightcurvelynx/effects/microlensing.py
@@ -17,6 +17,7 @@ class Microlensing(EffectModel, CiteClass):
     but they can be in the future.
 
     Values that should be parametrized are:
+    
     * lens_mass (M_L)
     * lens_distance (D_L)
     * source_distance (D_S)
@@ -27,9 +28,9 @@ class Microlensing(EffectModel, CiteClass):
     ----------
     * V. Bozza, MNRAS 408 (2010) 2188: general algorithm for binary lensing;
     * V. Bozza, E. Bachelet, F. Bartolic, T. Heintz, A. Hoag, M. Hundertmark, MNRAS 479 (2018) 5157:
-    BinaryMag2 function, Extended-Source-Point-Lens methods;
+      BinaryMag2 function, Extended-Source-Point-Lens methods;
     * V. Bozza, E. Khalouei and E. Bachelet, MNRAS 505 (2021) 126: astrometry, generalized limb darkening,
-    Keplerian orbital motion;
+      Keplerian orbital motion;
     * V. Bozza, v. Saggese, G. Covone, P. Rota & J. Zhang, A&A 694 (2025) 219: multiple lenses.
 
     Attributes

--- a/src/lightcurvelynx/graph_state.py
+++ b/src/lightcurvelynx/graph_state.py
@@ -89,7 +89,7 @@ class GraphState:
     def __contains__(self, key):
         """Check if the GraphState contains an entry.
 
-        The key can be::
+        The key can be:
 
         1) the name of a node (in which case we return True if the node exists),
         2) the full name of a parameter (in which case we return True if the
@@ -155,7 +155,7 @@ class GraphState:
     def __getitem__(self, key):
         """Access an entry in the GraphState.
 
-        The key can be::
+        The key can be:
 
         1) the name of a node (in which case we return that node's dictionary of
            parameter_name -> value),

--- a/src/lightcurvelynx/math_nodes/basic_math_node.py
+++ b/src/lightcurvelynx/math_nodes/basic_math_node.py
@@ -18,7 +18,7 @@ class BasicMathNode(FunctionNode):
     variables in the expression must match the input variables provided by kwargs.
 
     Example::
-    
+
         my_node = BasicMathNode(
             "redshift + 10.0 * sin(phase)",
             redshift=host.redshift,

--- a/src/lightcurvelynx/math_nodes/basic_math_node.py
+++ b/src/lightcurvelynx/math_nodes/basic_math_node.py
@@ -17,7 +17,8 @@ class BasicMathNode(FunctionNode):
     the expression once and execute using math, numpy, or JAX. The names of the
     variables in the expression must match the input variables provided by kwargs.
 
-    Example:
+    Example::
+    
         my_node = BasicMathNode(
             "redshift + 10.0 * sin(phase)",
             redshift=host.redshift,

--- a/src/lightcurvelynx/math_nodes/bilby_priors.py
+++ b/src/lightcurvelynx/math_nodes/bilby_priors.py
@@ -27,21 +27,23 @@ class BilbyPriorNode(FunctionNode, CiteClass):
     the `seed` argument when initializing the node or by calling the `set_seed` method. However,
     you cannot control the samples from this node via a simulation-wide random number generator.
 
-    References
-    ----------
-    @article{bilby_paper,
-        author = "Ashton, Gregory and others",
-        title = "{BILBY: A user-friendly Bayesian inference library for gravitational-wave astronomy}",
-        eprint = "1811.02042",
-        archivePrefix = "arXiv",
-        primaryClass = "astro-ph.IM",
-        doi = "10.3847/1538-4365/ab06fc",
-        journal = "Astrophys. J. Suppl.",
-        volume = "241",
-        number = "2",
-        pages = "27",
-        year = "2019"
-    }
+    Citations
+    ---------
+    Cite as::
+
+          @article{bilby_paper,
+              author = "Ashton, Gregory and others",
+              title = "{BILBY: A user-friendly Bayesian inference library for gravitational-wave astronomy}",
+              eprint = "1811.02042",
+              archivePrefix = "arXiv",
+              primaryClass = "astro-ph.IM",
+              doi = "10.3847/1538-4365/ab06fc",
+              journal = "Astrophys. J. Suppl.",
+              volume = "241",
+              number = "2",
+              pages = "27",
+              year = "2019"
+          }
     """
 
     def __init__(self, prior, seed=None, **kwargs):
@@ -111,7 +113,8 @@ class BilbyPriorNode(FunctionNode, CiteClass):
 
         Raises
         ------
-        ValueError is func attribute is None.
+        ValueError 
+            if func attribute is None.
         """
         # Sample from the Bilby prior model and extract the parameters from the dictionary.
         param_dict = self.prior.sample(graph_state.num_samples)

--- a/src/lightcurvelynx/math_nodes/bilby_priors.py
+++ b/src/lightcurvelynx/math_nodes/bilby_priors.py
@@ -113,7 +113,7 @@ class BilbyPriorNode(FunctionNode, CiteClass):
 
         Raises
         ------
-        ValueError 
+        ValueError
             if func attribute is None.
         """
         # Sample from the Bilby prior model and extract the parameters from the dictionary.

--- a/src/lightcurvelynx/math_nodes/np_random.py
+++ b/src/lightcurvelynx/math_nodes/np_random.py
@@ -18,7 +18,7 @@ class NumpyRandomFunc(FunctionNode):
         This object's random number generator.
     sample_size : tuple
         The shape of the array to generate for each sample. The actual returned value
-        will be (num_samples, size). If an empty tuple will generate a single value per sample.
+        will be ``(num_samples, *size)``. If an empty tuple will generate a single value per sample.
 
     Parameters
     ----------
@@ -26,7 +26,7 @@ class NumpyRandomFunc(FunctionNode):
         The name of the random function to use.
     size : int or tuple, optional
         The shape of the array to generate for each sample. Actual
-        returned value will be (num_samples, size).
+        returned value will be ``(num_samples, *size)``.
         Default: None (single values for each sample)
     seed : int, optional
         The seed to use.
@@ -168,7 +168,7 @@ class NumpyMultivariateNormalFunc(FunctionNode):
         This object's random number generator.
     sample_size : tuple
         The shape of the array to generate for each sample. The actual returned value
-        will be (num_samples, size). If an empty tuple will generate a single value per sample.
+        will be ``(num_samples, *size)``. If an empty tuple will generate a single value per sample.
 
     Parameters
     ----------

--- a/src/lightcurvelynx/math_nodes/np_random.py
+++ b/src/lightcurvelynx/math_nodes/np_random.py
@@ -18,7 +18,7 @@ class NumpyRandomFunc(FunctionNode):
         This object's random number generator.
     sample_size : tuple
         The shape of the array to generate for each sample. The actual returned value
-        will be (num_samples, *size). If an empty tuple will generate a single value per sample.
+        will be (num_samples, size). If an empty tuple will generate a single value per sample.
 
     Parameters
     ----------
@@ -26,13 +26,13 @@ class NumpyRandomFunc(FunctionNode):
         The name of the random function to use.
     size : int or tuple, optional
         The shape of the array to generate for each sample. Actual
-        returned value will be (num_samples, *size).
+        returned value will be (num_samples, size).
         Default: None (single values for each sample)
     seed : int, optional
         The seed to use.
 
-    Notes
-    -----
+    Note
+    ----
     Since we need to create a new random number generator for this object
     and use that generator's functions, we cannot pass in the function directly.
     Instead we need to pass in the function's name.
@@ -41,11 +41,11 @@ class NumpyRandomFunc(FunctionNode):
 
     Examples
     --------
-    # Create a uniform random number generator between 100.0 and 150.0
-    func_node = NumpyRandomFunc("uniform", low=100.0, high=150.0)
+    >>> # Create a uniform random number generator between 100.0 and 150.0
+    >>> func_node = NumpyRandomFunc("uniform", low=100.0, high=150.0)
 
-    # Create a normal random number generator with mean=5.0 and std=1.0
-    func_node = NumpyRandomFunc("normal", loc=5.0, scale=1.0)
+    >>> # Create a normal random number generator with mean=5.0 and std=1.0
+    >>> func_node = NumpyRandomFunc("normal", loc=5.0, scale=1.0)
     """
 
     def __init__(self, func_name, size=1, seed=None, **kwargs):
@@ -168,7 +168,7 @@ class NumpyMultivariateNormalFunc(FunctionNode):
         This object's random number generator.
     sample_size : tuple
         The shape of the array to generate for each sample. The actual returned value
-        will be (num_samples, *size). If an empty tuple will generate a single value per sample.
+        will be (num_samples, size). If an empty tuple will generate a single value per sample.
 
     Parameters
     ----------
@@ -181,11 +181,11 @@ class NumpyMultivariateNormalFunc(FunctionNode):
 
     Examples
     --------
-    # Create a uniform random number generator between 100.0 and 150.0
-    func_node = NumpyRandomFunc("uniform", low=100.0, high=150.0)
+    >>> # Create a uniform random number generator between 100.0 and 150.0
+    >>> func_node = NumpyRandomFunc("uniform", low=100.0, high=150.0)
 
-    # Create a normal random number generator with mean=5.0 and std=1.0
-    func_node = NumpyRandomFunc("normal", loc=5.0, scale=1.0)
+    >>> # Create a normal random number generator with mean=5.0 and std=1.0
+    >>> func_node = NumpyRandomFunc("normal", loc=5.0, scale=1.0)
     """
 
     def __init__(self, mean, cov, seed=None, **kwargs):

--- a/src/lightcurvelynx/math_nodes/ra_dec_sampler.py
+++ b/src/lightcurvelynx/math_nodes/ra_dec_sampler.py
@@ -393,8 +393,8 @@ class ApproximateMOCSampler(NumpyRandomFunc, CiteClass):
     * MOCPY: https://github.com/cds-astro/mocpy/
     * CDS Healpix: https://github.com/cds-astro/cds-healpix-python
     * MOC: Pierre Fernique, Thomas Boch, Tom Donaldson, Daniel Durand , Wil O'Mullane, Martin Reinecke,
-    and Mark Taylor. MOC - HEALPix Multi-Order Coverage map Version 1.0. IVOA Recommendation 02 June 2014,
-    pages 602, Jun 2014. doi:10.5479/ADS/bib/2014ivoa.spec.0602F.
+      and Mark Taylor. MOC - HEALPix Multi-Order Coverage map Version 1.0. IVOA Recommendation 02 June 2014,
+      pages 602, Jun 2014. doi:10.5479/ADS/bib/2014ivoa.spec.0602F.
 
     Attributes
     ----------

--- a/src/lightcurvelynx/math_nodes/scipy_random.py
+++ b/src/lightcurvelynx/math_nodes/scipy_random.py
@@ -226,7 +226,7 @@ class ScipyRandomDist(FunctionNode):
         This object's random number generator.
     sample_size : tuple
         The shape of the array to generate for each sample. The actual returned value
-        will be (num_samples, size). If an empty tuple will generate a single value per sample.
+        will be ``(num_samples, *size)``. If an empty tuple will generate a single value per sample.
     params_names : list of str
         The names of the parameters used to create the distribution object.
 

--- a/src/lightcurvelynx/math_nodes/scipy_random.py
+++ b/src/lightcurvelynx/math_nodes/scipy_random.py
@@ -226,7 +226,7 @@ class ScipyRandomDist(FunctionNode):
         This object's random number generator.
     sample_size : tuple
         The shape of the array to generate for each sample. The actual returned value
-        will be (num_samples, *size). If an empty tuple will generate a single value per sample.
+        will be (num_samples, size). If an empty tuple will generate a single value per sample.
     params_names : list of str
         The names of the parameters used to create the distribution object.
 
@@ -297,7 +297,8 @@ class ScipyRandomDist(FunctionNode):
 
         Raises
         ------
-        ValueError is func attribute is None.
+        ValueError
+            is func attribute is None.
         """
         # If a random number generator is given use that. Otherwise use the default one.
         rng = rng_info if rng_info is not None else self._rng

--- a/src/lightcurvelynx/math_nodes/single_value_node.py
+++ b/src/lightcurvelynx/math_nodes/single_value_node.py
@@ -6,8 +6,8 @@ from lightcurvelynx.base_models import ParameterizedNode
 class SingleVariableNode(ParameterizedNode):
     """A ParameterizedNode holding a single pre-defined variable.
 
-    Notes
-    -----
+    Note
+    ----
     Often used for testing, but can be used to make graph dependencies clearer.
 
     Parameters

--- a/src/lightcurvelynx/models/agn.py
+++ b/src/lightcurvelynx/models/agn.py
@@ -70,19 +70,20 @@ class AGN(SEDModel):
     """A model for an AGN.
 
     Parameterized values include:
-      * accretion_rate - The accretion rate (ME_dot) at Eddington luminosity in g/s.
-      * blackhole_accretion_rate - The accretion rate of the black hole in g/s.
-      * blackhole_mass - The black hole mass in solar mass.
-      * edd_ratio - The Eddington ratio.
-      * dec - The object's declination in degrees. [from BasePhysicalModel]
-      * distance - The object's luminosity distance in pc. [from BasePhysicalModel]
-      * inclination - The inclination of the accretion disk in radians (sampled uniformly
-        between 0 and pi/2).
-      * L_bol - The bolometric luminosity in erg/s.
-      * mag_i - The i band absolute magnitude.
-      * ra - The object's right ascension in degrees. [from BasePhysicalModel]
-      * redshift - The object's redshift. [from BasePhysicalModel]
-      * t0 - The t0 of the zero phase, date. [from BasePhysicalModel]
+
+    * accretion_rate - The accretion rate (ME_dot) at Eddington luminosity in g/s.
+    * blackhole_accretion_rate - The accretion rate of the black hole in g/s.
+    * blackhole_mass - The black hole mass in solar mass.
+    * edd_ratio - The Eddington ratio.
+    * dec - The object's declination in degrees. [from BasePhysicalModel]
+    * distance - The object's luminosity distance in pc. [from BasePhysicalModel]
+    * inclination - The inclination of the accretion disk in radians (sampled uniformly
+      between 0 and pi/2).
+    * L_bol - The bolometric luminosity in erg/s.
+    * mag_i - The i band absolute magnitude.
+    * ra - The object's right ascension in degrees. [from BasePhysicalModel]
+    * redshift - The object's redshift. [from BasePhysicalModel]
+    * t0 - The t0 of the zero phase, date. [from BasePhysicalModel]
 
     Parameters
     ----------

--- a/src/lightcurvelynx/models/bagle_models.py
+++ b/src/lightcurvelynx/models/bagle_models.py
@@ -38,11 +38,13 @@ class BagleWrapperModel(BandfluxModel, CiteClass):
     """A wrapper for single bagle models (one model type).
 
     Parameterized values include:
-      * dec - The object's declination in degrees. [from BasePhysicalModel]
-      * distance - The object's luminosity distance in pc. [from BasePhysicalModel]
-      * ra - The object's right ascension in degrees. [from BasePhysicalModel]
-      * redshift - The object's redshift. [from BasePhysicalModel]
-      * t0 - The t0 of the zero phase, date. [from BasePhysicalModel]
+
+    * dec - The object's declination in degrees. [from BasePhysicalModel]
+    * distance - The object's luminosity distance in pc. [from BasePhysicalModel]
+    * ra - The object's right ascension in degrees. [from BasePhysicalModel]
+    * redshift - The object's redshift. [from BasePhysicalModel]
+    * t0 - The t0 of the zero phase, date. [from BasePhysicalModel]
+
     Additional parameterized values are used for specific bagle models.
 
     Note
@@ -182,23 +184,25 @@ class BagleMultiWrapperModel(BandfluxModel, CiteClass):
     """A wrapper for multiple bagle models (multiple model types).
 
     Parameterized values include:
-      * dec - The object's declination in degrees. [from BasePhysicalModel]
-      * distance - The object's luminosity distance in pc. [from BasePhysicalModel]
-      * ra - The object's right ascension in degrees. [from BasePhysicalModel]
-      * redshift - The object's redshift. [from BasePhysicalModel]
-      * t0 - The t0 of the zero phase, date. [from BasePhysicalModel]
+
+    * dec - The object's declination in degrees. [from BasePhysicalModel]
+    * distance - The object's luminosity distance in pc. [from BasePhysicalModel]
+    * ra - The object's right ascension in degrees. [from BasePhysicalModel]
+    * redshift - The object's redshift. [from BasePhysicalModel]
+    * t0 - The t0 of the zero phase, date. [from BasePhysicalModel]
+
     Additional parameterized values are used for specific bagle models.
 
     References
     ----------
-    * Lu et al., “The BAGLE Python Package for Bayesian Analysis of Gravitational Lensing Events”,
+    * Lu et al., "The BAGLE Python Package for Bayesian Analysis of Gravitational Lensing Events",
       AAS Journals, submitted
-    * Bhadra et al., “Modeling Binary Lenses and Sources with the BAGLE Python Package”, AAS Journals,
+    * Bhadra et al., "Modeling Binary Lenses and Sources with the BAGLE Python Package", AAS Journals,
       submitted
-    * Chen et al., “Adjusting Gaussian Process Priors for BAGLE's Gravitational Microlensing Model Fits”,
+    * Chen et al., "Adjusting Gaussian Process Priors for BAGLE's Gravitational Microlensing Model Fits",
       in prep.
 
-    Atttributes
+    Attributes
     -----------
     num_models : int
         The number of models being wrapped.
@@ -211,7 +215,8 @@ class BagleMultiWrapperModel(BandfluxModel, CiteClass):
     models : list of str or class
         The bagle model classes (or their names as strings) to use in the simulation.
     parameter_dicts : dict
-        A list of parameter dictionaries, one per model, each containing.
+        A list of parameter dictionaries, one per model, each containing the parameter names
+        and values for use in the corresponding model.
     filter_idx : dict, optional
         A mapping from filter names to indices expected by the bagle model. If not provided,
         a default mapping for ugrizy filters to [0, 1, 2, 3, 4, 5] will be used.

--- a/src/lightcurvelynx/models/basic_models.py
+++ b/src/lightcurvelynx/models/basic_models.py
@@ -9,12 +9,13 @@ class ConstantSEDModel(SEDModel):
     """A model with a constant SED over both wavelength and time.
 
     Parameterized values include:
-      * brightness - The inherent brightness
-      * dec - The object's declination in degrees. [from BasePhysicalModel]
-      * distance - The object's luminosity distance in pc. [from BasePhysicalModel]
-      * ra - The object's right ascension in degrees. [from BasePhysicalModel]
-      * redshift - The object's redshift. [from BasePhysicalModel]
-      * t0 - No effect for static model. [from BasePhysicalModel]
+
+    * brightness - The inherent brightness
+    * dec - The object's declination in degrees. [from BasePhysicalModel]
+    * distance - The object's luminosity distance in pc. [from BasePhysicalModel]
+    * ra - The object's right ascension in degrees. [from BasePhysicalModel]
+    * redshift - The object's redshift. [from BasePhysicalModel]
+    * t0 - No effect for static model. [from BasePhysicalModel]
 
     Parameters
     ----------
@@ -60,13 +61,14 @@ class StepModel(ConstantSEDModel):
     """A static model that is on for a fixed amount of time.
 
     Parameterized values include:
-      * brightness - The inherent brightness
-      * dec - The object's declination in degrees. [from BasePhysicalModel]
-      * distance - The object's luminosity distance in pc. [from BasePhysicalModel]
-      * ra - The object's right ascension in degrees. [from BasePhysicalModel]
-      * redshift - The object's redshift. [from BasePhysicalModel]
-      * t0 - The time the step function starts, in MJD.
-      * t1- The time the step function ends, in MJD.
+
+    * brightness - The inherent brightness
+    * dec - The object's declination in degrees. [from BasePhysicalModel]
+    * distance - The object's luminosity distance in pc. [from BasePhysicalModel]
+    * ra - The object's right ascension in degrees. [from BasePhysicalModel]
+    * redshift - The object's redshift. [from BasePhysicalModel]
+    * t0 - The time the step function starts, in MJD.
+    * t1- The time the step function ends, in MJD.
 
     Parameters
     ----------
@@ -114,18 +116,19 @@ class StepModel(ConstantSEDModel):
 
 
 class SinWaveModel(SEDModel):
-    """A model that emits a sine wave.
+    """A model that emits a sine wave::
 
-    flux = brightness + amplitude * sin(2 * pi * frequency * (time - t0))
+        flux = brightness + amplitude * sin(2 * pi * frequency * (time - t0))
 
     Parameterized values include:
-      * brightness - The inherent brightness
-      * frequency - The frequence of the sine wave.
-      * dec - The object's declination in degrees. [from BasePhysicalModel]
-      * distance - The object's luminosity distance in pc. [from BasePhysicalModel]
-      * ra - The object's right ascension in degrees. [from BasePhysicalModel]
-      * redshift - The object's redshift. [from BasePhysicalModel]
-      * t0 - The start of the sine wave's period. [from BasePhysicalModel]
+
+    * brightness - The inherent brightness
+    * frequency - The frequence of the sine wave.
+    * dec - The object's declination in degrees. [from BasePhysicalModel]
+    * distance - The object's luminosity distance in pc. [from BasePhysicalModel]
+    * ra - The object's right ascension in degrees. [from BasePhysicalModel]
+    * redshift - The object's redshift. [from BasePhysicalModel]
+    * t0 - The start of the sine wave's period. [from BasePhysicalModel]
 
     Parameters
     ----------
@@ -180,19 +183,22 @@ class SinWaveModel(SEDModel):
 
 class LinearWavelengthModel(SEDModel):
     """A model that emits flux as a linear function of wavelength
-    (that is constant over time): f(t, w) = scale * w + base.
+    (that is constant over time)::
+     
+        f(t, w) = scale * w + base.
 
     Includes optional minimum and maximum wavelength bounds to test
     extrapolation.
 
     Parameterized values include:
-      * linear_base - The base brightness in nJy.
-      * linear_scale - The slope of the linear function in nJy/Angstrom.
-      * dec - The object's declination in degrees. [from BasePhysicalModel]
-      * distance - The object's luminosity distance in pc. [from BasePhysicalModel]
-      * ra - The object's right ascension in degrees. [from BasePhysicalModel]
-      * redshift - The object's redshift. [from BasePhysicalModel]
-      * t0 - No effect for static model. [from BasePhysicalModel]
+
+    * linear_base - The base brightness in nJy.
+    * linear_scale - The slope of the linear function in nJy/Angstrom.
+    * dec - The object's declination in degrees. [from BasePhysicalModel]
+    * distance - The object's luminosity distance in pc. [from BasePhysicalModel]
+    * ra - The object's right ascension in degrees. [from BasePhysicalModel]
+    * redshift - The object's redshift. [from BasePhysicalModel]
+    * t0 - No effect for static model. [from BasePhysicalModel]
 
     Attributes
     ----------

--- a/src/lightcurvelynx/models/basic_models.py
+++ b/src/lightcurvelynx/models/basic_models.py
@@ -184,7 +184,7 @@ class SinWaveModel(SEDModel):
 class LinearWavelengthModel(SEDModel):
     """A model that emits flux as a linear function of wavelength
     (that is constant over time)::
-     
+
         f(t, w) = scale * w + base.
 
     Includes optional minimum and maximum wavelength bounds to test

--- a/src/lightcurvelynx/models/bayesn.py
+++ b/src/lightcurvelynx/models/bayesn.py
@@ -12,22 +12,23 @@ from lightcurvelynx.models.physical_model import SEDModel
 class BayesnModel(SEDModel, CiteClass):
     """A bayesian model for supernova type Ia
 
-    The model is defined in (Mandel et al 2022) as:
+    The model is defined in (Mandel et al 2022) as::
 
-    flux(time, wave) = H_grid * 10 ** (-0.4 * W_grid) * 10 ** (-0.4 * (distmod _ m_abs))
+        flux(time, wave) = H_grid * 10 ** (-0.4 * W_grid) * 10 ** (-0.4 * (distmod _ m_abs))
 
     This class is based on the bayesian implementation at:
     https://github.com/bayesn/bayesn/blob/main/bayesn/bayesn_model.py
 
     Parameterized values include:
-        * ra - The object's right ascension in degrees. [from BasePhysicalModel]
-        * dec - The object's declination in degrees. [from BasePhysicalModel]
-        * redshift - The object's redshift. [from BasePhysicalModel]
-        * t0 - The t0 of the zero phase, date. [from BasePhysicalModel]
-        * Amplitude - The fixed normalisation factor for distance modulus. [from Amplitude class]
-        * theta - The bayeSN theta parameter.
-        * Av - The bayeSN Av parameter.
-        * Rv - The bayeSN Rv parameter.
+
+    * ra - The object's right ascension in degrees. [from BasePhysicalModel]
+    * dec - The object's declination in degrees. [from BasePhysicalModel]
+    * redshift - The object's redshift. [from BasePhysicalModel]
+    * t0 - The t0 of the zero phase, date. [from BasePhysicalModel]
+    * Amplitude - The fixed normalisation factor for distance modulus. [from Amplitude class]
+    * theta - The bayeSN theta parameter.
+    * Av - The bayeSN Av parameter.
+    * Rv - The bayeSN Rv parameter.
 
     References
     ----------

--- a/src/lightcurvelynx/models/eztaox_models.py
+++ b/src/lightcurvelynx/models/eztaox_models.py
@@ -23,7 +23,7 @@ class EzTaoXWrapperModel(BandfluxModel, CiteClass):
     * ra - The object's right ascension in degrees. [from BasePhysicalModel]
     * redshift - The object's redshift. [from BasePhysicalModel]
     * t0 - The t0 of the zero phase, date. [from BasePhysicalModel]
-    
+
     Additional parameterized values are used for specific eztaox models.
 
     References

--- a/src/lightcurvelynx/models/eztaox_models.py
+++ b/src/lightcurvelynx/models/eztaox_models.py
@@ -17,11 +17,13 @@ class EzTaoXWrapperModel(BandfluxModel, CiteClass):
     """A wrapper for an eztaox model.
 
     Parameterized values include:
-      * dec - The object's declination in degrees. [from BasePhysicalModel]
-      * distance - The object's luminosity distance in pc. [from BasePhysicalModel]
-      * ra - The object's right ascension in degrees. [from BasePhysicalModel]
-      * redshift - The object's redshift. [from BasePhysicalModel]
-      * t0 - The t0 of the zero phase, date. [from BasePhysicalModel]
+
+    * dec - The object's declination in degrees. [from BasePhysicalModel]
+    * distance - The object's luminosity distance in pc. [from BasePhysicalModel]
+    * ra - The object's right ascension in degrees. [from BasePhysicalModel]
+    * redshift - The object's redshift. [from BasePhysicalModel]
+    * t0 - The t0 of the zero phase, date. [from BasePhysicalModel]
+    
     Additional parameterized values are used for specific eztaox models.
 
     References

--- a/src/lightcurvelynx/models/galaxy_models.py
+++ b/src/lightcurvelynx/models/galaxy_models.py
@@ -9,13 +9,14 @@ class GaussianGalaxy(SEDModel):
     as the distance from the center increases.
 
     Parameterized values include:
-      * brightness - The inherent brightness at the center of the galaxy.
-      * dec - The object's declination in degrees. [from BasePhysicalModel]
-      * distance - The object's luminosity distance in pc. [from BasePhysicalModel]
-      * galaxy_radius_std - The standard deviation of the brightness in degrees.
-      * ra - The object's right ascension in degrees. [from BasePhysicalModel]
-      * redshift - The object's redshift. [from BasePhysicalModel]
-      * t0 - No effect for a GuassianGalaxy. [from BasePhysicalModel]
+
+    * brightness - The inherent brightness at the center of the galaxy.
+    * dec - The object's declination in degrees. [from BasePhysicalModel]
+    * distance - The object's luminosity distance in pc. [from BasePhysicalModel]
+    * galaxy_radius_std - The standard deviation of the brightness in degrees.
+    * ra - The object's right ascension in degrees. [from BasePhysicalModel]
+    * redshift - The object's redshift. [from BasePhysicalModel]
+    * t0 - No effect for a GuassianGalaxy. [from BasePhysicalModel]
 
     Parameters
     ----------

--- a/src/lightcurvelynx/models/lightcurve_template_model.py
+++ b/src/lightcurvelynx/models/lightcurve_template_model.py
@@ -67,11 +67,12 @@ class LightcurveBandData:
     ----------
     lightcurves : dict or numpy.ndarray
         The light curves can be passed as either:
+
         1) a dictionary mapping filter names to a (T, 2) array of the bandfluxes in that filter
-        where the first column is time and the second column is the light curve values, or
+           where the first column is time and the second column is the light curve values, or
         2) a numpy array of shape (T, 3) array where the first column is time (in days), the
-        second column is the light curve values, and the third column is the filter.
-        The light curve values can be either fluxes (in nJy) or AB magnitudes (if magnitudes_in=True).
+           second column is the light curve values, and the third column is the filter.
+           The light curve values can be either fluxes (in nJy) or AB magnitudes (if magnitudes_in=True).
     lc_data_t0 : float
         The reference epoch of the input light curve. The model will be shifted
         to the model's lc_data_t0 when computing fluxes.  For periodic light curves, this either
@@ -409,9 +410,10 @@ class BaseLightcurveBandTemplateModel(BandfluxModel, ABC):
     to generate the SED (the wavelengths must match).
 
     Parameterized values include:
-      * dec - The object's declination in degrees.
-      * ra - The object's right ascension in degrees.
-      * t0 - The t0 of the zero phase (if applicable), date.
+
+    * dec - The object's declination in degrees.
+    * ra - The object's right ascension in degrees.
+    * t0 - The t0 of the zero phase (if applicable), date.
 
     Attributes
     ----------
@@ -528,12 +530,13 @@ class LightcurveTemplateModel(BaseLightcurveBandTemplateModel):
     to generate the SED (the wavelengths must match).
 
     Parameterized values include:
-      * dec - The object's declination in degrees.
-      * ra - The object's right ascension in degrees.
-      * t0 - The t0 of the zero phase (if applicable), date.
 
-    Notes
-    -----
+    * dec - The object's declination in degrees.
+    * ra - The object's right ascension in degrees.
+    * t0 - The t0 of the zero phase (if applicable), date.
+
+    Note
+    ----
     If you are interested in generating SED-level data, use the SEDTemplateModel in
     src/lightcurvelynx/models/sed_template_model.py instead.
 
@@ -552,11 +555,12 @@ class LightcurveTemplateModel(BaseLightcurveBandTemplateModel):
     ----------
     lightcurves : dict or numpy.ndarray
         The light curves can be passed as either:
+
         1) a LightcurveBandData instance,
         2) a dictionary mapping filter names to a (T, 2) array of the bandlfuxes in that filter
-        where the first column is time and the second column is the flux density (in nJy), or
+           where the first column is time and the second column is the flux density (in nJy), or
         3) a numpy array of shape (T, 3) array where the first column is time (in days), the
-        second column is the bandflux (in nJy), and the third column is the filter.
+           second column is the bandflux (in nJy), and the third column is the filter.
     passbands : Passband or PassbandGroup or None
         The passband or passband group to use for defining the light curve. If provided (not None),
         these will be used to create box-shaped SED basis functions for each filter.
@@ -754,9 +758,10 @@ class MultiLightcurveTemplateModel(BaseLightcurveBandTemplateModel):
     to generate the SED (the wavelengths must match).
 
     Parameterized values include:
-      * dec - The object's declination in degrees.
-      * ra - The object's right ascension in degrees.
-      * t0 - The t0 of the zero phase (if applicable), date.
+
+    * dec - The object's declination in degrees.
+    * ra - The object's right ascension in degrees.
+    * t0 - The t0 of the zero phase (if applicable), date.
 
     Attributes
     ----------

--- a/src/lightcurvelynx/models/multi_object_model.py
+++ b/src/lightcurvelynx/models/multi_object_model.py
@@ -21,7 +21,9 @@ class MultiObjectModel(SEDModel):
     While this model supports both BandfluxModels and SED, it inherits from SEDModel
     to pick up some of the helper functions.
 
-    Note: Each object may have its own sampled (RA, dec) position, which are not
+    Note
+    ----
+    Each object may have its own sampled (RA, dec) position, which are not
     required to align.
 
     Attributes
@@ -212,7 +214,9 @@ class AdditiveMultiObjectModel(MultiObjectModel):
     for each model (for unresolved objects).  The observer frame effects are applied
     to the weighted sum of the models.
 
-    Note: Each model may have its own sampled (RA, dec) position, which are not
+    Note
+    ----
+    Each model may have its own sampled (RA, dec) position, which are not
     required to align.
 
     Attributes

--- a/src/lightcurvelynx/models/periodic_model.py
+++ b/src/lightcurvelynx/models/periodic_model.py
@@ -7,12 +7,13 @@ class PeriodicModel(SEDModel, ABC):
     """The base model for periodic sources.
 
     Parameterized values include:
-      * dec - The object's declination in degrees. [from BasePhysicalModel]
-      * distance - The object's luminosity distance in pc. [from BasePhysicalModel]
-      * period - The period of the source, in days.
-      * ra - The object's right ascension in degrees. [from BasePhysicalModel]
-      * redshift - The object's redshift. [from BasePhysicalModel]
-      * t0 - The t0 of the zero phase, date. [from BasePhysicalModel]
+
+    * dec - The object's declination in degrees. [from BasePhysicalModel]
+    * distance - The object's luminosity distance in pc. [from BasePhysicalModel]
+    * period - The period of the source, in days.
+    * ra - The object's right ascension in degrees. [from BasePhysicalModel]
+    * redshift - The object's redshift. [from BasePhysicalModel]
+    * t0 - The t0 of the zero phase, date. [from BasePhysicalModel]
 
     Parameters
     ----------

--- a/src/lightcurvelynx/models/periodic_variable_star.py
+++ b/src/lightcurvelynx/models/periodic_variable_star.py
@@ -11,12 +11,13 @@ class PeriodicVariableStar(PeriodicModel, ABC):
     """A model for a periodic variable star.
 
     Parameterized values include:
-      * dec - The object's declination in degrees. [from BasePhysicalModel]
-      * distance - The object's luminosity distance in pc. [from BasePhysicalModel]
-      * period - The period of the source, in days. [from PeriodicModel]
-      * ra - The object's right ascension in degrees. [from BasePhysicalModel]
-      * redshift - The object's redshift. [from BasePhysicalModel]
-      * t0 - The t0 of the zero phase, date. [from BasePhysicalModel]
+
+    * dec - The object's declination in degrees. [from BasePhysicalModel]
+    * distance - The object's luminosity distance in pc. [from BasePhysicalModel]
+    * period - The period of the source, in days. [from PeriodicModel]
+    * ra - The object's right ascension in degrees. [from BasePhysicalModel]
+    * redshift - The object's redshift. [from BasePhysicalModel]
+    * t0 - The t0 of the zero phase, date. [from BasePhysicalModel]
 
     Attributes
     ----------
@@ -97,18 +98,19 @@ class EclipsingBinaryStar(PeriodicVariableStar):
     No limb darkening, reflection, or other effects are included.
 
     Parameterized values include:
-      * dec - The object's declination in degrees. [from BasePhysicalModel]
-      * distance - The object's luminosity distance in pc. [from BasePhysicalModel]
-      * inclination - The inclination of the orbit, in degrees.
-      * major_semiaxis - The major semiaxis of the orbit, in AU.
-      * period - The period of the source, in days. [from PeriodicModel]
-      * primary_radius - The radius of the primary star, in solar radii.
-      * primary_temperature - The effective temperature of the primary star, in kelvins.
-      * ra - The object's right ascension in degrees. [from BasePhysicalModel]
-      * redshift - The object's redshift. [from BasePhysicalModel]
-      * secondary_radius - The radius of the secondary star, in solar radii.
-      * secondary_temperature - The effective temperature of the secondary star, in kelvins.
-      * t0 - The t0 of the zero phase, date. [from PeriodicModel]
+
+    * dec - The object's declination in degrees. [from BasePhysicalModel]
+    * distance - The object's luminosity distance in pc. [from BasePhysicalModel]
+    * inclination - The inclination of the orbit, in degrees.
+    * major_semiaxis - The major semiaxis of the orbit, in AU.
+    * period - The period of the source, in days. [from PeriodicModel]
+    * primary_radius - The radius of the primary star, in solar radii.
+    * primary_temperature - The effective temperature of the primary star, in kelvins.
+    * ra - The object's right ascension in degrees. [from BasePhysicalModel]
+    * redshift - The object's redshift. [from BasePhysicalModel]
+    * secondary_radius - The radius of the secondary star, in solar radii.
+    * secondary_temperature - The effective temperature of the secondary star, in kelvins.
+    * t0 - The t0 of the zero phase, date. [from PeriodicModel]
 
     Attributes
     ----------

--- a/src/lightcurvelynx/models/physical_model.py
+++ b/src/lightcurvelynx/models/physical_model.py
@@ -32,11 +32,12 @@ class BasePhysicalModel(ParameterizedNode, ABC):
     Physical models also support adding and applying a variety of effects, such as redshift.
 
     Parameterized values include:
-      * dec - The object's declination in degrees.
-      * distance - The object's luminosity distance in pc.
-      * ra - The object's right ascension in degrees.
-      * redshift - The object's redshift.
-      * t0 - The t0 of the zero phase (if applicable), date.
+
+    * dec - The object's declination in degrees.
+    * distance - The object's luminosity distance in pc.
+    * ra - The object's right ascension in degrees.
+    * redshift - The object's redshift.
+    * t0 - The t0 of the zero phase (if applicable), date.
 
     Parameters
     ----------
@@ -414,8 +415,11 @@ class SEDModel(BasePhysicalModel):
 
     def compute_sed(self, times, wavelengths, graph_state, **kwargs):
         """Draw effect-free rest frame flux densities.
-        The rest-frame flux is defined as F_nu = L_nu / 4*pi*D_L**2,
-        where D_L is the luminosity distance.
+        The rest-frame flux is defined as::
+         
+            F_nu = L_nu / 4*pi*D_L**2,
+
+        where ``D_L`` is the luminosity distance.
 
         Parameters
         ----------

--- a/src/lightcurvelynx/models/physical_model.py
+++ b/src/lightcurvelynx/models/physical_model.py
@@ -416,7 +416,7 @@ class SEDModel(BasePhysicalModel):
     def compute_sed(self, times, wavelengths, graph_state, **kwargs):
         """Draw effect-free rest frame flux densities.
         The rest-frame flux is defined as::
-         
+
             F_nu = L_nu / 4*pi*D_L**2,
 
         where ``D_L`` is the luminosity distance.

--- a/src/lightcurvelynx/models/pylima_models.py
+++ b/src/lightcurvelynx/models/pylima_models.py
@@ -46,11 +46,13 @@ class PyLIMAWrapperModel(BandfluxModel, CiteClass):
     """A wrapper for single pyLIMA models (one model type).
 
     Parameterized values include:
-      * dec - The object's declination in degrees. [from BasePhysicalModel]
-      * distance - The object's luminosity distance in pc. [from BasePhysicalModel]
-      * ra - The object's right ascension in degrees. [from BasePhysicalModel]
-      * redshift - The object's redshift. [from BasePhysicalModel]
-      * t0 - The t0 of the zero phase, date. [from BasePhysicalModel]
+
+    * dec - The object's declination in degrees. [from BasePhysicalModel]
+    * distance - The object's luminosity distance in pc. [from BasePhysicalModel]
+    * ra - The object's right ascension in degrees. [from BasePhysicalModel]
+    * redshift - The object's redshift. [from BasePhysicalModel]
+    * t0 - The t0 of the zero phase, date. [from BasePhysicalModel]
+    
     Additional parameterized values are used for specific PyLIMA models.
 
     Parameters

--- a/src/lightcurvelynx/models/pylima_models.py
+++ b/src/lightcurvelynx/models/pylima_models.py
@@ -52,7 +52,7 @@ class PyLIMAWrapperModel(BandfluxModel, CiteClass):
     * ra - The object's right ascension in degrees. [from BasePhysicalModel]
     * redshift - The object's redshift. [from BasePhysicalModel]
     * t0 - The t0 of the zero phase, date. [from BasePhysicalModel]
-    
+
     Additional parameterized values are used for specific PyLIMA models.
 
     Parameters

--- a/src/lightcurvelynx/models/redback_models.py
+++ b/src/lightcurvelynx/models/redback_models.py
@@ -22,7 +22,7 @@ class RedbackWrapperModel(SEDModel, CiteClass):
     * ra - The object's right ascension in degrees. [from BasePhysicalModel]
     * redshift - The object's redshift. [from BasePhysicalModel]
     * t0 - The t0 of the zero phase, date. [from BasePhysicalModel]
-    
+
     Additional parameterized values are used for specific redback models.
 
     References

--- a/src/lightcurvelynx/models/redback_models.py
+++ b/src/lightcurvelynx/models/redback_models.py
@@ -16,11 +16,13 @@ class RedbackWrapperModel(SEDModel, CiteClass):
     """A wrapper for redback models.
 
     Parameterized values include:
-      * dec - The object's declination in degrees. [from BasePhysicalModel]
-      * distance - The object's luminosity distance in pc. [from BasePhysicalModel]
-      * ra - The object's right ascension in degrees. [from BasePhysicalModel]
-      * redshift - The object's redshift. [from BasePhysicalModel]
-      * t0 - The t0 of the zero phase, date. [from BasePhysicalModel]
+
+    * dec - The object's declination in degrees. [from BasePhysicalModel]
+    * distance - The object's luminosity distance in pc. [from BasePhysicalModel]
+    * ra - The object's right ascension in degrees. [from BasePhysicalModel]
+    * redshift - The object's redshift. [from BasePhysicalModel]
+    * t0 - The t0 of the zero phase, date. [from BasePhysicalModel]
+    
     Additional parameterized values are used for specific redback models.
 
     References

--- a/src/lightcurvelynx/models/salt2_jax.py
+++ b/src/lightcurvelynx/models/salt2_jax.py
@@ -11,17 +11,17 @@ from lightcurvelynx.models.physical_model import SEDModel
 class SALT2JaxModel(SEDModel, CiteClass):
     """A SALT2 model implemented with JAX for it can use auto-differentiation.
 
-    The model is defined in (Guy J., 2007) as:
+    The model is defined in (Guy J., 2007) as::
 
-    flux(time, wave) = x0 * [M0(time, wave) + x1 * M1(time, wave)] * exp(c * CL(wave))
+        flux(time, wave) = x0 * [M0(time, wave) + x1 * M1(time, wave)] * exp(c * CL(wave))
 
-    where x0, x1, and c are given parameters, M0 is the average spectral sequence,
-    M1 is the first compoment to describe variability, and CL is the average color
+    where ``x0``, ``x1``, and ``c`` are given parameters, ``M0`` is the average spectral sequence,
+    ``M1`` is the first compoment to describe variability, and ``CL`` is the average color
     correction law.
 
-    We use the formulation in sncosmo where CL is defined such that:
+    We use the formulation in sncosmo where CL is defined such that::
 
-    flux(time, wave) = x0 * [M0(time, wave) + x1 * M1(time, wave)] * 10 ** (-0.4 * c * CL(wave))
+        flux(time, wave) = x0 * [M0(time, wave) + x1 * M1(time, wave)] * 10 ** (-0.4 * c * CL(wave))
 
     This class is based on the sncosmo implementation at:
     https://github.com/sncosmo/sncosmo/blob/v2.10.1/sncosmo/models.py
@@ -29,15 +29,16 @@ class SALT2JaxModel(SEDModel, CiteClass):
     when auto-differentiation is not needed.
 
     Parameterized values include:
-      * c - The SALT2 c parameter.
-      * dec - The object's declination in degrees. [from BasePhysicalModel]
-      * distance - The object's luminosity distance in pc. [from BasePhysicalModel]
-      * period - The period of the source, in days.
-      * ra - The object's right ascension in degrees. [from BasePhysicalModel]
-      * redshift - The object's redshift. [from BasePhysicalModel]
-      * t0 - The t0 of the zero phase, date. [from BasePhysicalModel]
-      * x0 - The SALT2 x0 parameter.
-      * x1 - The SALT2 x1 parameter.
+
+    * c - The SALT2 c parameter.
+    * dec - The object's declination in degrees. [from BasePhysicalModel]
+    * distance - The object's luminosity distance in pc. [from BasePhysicalModel]
+    * period - The period of the source, in days.
+    * ra - The object's right ascension in degrees. [from BasePhysicalModel]
+    * redshift - The object's redshift. [from BasePhysicalModel]
+    * t0 - The t0 of the zero phase, date. [from BasePhysicalModel]
+    * x0 - The SALT2 x0 parameter.
+    * x1 - The SALT2 x1 parameter.
 
     References
     ----------

--- a/src/lightcurvelynx/models/sed_template_model.py
+++ b/src/lightcurvelynx/models/sed_template_model.py
@@ -260,12 +260,13 @@ class SEDTemplateModel(SEDModel):
     the baseline value for that wavelength (0.0 by default).
 
     Parameterized values include:
-      * dec - The object's declination in degrees.
-      * ra - The object's right ascension in degrees.
-      * t0 - The t0 of the zero phase (if applicable), date.
 
-    Notes
-    -----
+    * dec - The object's declination in degrees.
+    * ra - The object's right ascension in degrees.
+    * t0 - The t0 of the zero phase (if applicable), date.
+
+    Note
+    ----
     If you are interested in generating light curves from band-level curves, use
     the LightcurveTemplateModel in src/lightcurvelynx/models/lightcurve_template_model.py
     instead.
@@ -279,9 +280,10 @@ class SEDTemplateModel(SEDModel):
     ----------
     template : numpy.ndarray or SEDTemplate
         The SED template information can be passed as either:
+
         1) a SEDTemplate instance, or
         2) a numpy array of shape (T, 3) array where the first column is phase (in days), the
-        second column is wavelength (in Angstroms), and the third column is the SED value (in nJy).
+           second column is wavelength (in Angstroms), and the third column is the SED value (in nJy).
     sed_data_t0 : float or None, optional
         The reference epoch of the input template. This is the time stamp of the input
         array that will correspond to t0 in the model. This is only required if the template
@@ -383,9 +385,10 @@ class MultiSEDTemplateModel(SEDModel):
     SEDTemplate documentation for details on how each template is handled.
 
     Parameterized values include:
-      * dec - The object's declination in degrees.
-      * ra - The object's right ascension in degrees.
-      * t0 - The t0 of the zero phase (if applicable), date.
+
+    * dec - The object's declination in degrees.
+    * ra - The object's right ascension in degrees.
+    * t0 - The t0 of the zero phase (if applicable), date.
 
     Attributes
     ----------
@@ -458,10 +461,11 @@ class SIMSEDModel(MultiSEDTemplateModel):
     """Generate fluxes from SIMSED-formated data.
 
     Parameterized values include:
-      * dec - The object's declination in degrees.
-      * distance - The object's luminosity distance in pc.
-      * ra - The object's right ascension in degrees.
-      * t0 - The t0 of the zero phase (if applicable), date.
+
+    * dec - The object's declination in degrees.
+    * distance - The object's luminosity distance in pc.
+    * ra - The object's right ascension in degrees.
+    * t0 - The t0 of the zero phase (if applicable), date.
 
     Attributes
     ----------

--- a/src/lightcurvelynx/models/sncosmo_models.py
+++ b/src/lightcurvelynx/models/sncosmo_models.py
@@ -21,7 +21,7 @@ class SncosmoWrapperModel(SEDModel, CiteClass):
     * ra - The object's right ascension in degrees. [from BasePhysicalModel]
     * redshift - The object's redshift. [from BasePhysicalModel]
     * t0 - The t0 of the zero phase, date. [from BasePhysicalModel]
-    
+
     Additional parameterized values are used for specific sncosmo models.
 
     References

--- a/src/lightcurvelynx/models/sncosmo_models.py
+++ b/src/lightcurvelynx/models/sncosmo_models.py
@@ -15,11 +15,13 @@ class SncosmoWrapperModel(SEDModel, CiteClass):
     """A wrapper for sncosmo models.
 
     Parameterized values include:
-      * dec - The object's declination in degrees. [from BasePhysicalModel]
-      * distance - The object's luminosity distance in pc. [from BasePhysicalModel]
-      * ra - The object's right ascension in degrees. [from BasePhysicalModel]
-      * redshift - The object's redshift. [from BasePhysicalModel]
-      * t0 - The t0 of the zero phase, date. [from BasePhysicalModel]
+
+    * dec - The object's declination in degrees. [from BasePhysicalModel]
+    * distance - The object's luminosity distance in pc. [from BasePhysicalModel]
+    * ra - The object's right ascension in degrees. [from BasePhysicalModel]
+    * redshift - The object's redshift. [from BasePhysicalModel]
+    * t0 - The t0 of the zero phase, date. [from BasePhysicalModel]
+    
     Additional parameterized values are used for specific sncosmo models.
 
     References

--- a/src/lightcurvelynx/models/snia_host.py
+++ b/src/lightcurvelynx/models/snia_host.py
@@ -5,12 +5,13 @@ class SNIaHost(SEDModel):
     """A SN Ia host galaxy model with a hostmass parameter, more to be added.
 
     Parameterized values include:
-      * dec - The object's declination in degrees. [from BasePhysicalModel]
-      * distance - The object's luminosity distance in pc. [from BasePhysicalModel]
-      * hostmass - The hostmass value in units of log10(M/M_solar).
-      * ra - The object's right ascension in degrees. [from BasePhysicalModel]
-      * redshift - The object's redshift. [from BasePhysicalModel]
-      * t0 - The t0 of the zero phase, date. [from BasePhysicalModel]
+
+    * dec - The object's declination in degrees. [from BasePhysicalModel]
+    * distance - The object's luminosity distance in pc. [from BasePhysicalModel]
+    * hostmass - The hostmass value in units of log10(M/M_solar).
+    * ra - The object's right ascension in degrees. [from BasePhysicalModel]
+    * redshift - The object's redshift. [from BasePhysicalModel]
+    * t0 - The t0 of the zero phase, date. [from BasePhysicalModel]
     """
 
     def __init__(self, **kwargs):

--- a/src/lightcurvelynx/models/static_sed_model.py
+++ b/src/lightcurvelynx/models/static_sed_model.py
@@ -13,11 +13,12 @@ class StaticSEDModel(SEDModel):
     the flux from that SED at all time steps.
 
     Parameterized values include:
-      * dec - The object's declination in degrees. [from BasePhysicalModel]
-      * distance - The object's luminosity distance in pc. [from BasePhysicalModel]
-      * ra - The object's right ascension in degrees. [from BasePhysicalModel]
-      * redshift - The object's redshift. [from BasePhysicalModel]
-      * t0 - The t0 of the zero phase, date. [from BasePhysicalModel. Not used.]
+
+    * dec - The object's declination in degrees. [from BasePhysicalModel]
+    * distance - The object's luminosity distance in pc. [from BasePhysicalModel]
+    * ra - The object's right ascension in degrees. [from BasePhysicalModel]
+    * redshift - The object's redshift. [from BasePhysicalModel]
+    * t0 - The t0 of the zero phase, date. [from BasePhysicalModel. Not used.]
 
     Attributes
     ----------
@@ -205,11 +206,12 @@ class StaticBandfluxModel(BandfluxModel):
     and uses that at all time steps.
 
     Parameterized values include:
-      * dec - The object's declination in degrees. [from PhysicalModel]
-      * distance - The object's luminosity distance in pc. [from PhysicalModel]
-      * ra - The object's right ascension in degrees. [from PhysicalModel]
-      * redshift - The object's redshift. [from PhysicalModel]
-      * t0 - The t0 of the zero phase, date. [from PhysicalModel. Not used.]
+
+    * dec - The object's declination in degrees. [from PhysicalModel]
+    * distance - The object's luminosity distance in pc. [from PhysicalModel]
+    * ra - The object's right ascension in degrees. [from PhysicalModel]
+    * redshift - The object's redshift. [from PhysicalModel]
+    * t0 - The t0 of the zero phase, date. [from PhysicalModel. Not used.]
 
     Attributes
     ----------

--- a/src/lightcurvelynx/obstable/argus_obstable.py
+++ b/src/lightcurvelynx/obstable/argus_obstable.py
@@ -48,7 +48,7 @@ class ArgusHealpixObsTable(ObsTable):
     **kwargs : dict
         Additional keyword arguments to pass to the constructor. This includes overrides
         for survey parameters such as:
-        
+
         - dark_electrons : The dark current for the camera in electrons per second per pixel.
         - gain: The gain for the camera in electrons per ADU.
         - pixel_scale: The pixel scale for the camera in arcseconds per pixel.

--- a/src/lightcurvelynx/obstable/argus_obstable.py
+++ b/src/lightcurvelynx/obstable/argus_obstable.py
@@ -48,6 +48,7 @@ class ArgusHealpixObsTable(ObsTable):
     **kwargs : dict
         Additional keyword arguments to pass to the constructor. This includes overrides
         for survey parameters such as:
+        
         - dark_electrons : The dark current for the camera in electrons per second per pixel.
         - gain: The gain for the camera in electrons per ADU.
         - pixel_scale: The pixel scale for the camera in arcseconds per pixel.

--- a/src/lightcurvelynx/obstable/fake_obs_table.py
+++ b/src/lightcurvelynx/obstable/fake_obs_table.py
@@ -55,7 +55,7 @@ class FakeObsTable(ObsTable):
     **kwargs : dict
         Additional keyword arguments to pass to the ObsTable constructor. This includes overrides
         for survey parameters such as:
-        
+
         - survey_name: The name of the survey (default="FAKE_SURVEY").
     """
 

--- a/src/lightcurvelynx/obstable/fake_obs_table.py
+++ b/src/lightcurvelynx/obstable/fake_obs_table.py
@@ -45,14 +45,17 @@ class FakeObsTable(ObsTable):
         The name of the strategy to use to derive any missing table parameters needed to compute the noise.
         This is used if the table does not provide all the necessary parameters for the given noise model.
         Should be one of:
+
         - "given_only" : Use only the parameters already provided in the table and survey values.
         - "five_sigma_depth": Derive approximate noise from only the 5-sigma depth values if available
           (no survey values like PSF, sky background, etc. are used).
         - "exhaustive": Try all available derivation methods to fill in missing parameters.
+
         Default is "given_only" which does not attempt any derivation.
     **kwargs : dict
         Additional keyword arguments to pass to the ObsTable constructor. This includes overrides
         for survey parameters such as:
+        
         - survey_name: The name of the survey (default="FAKE_SURVEY").
     """
 

--- a/src/lightcurvelynx/obstable/lsst_obstable.py
+++ b/src/lightcurvelynx/obstable/lsst_obstable.py
@@ -74,7 +74,7 @@ class LSSTObsTable(ObsTable):
     **kwargs : dict
         Additional keyword arguments to pass to the constructor. This includes overrides
         for survey parameters such as:
-        
+
         - dark_current : The dark current for the camera in electrons per second per pixel.
         - gain: The gain for the camera in electrons per ADU.
         - pixel_scale: The pixel scale for the camera in arcseconds per pixel.
@@ -250,7 +250,7 @@ class LSSTObsTable(ObsTable):
         Note this table uses a combination of the schemas (e.g. OpSim and ConsDB).
 
         As an example we can read a table from a file (e.g. using the `read_sqlite_table` function)::
-        
+
             from lightcurvelynx.utils.io_utils import read_sqlite_table
             table = read_sqlite_table("path_to_file.db", sql_query="SELECT * FROM observations")
 

--- a/src/lightcurvelynx/obstable/lsst_obstable.py
+++ b/src/lightcurvelynx/obstable/lsst_obstable.py
@@ -74,6 +74,7 @@ class LSSTObsTable(ObsTable):
     **kwargs : dict
         Additional keyword arguments to pass to the constructor. This includes overrides
         for survey parameters such as:
+        
         - dark_current : The dark current for the camera in electrons per second per pixel.
         - gain: The gain for the camera in electrons per ADU.
         - pixel_scale: The pixel scale for the camera in arcseconds per pixel.
@@ -190,12 +191,14 @@ class LSSTObsTable(ObsTable):
     def from_ccdvisit_table(cls, table, make_detector_footprint=False, **kwargs):
         """Construct an LSSTObsTable object from a CCDVisit table.
 
-        As an example we could access the DP1 CCDVisit table from RSP as:
+        As an example we could access the DP1 CCDVisit table from RSP as::
+
             from lsst.rsp import get_tap_service
             service = get_tap_service("tap")
             table = service.search("SELECT * FROM dp1.CcdVisit").to_table().to_pandas()
 
-        Or you can read a table from a file (e.g. using the `read_sqlite_table` function).
+        Or you can read a table from a file (e.g. using the `read_sqlite_table` function)::
+
             from lightcurvelynx.utils.io_utils import read_sqlite_table
             table = read_sqlite_table("path_to_file.db", sql_query="SELECT * FROM observations")
 
@@ -246,7 +249,8 @@ class LSSTObsTable(ObsTable):
         https://survey-strategy.lsst.io/progress/sv_status/sv_20250930.html
         Note this table uses a combination of the schemas (e.g. OpSim and ConsDB).
 
-        As an example we can read a table from a file (e.g. using the `read_sqlite_table` function).
+        As an example we can read a table from a file (e.g. using the `read_sqlite_table` function)::
+        
             from lightcurvelynx.utils.io_utils import read_sqlite_table
             table = read_sqlite_table("path_to_file.db", sql_query="SELECT * FROM observations")
 

--- a/src/lightcurvelynx/obstable/obs_table.py
+++ b/src/lightcurvelynx/obstable/obs_table.py
@@ -380,9 +380,9 @@ class ObsTable:
 
         Raise
         -----
-        FileNotFoundError 
+        FileNotFoundError
             if the file does not exist.
-        ValueError 
+        ValueError
             if unable to load the table.
         """
         survey_data = read_sqlite_table(filename, table_name=None, sql_query=sql_query)
@@ -604,7 +604,7 @@ class ObsTable:
 
         Raise
         -----
-        FileExistsError 
+        FileExistsError
             if the file already exists and overwrite is False.
         """
         if_exists = "replace" if overwrite else "fail"
@@ -630,7 +630,7 @@ class ObsTable:
 
         Raise
         -----
-        FileExistsError 
+        FileExistsError
             if the file already exists and overwrite is False.
         """
         if not overwrite and Path(filename).is_file():

--- a/src/lightcurvelynx/obstable/obs_table.py
+++ b/src/lightcurvelynx/obstable/obs_table.py
@@ -380,8 +380,10 @@ class ObsTable:
 
         Raise
         -----
-        FileNotFoundError if the file does not exist.
-        ValueError if unable to load the table.
+        FileNotFoundError 
+            if the file does not exist.
+        ValueError 
+            if unable to load the table.
         """
         survey_data = read_sqlite_table(filename, table_name=None, sql_query=sql_query)
         return cls(survey_data, **kwargs)
@@ -602,7 +604,8 @@ class ObsTable:
 
         Raise
         -----
-        FileExistsError if the file already exists and overwrite is False.
+        FileExistsError 
+            if the file already exists and overwrite is False.
         """
         if_exists = "replace" if overwrite else "fail"
 
@@ -627,7 +630,8 @@ class ObsTable:
 
         Raise
         -----
-        FileExistsError if the file already exists and overwrite is False.
+        FileExistsError 
+            if the file already exists and overwrite is False.
         """
         if not overwrite and Path(filename).is_file():
             raise FileExistsError(f"File {filename} already exists.")
@@ -898,7 +902,7 @@ class ObsTable:
         When a flux value exceeds the saturation limit, it is clipped to the limit and flagged as
         saturated. In these cases, the associated flux_error is increased to account for the offset
         introduced by clipping. The new error is computed as the quadrature sum of the original
-        flux_error and the difference between the orginal flux and saturated flux:
+        flux_error and the difference between the orginal flux and saturated flux::
 
             saturated_flux_error = sqrt(flux_error**2 + (flux - saturated_flux)**2)
 
@@ -919,12 +923,13 @@ class ObsTable:
         -------
         tuple of numpy.ndarray
             A tuple with three entries:
+
             - The saturated flux in nJy. A size S x T array where S is the
-                number of samples in the graph state and T is the number of time points.
+              number of samples in the graph state and T is the number of time points.
             - The saturated flux error in nJy. A size S x T array where S is the
-                number of samples in the graph state and T is the number of time points.
+              number of samples in the graph state and T is the number of time points.
             - A boolean array indicating which points are saturated. A size S x T array
-                where S is the number of samples in the graph state and T is the number of time points.
+              where S is the number of samples in the graph state and T is the number of time points.
         """
         if self._saturation_mags is None:
             logger.info("Saturation thresholds not provided. Skipping saturation computation.")

--- a/src/lightcurvelynx/obstable/obs_table_params.py
+++ b/src/lightcurvelynx/obstable/obs_table_params.py
@@ -357,7 +357,7 @@ class FiveSigmaDepthDeriver(ParamDeriver):
     """Class to derive the noise parameters from only the five-sigma depth information.
 
     Supported parameters (and their units) include:
-    
+
     - bandflux_error: The error associated with the computed bandflux.
     - bandflux_ref: The total flux that would be transmitted through the given bandfilter.
     - five_sigma_depth: Five-sigma depth in magnitudes

--- a/src/lightcurvelynx/obstable/obs_table_params.py
+++ b/src/lightcurvelynx/obstable/obs_table_params.py
@@ -239,6 +239,7 @@ class FullParamDeriver(ParamDeriver):
     """Class to derive all supported parameters from an ObsTable using predefined formulas.
 
     Supported parameters (and their units) include:
+
     - adu_bias: Bias level in ADU
     - dark_current: Dark current in electrons / second / pixel
     - exptime: Exposure time in seconds
@@ -356,6 +357,7 @@ class FiveSigmaDepthDeriver(ParamDeriver):
     """Class to derive the noise parameters from only the five-sigma depth information.
 
     Supported parameters (and their units) include:
+    
     - bandflux_error: The error associated with the computed bandflux.
     - bandflux_ref: The total flux that would be transmitted through the given bandfilter.
     - five_sigma_depth: Five-sigma depth in magnitudes

--- a/src/lightcurvelynx/obstable/opsim.py
+++ b/src/lightcurvelynx/obstable/opsim.py
@@ -32,7 +32,7 @@ _opsim_view_radius = 1.75
 """The angular radius of the observation field (in degrees)."""
 
 _opsim_ccd_radius = 0.1574
-"""The approximate angular radius of a single LSST CCD (in degrees). Each CCD is 800*800 arcsec^2.
+"""The approximate angular radius of a single LSST CCD (in degrees). Each CCD is ``800*800 arcsec^2``.
 We approximate the radius as 800 arcsec/ sqrt(2). We overestimate slightly, because this value is
 used in range searches. More exact filtering is done with the detector footprint.
 """
@@ -96,6 +96,7 @@ class OpSim(ObsTable):
     **kwargs : dict
         Additional keyword arguments to pass to the constructor. This includes overrides
         for survey parameters such as:
+        
         - dark_current : The dark current for the camera in electrons per second per pixel.
         - ext_coeff: Mapping of filter names to extinction coefficients.
         - pixel_scale: The pixel scale for the camera in arcseconds per pixel.
@@ -356,12 +357,13 @@ def oversample_opsim(
         The start and end times of the observations in MJD.
         None means to use the minimum (maximum) time in
         all the observations found for the given pointing.
-        Time is being samples as np.arange(*time_range, delta_t).
+        Time is being samples as ``np.arange(*time_range, delta_t)``.
     bands : list of str or None, optional
         The list of bands to include in the oversampled table.
         The default is to include all bands found for the given pointing.
     strategy : str, optional
         The strategy to select prototype observations.
+
         - "darkest_sky" selects the observations with the minimal sky brightness
           (maximum "skyBrightness" value) in each band. This is the default.
         - "random" selects the observations randomly. Fixed seed is used.

--- a/src/lightcurvelynx/obstable/opsim.py
+++ b/src/lightcurvelynx/obstable/opsim.py
@@ -96,7 +96,7 @@ class OpSim(ObsTable):
     **kwargs : dict
         Additional keyword arguments to pass to the constructor. This includes overrides
         for survey parameters such as:
-        
+
         - dark_current : The dark current for the camera in electrons per second per pixel.
         - ext_coeff: Mapping of filter names to extinction coefficients.
         - pixel_scale: The pixel scale for the camera in arcseconds per pixel.

--- a/src/lightcurvelynx/obstable/roman_obstable.py
+++ b/src/lightcurvelynx/obstable/roman_obstable.py
@@ -105,7 +105,7 @@ class RomanObsTable(ObsTable):
     **kwargs : dict
         Additional keyword arguments to pass to the ObsTable constructor. This includes overrides
         for survey parameters such as:
-        
+
         - dark_current : The dark current for the camera in electrons per second per pixel.
         - gain: The CCD gain (in e-/ADU).
         - pixel_scale: The pixel scale for the camera in arcseconds per pixel.

--- a/src/lightcurvelynx/obstable/roman_obstable.py
+++ b/src/lightcurvelynx/obstable/roman_obstable.py
@@ -105,6 +105,7 @@ class RomanObsTable(ObsTable):
     **kwargs : dict
         Additional keyword arguments to pass to the ObsTable constructor. This includes overrides
         for survey parameters such as:
+        
         - dark_current : The dark current for the camera in electrons per second per pixel.
         - gain: The CCD gain (in e-/ADU).
         - pixel_scale: The pixel scale for the camera in arcseconds per pixel.
@@ -306,8 +307,8 @@ class RomanObsTable(ObsTable):
     def calculate_skynoise(self, exptime, zodi_scale, zodi_countrate_min, thermal_countrate):
         """Calculate sky noise.
 
-        Reference
-        ---------
+        References
+        ----------
         Eq. 10 of Rose et al 2025 - https://ui.adsabs.harvard.edu/abs/2025ApJ...988...65R/abstract
 
         Parameters

--- a/src/lightcurvelynx/obstable/skymapper_obstable.py
+++ b/src/lightcurvelynx/obstable/skymapper_obstable.py
@@ -63,7 +63,7 @@ class SkyMapperObsTable(ObsTable, CiteClass):
     **kwargs : dict
         Additional keyword arguments to pass to the constructor. This includes overrides
         for survey parameters such as:
-        
+
         - dark_current : The dark current for the camera in electrons per second per pixel.
         - gain: The gain for the camera in electrons per ADU.
         - pixel_scale: The pixel scale for the camera in arcseconds per pixel.

--- a/src/lightcurvelynx/obstable/skymapper_obstable.py
+++ b/src/lightcurvelynx/obstable/skymapper_obstable.py
@@ -63,6 +63,7 @@ class SkyMapperObsTable(ObsTable, CiteClass):
     **kwargs : dict
         Additional keyword arguments to pass to the constructor. This includes overrides
         for survey parameters such as:
+        
         - dark_current : The dark current for the camera in electrons per second per pixel.
         - gain: The gain for the camera in electrons per ADU.
         - pixel_scale: The pixel scale for the camera in arcseconds per pixel.

--- a/src/lightcurvelynx/obstable/ztf_obstable.py
+++ b/src/lightcurvelynx/obstable/ztf_obstable.py
@@ -49,7 +49,7 @@ class ZTFObsTable(ObsTable):
     **kwargs : dict
         Additional keyword arguments to pass to the ObsTable constructor. This includes overrides
         for survey parameters such as:
-        
+
         - dark_current : The dark current for the camera in electrons per second per pixel.
         - gain: The CCD gain (in e-/ADU).
         - pixel_scale: The pixel scale for the camera in arcseconds per pixel.
@@ -156,9 +156,9 @@ class ZTFObsTable(ObsTable):
 
         Raise
         -----
-        FileNotFoundError 
+        FileNotFoundError
             if the file does not exist.
-        ValueError 
+        ValueError
             if unable to load the table.
         """
         if colmap is None:

--- a/src/lightcurvelynx/obstable/ztf_obstable.py
+++ b/src/lightcurvelynx/obstable/ztf_obstable.py
@@ -49,6 +49,7 @@ class ZTFObsTable(ObsTable):
     **kwargs : dict
         Additional keyword arguments to pass to the ObsTable constructor. This includes overrides
         for survey parameters such as:
+        
         - dark_current : The dark current for the camera in electrons per second per pixel.
         - gain: The CCD gain (in e-/ADU).
         - pixel_scale: The pixel scale for the camera in arcseconds per pixel.
@@ -155,8 +156,10 @@ class ZTFObsTable(ObsTable):
 
         Raise
         -----
-        FileNotFoundError if the file does not exist.
-        ValueError if unable to load the table.
+        FileNotFoundError 
+            if the file does not exist.
+        ValueError 
+            if unable to load the table.
         """
         if colmap is None:
             colmap = cls._default_colnames

--- a/src/lightcurvelynx/utils/bicubic_interp.py
+++ b/src/lightcurvelynx/utils/bicubic_interp.py
@@ -262,6 +262,7 @@ class BicubicAxis:
     with restrictions on acceptable data to match the SALT2 and SALT3 models.
 
     Restrictions include:
+
     - Data must contain at least 3 values.
     - Data must be sorted.
     - Data must be spaced at regular steps.
@@ -331,10 +332,10 @@ class BicubicAxis:
 
     def find_indices(self, query_pts):
         """Finds the first index *before* each of the query values with
-        the n - 1 index in each dimension mapped to n - 2.
+        the n - 1 index in each dimension mapped to n - 2::
 
-        values[idx[i]] <= query_pts[i] < values[idx[i] + 1]
-        for all i where idx[i] > 0 and idx[i] < n - 2.
+            values[idx[i]] <= query_pts[i] < values[idx[i] + 1]
+            for all i where idx[i] > 0 and idx[i] < n - 2.
 
         Parameters
         ----------

--- a/src/lightcurvelynx/utils/io_utils.py
+++ b/src/lightcurvelynx/utils/io_utils.py
@@ -28,15 +28,15 @@ class SquashOutput:
         The logging level to use when redirecting stdout and stderr to the logger.
         Default is logging.DEBUG.
 
-    Example
-    -------
-    with SquashOutput():
-        # Code that produces unwanted output
-        ...
+    Examples
+    --------
+    >>> with SquashOutput():
+    >>>     # Code that produces unwanted output
+    >>>     ...
 
-    with SquashOutput(stdout_to_log=True):
-        # Printed output is sent to logger.debug
-        ...
+    >>> with SquashOutput(stdout_to_log=True):
+    >>>     # Printed output is sent to logger.debug
+    >>>     ...
     """
 
     class _LoggerWriter:
@@ -108,11 +108,11 @@ class SquashLogging:
     level : int, optional
         The logging level below which to suppress logging output. Default: logging.ERROR
 
-    Example
-    -------
-    with SquashLogging(logger=logging.getLogger(), level=logging.ERROR):
-        # Code that produces unwanted logging at any level below logging.ERROR
-        ...
+    Examples
+    --------
+    >>> with SquashLogging(logger=logging.getLogger(), level=logging.ERROR):
+    >>>     # Code that produces unwanted logging at any level below logging.ERROR
+    >>>     ...
     """
 
     def __init__(self, logger, level=logging.ERROR):
@@ -263,7 +263,8 @@ def read_grid_data(input_file, format="ascii", validate=False):
 
     Raises
     ------
-    ValueError if any data validation fails.
+    ValueError 
+        if any data validation fails.
     """
     logging.debug(f"Loading file {input_file} (format={format})")
     if not Path(input_file).is_file():

--- a/src/lightcurvelynx/utils/io_utils.py
+++ b/src/lightcurvelynx/utils/io_utils.py
@@ -31,12 +31,12 @@ class SquashOutput:
     Examples
     --------
     >>> with SquashOutput():                       # doctest: +SKIP
-    >>>     # Code that produces unwanted output
-    >>>     ...
+    >>>     # Code that produces unwanted output   # doctest: +SKIP
+    >>>     ...                                    # doctest: +SKIP
 
-    >>> with SquashOutput(stdout_to_log=True):     # doctest: +SKIP
-    >>>     # Printed output is sent to logger.debug
-    >>>     ...
+    >>> with SquashOutput(stdout_to_log=True):       # doctest: +SKIP
+    >>>     # Printed output is sent to logger.debug # doctest: +SKIP
+    >>>     ...                                      # doctest: +SKIP
     """
 
     class _LoggerWriter:
@@ -110,8 +110,8 @@ class SquashLogging:
 
     Examples
     --------
-    >>> with SquashLogging(logger=logging.getLogger(), level=logging.ERROR): # doctest: +SKIP
-    >>>     # Code that produces unwanted logging at any level below logging.ERROR
+    >>> with SquashLogging(logger=logging.getLogger(), level=logging.ERROR):        # doctest: +SKIP
+    >>>     # Code that produces unwanted logging at any level below logging.ERROR  # doctest: +SKIP
     >>>     ...
     """
 

--- a/src/lightcurvelynx/utils/io_utils.py
+++ b/src/lightcurvelynx/utils/io_utils.py
@@ -31,11 +31,11 @@ class SquashOutput:
     Examples
     --------
     >>> with SquashOutput():                       # doctest: +SKIP
-    >>>     # Code that produces unwanted output   # doctest: +SKIP
+    >>>     # Code that produces unwanted output
     >>>     ...                                    # doctest: +SKIP
 
     >>> with SquashOutput(stdout_to_log=True):       # doctest: +SKIP
-    >>>     # Printed output is sent to logger.debug # doctest: +SKIP
+    >>>     # Printed output is sent to logger.debug
     >>>     ...                                      # doctest: +SKIP
     """
 
@@ -111,8 +111,8 @@ class SquashLogging:
     Examples
     --------
     >>> with SquashLogging(logger=logging.getLogger(), level=logging.ERROR):        # doctest: +SKIP
-    >>>     # Code that produces unwanted logging at any level below logging.ERROR  # doctest: +SKIP
-    >>>     ...
+    >>>     # Code that produces unwanted logging at any level below logging.ERROR
+    >>>     ...                                                                     # doctest: +SKIP
     """
 
     def __init__(self, logger, level=logging.ERROR):

--- a/src/lightcurvelynx/utils/io_utils.py
+++ b/src/lightcurvelynx/utils/io_utils.py
@@ -30,11 +30,11 @@ class SquashOutput:
 
     Examples
     --------
-    >>> with SquashOutput():
+    >>> with SquashOutput():                       # doctest: +SKIP
     >>>     # Code that produces unwanted output
     >>>     ...
 
-    >>> with SquashOutput(stdout_to_log=True):
+    >>> with SquashOutput(stdout_to_log=True):     # doctest: +SKIP
     >>>     # Printed output is sent to logger.debug
     >>>     ...
     """
@@ -110,7 +110,7 @@ class SquashLogging:
 
     Examples
     --------
-    >>> with SquashLogging(logger=logging.getLogger(), level=logging.ERROR):
+    >>> with SquashLogging(logger=logging.getLogger(), level=logging.ERROR): # doctest: +SKIP
     >>>     # Code that produces unwanted logging at any level below logging.ERROR
     >>>     ...
     """
@@ -263,7 +263,7 @@ def read_grid_data(input_file, format="ascii", validate=False):
 
     Raises
     ------
-    ValueError 
+    ValueError
         if any data validation fails.
     """
     logging.debug(f"Loading file {input_file} (format={format})")

--- a/src/lightcurvelynx/utils/post_process_results.py
+++ b/src/lightcurvelynx/utils/post_process_results.py
@@ -225,7 +225,7 @@ def results_augment_lightcurves(results, *, min_snr=0.0):
     - AB magnitude
     - AB magnitude error = (2.5 / ln(10)) * (fluxerr / flux)
     - relative time = mjd - t0 (if t0 in the results table)
-    
+
     None is used for invalid entries, e.g. negative flux or zero flux error.
 
     The input data frame can either be a single light curve (pandas.DataFrame)

--- a/src/lightcurvelynx/utils/post_process_results.py
+++ b/src/lightcurvelynx/utils/post_process_results.py
@@ -174,11 +174,13 @@ def lightcurve_compute_mag(flux, fluxerr):
 def augment_single_lightcurve(results, *, min_snr=0.0, t0=None):
     """Add columns to a single lightcurve DataFrame with additional information
     about the light curve, including:
+
     - SNR = flux / fluxerr
     - detection flag (True if SNR >= min_snr, False otherwise)
     - AB magnitude
     - AB magnitude error = (2.5 / ln(10)) * (fluxerr / flux)
     - relative time = mjd - t0 (if t0 is provided)
+
     None is used for invalid entries, e.g. negative flux or zero flux error.
 
     Parameters
@@ -217,11 +219,13 @@ def augment_single_lightcurve(results, *, min_snr=0.0, t0=None):
 def results_augment_lightcurves(results, *, min_snr=0.0):
     """Add columns to the results DataFrame with additional information
     about each light curve, including:
+
     - SNR = flux / fluxerr
     - detection flag (True if SNR >= min_snr, False otherwise)
     - AB magnitude
     - AB magnitude error = (2.5 / ln(10)) * (fluxerr / flux)
     - relative time = mjd - t0 (if t0 in the results table)
+    
     None is used for invalid entries, e.g. negative flux or zero flux error.
 
     The input data frame can either be a single light curve (pandas.DataFrame)


### PR DESCRIPTION
## Change Description

Address warnings and errors in docs rendering.

There are still loads of warnings like `WARNING: duplicate object description of lightcurvelynx.utils.extrapolate.FluxExtrapolationModel.nfit, other instance in autoapi/lightcurvelynx/utils/extrapolate/index, use :no-index: for one of them`.

Also did a visual pass over all of the rendered docstrings, and fixed any rendering issues that  stuck out to me.

## Code Quality
- [x] I have read the Contribution Guide and agree to the Code of Conduct
- [x] My code follows the code style of this project
- [x] My code builds (or compiles) cleanly without any errors or warnings
- [x] My code contains relevant comments and necessary documentation
