### PR TITLE
Make get_value_per_row robust to index changes

### DIFF
--- a/src/lightcurvelynx/obstable/obs_table.py
+++ b/src/lightcurvelynx/obstable/obs_table.py
@@ -307,9 +307,9 @@ class ObsTable:
 
         # Prioritize columns that are in the table.
         if key in self._table.columns:
-            return self._table[key][indices].to_numpy()
+            return self._table[key].iloc[indices].to_numpy()
         if key in self._inv_colmap and self._inv_colmap[key] in self._table.columns:
-            return self._table[self._inv_colmap[key]][indices].to_numpy()
+            return self._table[self._inv_colmap[key]].iloc[indices].to_numpy()
 
         # Otherwise fall back to the survey values if they are defined.
         value = self.survey_values.get(key, None)
@@ -324,7 +324,7 @@ class ObsTable:
             for fil, val in value.items():
                 if fil not in self.filters:
                     raise ValueError(f"Dictionary for '{key}' does not have a value for filter '{fil}'")
-                result[self._table["filter"][indices] == fil] = val
+                result[self._table["filter"].iloc[indices] == fil] = val
             return result
         raise TypeError(f"Unsupported type for '{key}': {type(value)}")
 


### PR DESCRIPTION
When we switched the noise functions to use `get_value_per_row` instead of creating a subset copy of the full table, it broke some of the filtering because `get_value_per_row` used indexing instead of iloc. This switched ``get_value_per_row`` to use iloc, so it should be more robust to dropping rows.
