### PR TITLE
Clarify error messages in parallel_runs notebook

### DIFF
--- a/docs/notebooks/parallel_runs.ipynb
+++ b/docs/notebooks/parallel_runs.ipynb
@@ -12,7 +12,7 @@
     "\n",
     "Note:\n",
     "  * Each process will load a full version of all the data, so they may be memory intensive.\n",
-    "  * In some cases, the default parallelization approach may fail with a `PickleError`. In such cases, we recommend using a third-party library such as Loky, Dask, or Ray; see the examples below."
+    "  * In some cases, the default parallelization approach may fail with a `PickleError` or something like `AttributeError: Can't get attribute 'XXX' on <module '__main__' (built-in)>`. In such cases, we recommend using a third-party library such as Loky, Dask, or Ray; see the examples below."
    ]
   },
   {


### PR DESCRIPTION
Rendered: https://lightcurvelynx--821.org.readthedocs.build/en/821/notebooks/parallel_runs.html?readthedocs-diff=true&readthedocs-diff-chunk=1