### PR TITLE
Add type checking in range_search

### DIFF
--- a/src/lightcurvelynx/obstable/obs_table.py
+++ b/src/lightcurvelynx/obstable/obs_table.py
@@ -772,17 +772,21 @@ class ObsTable:
 
         # If the points are scalars, make them into length 1 arrays.
         is_scalar = np.isscalar(query_ra) and np.isscalar(query_dec)
-        query_ra = np.atleast_1d(query_ra)
-        query_dec = np.atleast_1d(query_dec)
+        try:
+            query_ra = np.atleast_1d(query_ra).astype(float)
+            query_dec = np.atleast_1d(query_dec).astype(float)
+        except ValueError as err:
+            raise ValueError("Query RA and Dec must be convertible to float.") from err
 
-        # Confirm the query RA and Dec have the same length.
+        # Confirm the query RA and Dec are each 1-d and have the same length.
+        if query_ra.ndim != 1 or query_dec.ndim != 1:
+            raise ValueError("Query RA and Dec must be 1-dimensional arrays.")
         if len(query_ra) != len(query_dec):
             raise ValueError("Query RA and Dec must have the same length.")
 
-        # Check that there are no None values in the query. We use == to do
-        # an element-wise comparison.
-        if np.any(query_ra == None) or np.any(query_dec == None):  # noqa: E711
-            raise ValueError("Query RA and dec cannot contain None.")
+        # Check that there are no NaN values in the query (Nones are converted to NaN above).
+        if np.any(np.isnan(query_ra)) or np.any(np.isnan(query_dec)):
+            raise ValueError("Query RA and Dec cannot contain NaN.")
 
         # Transform the query point(s) to 3-d Cartesian coordinate(s).
         x, y, z = ra_dec_to_cartesian(query_ra, query_dec)

--- a/tests/lightcurvelynx/obstable/test_obs_table.py
+++ b/tests/lightcurvelynx/obstable/test_obs_table.py
@@ -495,13 +495,23 @@ def test_obs_table_range_search():
 
     # Test that we fail if bad query arrays are provided.
     with pytest.raises(ValueError):
+        # Nones.
         _ = ops_data.range_search(None, None, radius=0.5)
     with pytest.raises(ValueError):
+        # Mismatched sizes.
         _ = ops_data.range_search([1.0, 2.3], 4.5, radius=0.5)
     with pytest.raises(ValueError):
+        # Mismatched sizes.
         _ = ops_data.range_search([1.0, 2.3], [4.5, 6.7, 8.9], radius=0.5)
     with pytest.raises(ValueError):
+        # A None in a list.
         _ = ops_data.range_search([1.0, 2.3], [4.5, None], radius=0.5)
+    with pytest.raises(ValueError):
+        # Arrays of lists.
+        _ = ops_data.is_observed([[1.0, 2.3], [1.0, 2.3]], [[4.5, 6.7], [8.9, 10.11]], radius=0.5)
+    with pytest.raises(ValueError):
+        # Can't convert to float.
+        _ = ops_data.range_search(["not_a_number", 2.0], [4.5, 6.7], radius=0.5)
 
 
 def test_obs_table_get_observations():


### PR DESCRIPTION
This catches an error Sam was having when accidentally passing lists of lists into range_search (via the parameter setters earlier). This should produce a much easier to understand error for this type of mistake.
