### PR TITLE
Switch the FiveSigmaDepthNoiseModel to use AB magnitudes only

### DIFF
--- a/src/lightcurvelynx/noise_models/base_noise_models.py
+++ b/src/lightcurvelynx/noise_models/base_noise_models.py
@@ -2,6 +2,7 @@ from abc import ABC, abstractmethod
 
 import numpy as np
 
+from lightcurvelynx.astro_utils.mag_flux import mag2flux
 from lightcurvelynx.noise_models.noise_utils import poisson_bandflux_std
 
 
@@ -314,9 +315,8 @@ class GivenNoiseModel(FluxNoiseModel):
 class FiveSigmaDepthNoiseModel(FluxNoiseModel):
     """A noise model that simulates photon noise from only the five-sigma depth information.
 
-    It requires two pieces of information from the ObsTable:
-    - five_sigma_depth: The five-sigma depth in magnitudes.
-    - bandflux_ref: A reference bandflux in the same units as the input bandflux
+    This noise model uses the following values from the ObsTable:
+    - five_sigma_depth: The five-sigma depth in AB magnitudes.
 
     Note
     ----
@@ -324,7 +324,7 @@ class FiveSigmaDepthNoiseModel(FluxNoiseModel):
     only the five-sigma depth is available in the ObsTable.
     """
 
-    _required_values = ["five_sigma_depth", "bandflux_ref"]
+    _required_values = ["five_sigma_depth"]
 
     def __init__(self):
         pass
@@ -373,10 +373,10 @@ class FiveSigmaDepthNoiseModel(FluxNoiseModel):
         if len(indices) != len(bandflux):
             raise ValueError("Length of indices must match length of bandflux.")
 
+        # Compute the standard deviation of the noise from the five-sigma depth information.
+        # This uses five_sigma_depth in AB magnitudes, so we convert it to bandflux in nJy first.
         five_sigma_depth = obs_table.get_value_per_row("five_sigma_depth", indices=indices)
-        bandflux_ref = obs_table.get_value_per_row("bandflux_ref", indices=indices)
-        flux_five_sigma = bandflux_ref * np.power(10.0, -0.4 * five_sigma_depth)
-        flux_err = flux_five_sigma / 5.0
+        flux_err = mag2flux(five_sigma_depth) / 5.0
 
         # Generate the actual noisy bandflux measurements.
         rng = np.random.default_rng(rng)

--- a/tests/lightcurvelynx/noise_models/test_base_noise_models.py
+++ b/tests/lightcurvelynx/noise_models/test_base_noise_models.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from lightcurvelynx.astro_utils.mag_flux import mag2flux
 from lightcurvelynx.noise_models.base_noise_models import (
     ConstantFluxNoiseModel,
     FiveSigmaDepthNoiseModel,
@@ -278,7 +279,7 @@ def test_five_sigma_depth_noise_model():
     """Test that the FiveSigmaDepthNoiseModel correctly computes flux errors
     and applies noise to the bandflux."""
     model = FiveSigmaDepthNoiseModel()
-    assert set(model.required_values) == {"five_sigma_depth", "bandflux_ref"}
+    assert set(model.required_values) == {"five_sigma_depth"}
 
     table_values = {
         "time": np.array([0.0, 1.0, 2.0, 3.0, 4.0]),
@@ -287,12 +288,7 @@ def test_five_sigma_depth_noise_model():
         "filter": np.array(["r", "g", "r", "i", "g"]),
         "five_sigma_depth": 20.0 + np.arange(5),
     }
-    bandflux_ref = {"g": 3630e6, "r": 3635e6, "i": 3625e6}
-    const_values = {
-        "pixel_scale": 0.2,
-        "bandflux_ref": bandflux_ref,
-    }
-    ops_data = LookupOnlyObsTable(table_values=table_values, const_values=const_values)
+    ops_data = LookupOnlyObsTable(table_values=table_values)
     assert len(ops_data) == 5
 
     # Create and apply the noise model.
@@ -309,8 +305,5 @@ def test_five_sigma_depth_noise_model():
     )
     assert not np.any(bandflux == flux)
 
-    bandflux_ref_arr = np.array([bandflux_ref[filt] for filt in ops_data["filter"]])
-    expected_bandflux_error = (
-        bandflux_ref_arr * np.power(10.0, -0.4 * ops_data["five_sigma_depth"].to_numpy()) / 5.0
-    )
+    expected_bandflux_error = mag2flux(ops_data["five_sigma_depth"].to_numpy()) / 5.0
     assert np.allclose(flux_err, expected_bandflux_error)


### PR DESCRIPTION
Closes #827

Change the `FiveSigmaDepthNoiseModel` from using arbitrary systems to AB magnitudes only to be consistent with the rest of LightCurveLynx (where everything is in AB magnitudes).
