### PR TITLE
Fix broken test

### DIFF
--- a/docs/notebooks/pre_executed/using_pzflow.ipynb
+++ b/docs/notebooks/pre_executed/using_pzflow.ipynb
@@ -107,7 +107,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -210,7 +210,7 @@
     }
    ],
    "source": [
-    "flow_from_file = Flow(file=\"../../../tests/lightcurvelynx/data/test_flow.pkl\")\n",
+    "flow_from_file = Flow.from_file(\"../../../tests/lightcurvelynx/data/test_flow.pkl\")\n",
     "flow_from_file.sample(nsamples=10)"
    ]
   },
@@ -428,7 +428,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "lightcurvelynx",
+   "display_name": "lightcurvelynx (3.13.8)",
    "language": "python",
    "name": "python3"
   },
@@ -442,7 +442,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.4"
+   "version": "3.13.8"
   }
  },
  "nbformat": 4,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ dev = [
     "pre-commit", # Used to run checks before finalizing a git commit
     "pytest",
     "pytest-cov", # Used to report total code coverage
-    "pzflow",
+    "pzflow>=4.0",
     "ruff", # Used for static linting of files
     "sncosmo",
     "synphot", # Used for SED modeling tests
@@ -68,7 +68,7 @@ all = [
     "jax",
     "lsdb",  # Used to read and write LSDB catalogs
     "networkx",  # Used for graph visualization
-    "pzflow",
+    "pzflow>=4.0",
     "sncosmo",
     "synphot",  # used for SED modeling tests
     "VBMicrolensing",  # used for microlensing tests

--- a/src/lightcurvelynx/astro_utils/pzflow_node.py
+++ b/src/lightcurvelynx/astro_utils/pzflow_node.py
@@ -69,7 +69,7 @@ class PZFlowNode(FunctionNode, CiteClass):
                 "`pip install pzflow` or `conda install conda-forge::pzflow`."
             ) from err
 
-        flow_to_use = Flow(file=filename)
+        flow_to_use = Flow.from_file(filename)
         return PZFlowNode(flow_to_use, node_label=node_label, **kwargs)
 
     def compute(self, graph_state, rng_info=None, **kwargs):


### PR DESCRIPTION
One of the pzflow tests is failing due to a change in the API. Replace the constructor with `file` argument with the `from_file` class method.