### PR TITLE
Fix broken indexing after filtering with a mask

### DIFF
--- a/src/lightcurvelynx/obstable/argus_obstable.py
+++ b/src/lightcurvelynx/obstable/argus_obstable.py
@@ -106,7 +106,7 @@ class ArgusHealpixObsTable(ObsTable):
         # The table uses the healpix IDs as the index. We bring this into its own column for easier access
         # and reset the indices.
         if "healpix" in table.columns:
-            table.reset_index(inplace=True)  # Just reset the index if healpix is already a column.
+            table = table.reset_index()  # Just reset the index if healpix is already a column.
         elif table.index.name in ["healpix_id", "healpix"]:
             table = table.rename(columns={table.index.name: "healpix"}).reset_index()
         else:

--- a/src/lightcurvelynx/obstable/argus_obstable.py
+++ b/src/lightcurvelynx/obstable/argus_obstable.py
@@ -106,9 +106,9 @@ class ArgusHealpixObsTable(ObsTable):
         # The table uses the healpix IDs as the index. We bring this into its own column for easier access
         # and reset the indices.
         if "healpix" in table.columns:
-            table = table.reset_index()  # Just reset the index if healpix is already a column.
+            table.reset_index(inplace=True)  # Just reset the index if healpix is already a column.
         elif table.index.name in ["healpix_id", "healpix"]:
-            table = table.reset_index().rename(columns={table.index.name: "healpix"})
+            table = table.rename(columns={table.index.name: "healpix"}).reset_index()
         else:
             raise ValueError(
                 "The input table must have healpix IDs as the index or in a column named 'healpix'."

--- a/src/lightcurvelynx/obstable/obs_table.py
+++ b/src/lightcurvelynx/obstable/obs_table.py
@@ -691,6 +691,7 @@ class ObsTable:
 
         # Filter the rows in-place and build a new spatial data structure.
         self._table = self._table[mask]
+        self._table.reset_index(drop=True, inplace=True)  # Reset the indices after filtering
         self._spatial_data = None
         self._build_spatial_data()
 

--- a/src/lightcurvelynx/obstable/obs_table.py
+++ b/src/lightcurvelynx/obstable/obs_table.py
@@ -689,9 +689,9 @@ class ObsTable:
             mask = np.full((len(self._table),), False)
             mask[rows] = True
 
-        # Filter the rows in-place and build a new spatial data structure.
-        self._table = self._table[mask]
-        self._table.reset_index(drop=True, inplace=True)  # Reset the indices after filtering
+        # Filter the rows. Build a new spatial data structure and list of filters.
+        self._table = self._table[mask].reset_index(drop=True)
+        self.filters = np.unique(self._table["filter"]) if "filter" in self._table.columns else np.array([])
         self._spatial_data = None
         self._build_spatial_data()
 

--- a/tests/lightcurvelynx/obstable/test_obs_table.py
+++ b/tests/lightcurvelynx/obstable/test_obs_table.py
@@ -323,6 +323,7 @@ def test_obs_table_filter_rows():
     assert np.allclose(ops_data["ra"], 15.0 * (expected_times + 1.0))
     assert np.allclose(ops_data["dec"], -1.0 * expected_times)
     assert np.all(ops_data["filter"] == "r")
+    assert set(ops_data.filters) == set(["r"])
 
     # Check that the indices have been reset and that get_value_per_row() works with the new indices.
     assert np.array_equal(ops_data._table.index, np.arange(len(ops_data)))

--- a/tests/lightcurvelynx/obstable/test_obs_table.py
+++ b/tests/lightcurvelynx/obstable/test_obs_table.py
@@ -324,6 +324,10 @@ def test_obs_table_filter_rows():
     assert np.allclose(ops_data["dec"], -1.0 * expected_times)
     assert np.all(ops_data["filter"] == "r")
 
+    # Check that the indices have been reset and that get_value_per_row() works with the new indices.
+    assert np.array_equal(ops_data._table.index, np.arange(len(ops_data)))
+    assert np.allclose(ops_data.get_value_per_row("time"), expected_times)
+
     # Check that the size of the internal KD-tree has changed (again).
     assert ops_data._spatial_data.n == 4
 


### PR DESCRIPTION
The ObsTable does not correctly update the indices after mask filtering, which can cause `get_value_per_row` to fail.
