### PR TITLE
Small fixes

### DIFF
--- a/src/lightcurvelynx/astro_utils/black_body.py
+++ b/src/lightcurvelynx/astro_utils/black_body.py
@@ -31,7 +31,13 @@ def black_body_luminosity_density_per_solid(temperature, radius, wavelengths):
     """
     black_body = BlackBody(temperature * u.K)
     # Convert intensity to units compatible with nJy flux density
-    intensity_per_freq = black_body(wavelengths * u.cm).to_value(u.erg / u.s / u.cm**2 / u.Hz / u.steradian)
+    with np.errstate(over="ignore", invalid="ignore", under="ignore"):
+        intensity_per_freq = black_body(wavelengths * u.cm).to_value(
+            u.erg / u.s / u.cm**2 / u.Hz / u.steradian
+        )
+    # In the Wien tail, finite-precision evaluation can overflow in intermediate
+    # expm1 calculations; physically this corresponds to near-zero intensity.
+    intensity_per_freq = np.nan_to_num(intensity_per_freq, nan=0.0, posinf=0.0, neginf=0.0)
     # Integral over solid angle, on surface of sphere
     surface_flux = intensity_per_freq * np.pi
     # Multiply to total area (4pi r^2) and divide by 4pi steradians,

--- a/src/lightcurvelynx/astro_utils/coordinate_utils.py
+++ b/src/lightcurvelynx/astro_utils/coordinate_utils.py
@@ -70,7 +70,7 @@ def dedup_coords(ra, dec, threshold=1e-5):
     """
     ra = np.asarray(ra)
     dec = np.asarray(dec)
-    if len(ra) != len(dec):
+    if np.size(ra) != np.size(dec):
         raise ValueError("RA and Dec arrays must have the same length.")
 
     # Create a KD-tree for efficient nearest neighbor search.

--- a/src/lightcurvelynx/astro_utils/coordinate_utils.py
+++ b/src/lightcurvelynx/astro_utils/coordinate_utils.py
@@ -68,6 +68,11 @@ def dedup_coords(ra, dec, threshold=1e-5):
     unique_indices: numpy.ndarray
         Indices of the unique coordinates in the original arrays.
     """
+    ra = np.asarray(ra)
+    dec = np.asarray(dec)
+    if len(ra) != len(dec):
+        raise ValueError("RA and Dec arrays must have the same length.")
+
     # Create a KD-tree for efficient nearest neighbor search.
     x, y, z = ra_dec_to_cartesian(ra, dec)
     cart_coords = np.array([x, y, z]).T

--- a/tests/lightcurvelynx/astro_utils/test_coordinate_utils.py
+++ b/tests/lightcurvelynx/astro_utils/test_coordinate_utils.py
@@ -50,6 +50,10 @@ def test_dedup_coords():
     np.testing.assert_allclose(unique_ra, pts[expected_inds, 0], atol=1e-8)
     np.testing.assert_allclose(unique_dec, pts[expected_inds, 1], atol=1e-8)
 
+    # We fail if the lists are different lengths.
+    with pytest.raises(ValueError):
+        dedup_coords([0, 1], [0])  # Mismatched lengths
+
 
 def test_build_moc_from_coords():
     """Test building a MOC from coordinates."""

--- a/tests/lightcurvelynx/models/test_sncosmo_models.py
+++ b/tests/lightcurvelynx/models/test_sncosmo_models.py
@@ -70,7 +70,7 @@ def test_sncosmo_models_hsiao_t0() -> None:
     assert np.allclose(fluxes_flam, [67.83696271, 67.98471119, 47.20395186])
 
     # We raise a warning if the time is outside the bounds.
-    with np.testing.assert_warns(UserWarning):
+    with pytest.warns(UserWarning):
         model.evaluate_sed([0.0], [4000.0, 4100.0])
 
 


### PR DESCRIPTION
Fix three warnings in the tests:
- Overflow in the blackbody calculations
- Deprecation warning for numpy warns
Also add a length check on `dedup_coords`
