### PR TITLE
Fix small error with light curve template model

### DIFF
--- a/src/lightcurvelynx/models/lightcurve_template_model.py
+++ b/src/lightcurvelynx/models/lightcurve_template_model.py
@@ -141,6 +141,9 @@ class LightcurveBandData:
             if magnitudes_in:
                 lc[:, 1] = mag2flux(lc[:, 1])
 
+            # Persist potential shape/value updates back to the stored lightcurve.
+            self.lightcurves[filter] = lc
+
         # Store the minimum and maximum times for each light curve. This is done after
         # validating periodicity in case we needed to adjust the light curve start times.
         if periodic:
@@ -247,8 +250,8 @@ class LightcurveBandData:
         if filters is None:
             filters = filter_cols
         else:
-            to_keep = set(filter_cols) & set(filters)
-            filters = list(to_keep)
+            # Keep caller-provided filter order while selecting only available columns.
+            filters = [filter_name for filter_name in filters if filter_name in filter_cols]
         if len(filters) == 0:
             raise ValueError("Light curves table must have at least one filter column.")
 

--- a/tests/lightcurvelynx/models/test_lightcurve_template_model.py
+++ b/tests/lightcurvelynx/models/test_lightcurve_template_model.py
@@ -97,6 +97,30 @@ def test_create_lightcurve_band_data_from_dict() -> None:
         _ = LightcurveBandData(lightcurves, lc_data_t0=None)
 
 
+def test_create_lightcurve_band_data_from_dict_with_error_column_persists_updates() -> None:
+    """Regression test: when dict lightcurves include an error column, the normalized
+    2-column representation must be written back to the stored arrays.
+    """
+    times = np.array([1.0, 2.0, 3.0])
+    mags = np.array([20.0, 21.0, 22.0])
+    errs = np.array([0.1, 0.1, 0.1])
+    lightcurves = {
+        "u": np.column_stack((times, mags, errs)),
+    }
+
+    lc_data = LightcurveBandData(
+        lightcurves,
+        lc_data_t0=1.0,
+        magnitudes_in=True,
+        baseline={"u": 25.0},
+    )
+
+    # The internal lightcurve must be 2 columns with transformed values persisted.
+    assert lc_data.lightcurves["u"].shape == (3, 2)
+    assert np.allclose(lc_data.lightcurves["u"][:, 0], np.array([0.0, 1.0, 2.0]))
+    assert np.allclose(lc_data.lightcurves["u"][:, 1], mag2flux(mags))
+
+
 def test_create_lightcurve_band_data_periodic_from_dict() -> None:
     """Test that we can create a periodic LightcurveBandData object from a dict."""
     times = np.linspace(3, 13, 20)


### PR DESCRIPTION
Fixes a small error with the `LightcurveBandData` where the error column is only dropped in a local variable. This does not break anything now, but could cause unexpected behavior in the future.