### PR TITLE
Add a second batch of tests

### DIFF
--- a/src/lightcurvelynx/obstable/obs_table.py
+++ b/src/lightcurvelynx/obstable/obs_table.py
@@ -182,9 +182,8 @@ class ObsTable:
         # Save the noise model.
         self.noise_model = noise_model
 
-        # Build the kd-tree (or other spatial data structure).
-        self._spatial_data = None
-        self._build_spatial_data()
+        # Update all of the cached data.
+        self._update_cached_data()
 
         # Create the footprint if one is provided.
         if detector_footprint is not None:
@@ -321,10 +320,10 @@ class ObsTable:
         if isinstance(value, dict):
             # Map the values for each filter to the rows in the table.
             result = np.zeros(len(indices), dtype=float)
-            for fil, val in value.items():
-                if fil not in self.filters:
-                    raise ValueError(f"Dictionary for '{key}' does not have a value for filter '{fil}'")
-                result[self._table["filter"].iloc[indices] == fil] = val
+            for filt in self.filters:
+                if filt not in value:
+                    raise ValueError(f"Dictionary for '{key}' does not have a value for filter '{filt}'")
+                result[self._table["filter"].iloc[indices] == filt] = value[filt]
             return result
         raise TypeError(f"Unsupported type for '{key}': {type(value)}")
 
@@ -559,6 +558,21 @@ class ObsTable:
         fig, ax = plot_moc(moc, fig=fig, ax=ax, **kwargs)
         return fig, ax
 
+    def _update_cached_data(self):
+        """Update any cached data based on the current table and survey values.
+        This can be used any time the underlying table is updated, such as when rows
+        are filtered.
+        """
+        # Reset the index column if it exists.
+        self._table = self._table.reset_index(drop=True)
+
+        # Rebuild the list of filters.
+        self.filters = np.unique(self._table["filter"]) if "filter" in self._table.columns else np.array([])
+
+        # Build the kd-tree (or other spatial data structure).
+        self._spatial_data = None
+        self._build_spatial_data()
+
     def _build_spatial_data(self):
         """Construct the KD-tree from the ObsTable."""
         # Convert the pointings to Cartesian coordinates on a unit sphere.
@@ -689,11 +703,9 @@ class ObsTable:
             mask = np.full((len(self._table),), False)
             mask[rows] = True
 
-        # Filter the rows. Build a new spatial data structure and list of filters.
-        self._table = self._table[mask].reset_index(drop=True)
-        self.filters = np.unique(self._table["filter"]) if "filter" in self._table.columns else np.array([])
-        self._spatial_data = None
-        self._build_spatial_data()
+        # Filter the rows. Update all of the cached data.
+        self._table = self._table[mask]
+        self._update_cached_data()
 
         return self
 

--- a/src/lightcurvelynx/obstable/ztf_obstable.py
+++ b/src/lightcurvelynx/obstable/ztf_obstable.py
@@ -134,6 +134,7 @@ class ZTFObsTable(ObsTable):
         # replace invalid values in table
         self._table = self._table.replace("", np.nan)
         self._table = self._table.dropna(subset=["fwhm_px"])
+        self._table = self._table.reset_index(drop=True)
 
         # Compute the sky background in electrons/pixel if not already present.
         if "sky_bg_e" not in self and "sky_adu" in self and "gain" in self:

--- a/tests/lightcurvelynx/obstable/test_lsst_obstable.py
+++ b/tests/lightcurvelynx/obstable/test_lsst_obstable.py
@@ -134,17 +134,31 @@ def test_lsst_obstable_from_ccdvisit():
 def test_lsst_obstable_from_sv_visits():
     """Test that we can read an LSSTObsTable from the SV visits table."""
     values = {
-        "exp_midpt_mjd": np.array([0.0, 1.0, 2.0, 3.0, 4.0]),
-        "fieldRA": np.array([15.0, 30.0, 15.0, 0.0, 60.0]),
-        "fieldDec": np.array([-10.0, -5.0, 0.0, 5.0, 10.0]),
-        "sky_bg_median": np.ones(5),
-        "zero_point_median": 25.0 * np.ones(5),
+        "exp_midpt_mjd": np.array([0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0]),
+        "fieldRA": np.array([15.0, 30.0, 15.0, 0.0, 60.0, 15.0, 30.0, 15.0]),
+        "fieldDec": np.array([-10.0, -5.0, 0.0, 5.0, 10.0, 15.0, 20.0, 25.0]),
+        "sky_bg_median": np.ones(8),
+        "zero_point_median": 25.0 * np.ones(8),
+        "filter": np.array(["a", "b", "c", "d", "e", "f", "g", "h"]),
     }
     pdf = pd.DataFrame(values)
 
+    # Make one of the sky_bg_median and one of the zero_point_median values NaN
+    # to test that we can handle missing data.
+    pdf.loc[2, "sky_bg_median"] = np.nan
+    pdf.loc[4, "zero_point_median"] = np.nan
+
     ops_data = LSSTObsTable.from_sv_visits_table(pdf)
-    assert len(ops_data) == 5
+    assert len(ops_data) == 6
     assert ops_data.radius == pytest.approx(1.75)
+
+    # Check that we updated the indices and filters correctly.
+    assert np.allclose(
+        ops_data.get_value_per_row("time", indices=[0, 1, 2, 3, 5]),
+        [0.0, 1.0, 3.0, 5.0, 7.0],
+    )
+    assert set(ops_data.filters) == set(["a", "b", "d", "f", "g", "h"])
+    assert ops_data._spatial_data.n == 6
 
 
 def test_lsst_noise_model_delegation():

--- a/tests/lightcurvelynx/obstable/test_obs_table.py
+++ b/tests/lightcurvelynx/obstable/test_obs_table.py
@@ -36,6 +36,12 @@ def test_create_obs_table():
     assert ops_data.survey_values["zp_per_sec"] is None
     assert ops_data.survey_values["survey_name"] == "Unknown"
 
+    # We can use get item to access rows and survey values.
+    assert np.allclose(ops_data["ra"], values["ra"])
+    assert ops_data["survey_name"] == "Unknown"
+    with pytest.raises(KeyError):
+        _ = ops_data["non_existent_column"]
+
     # Check that we can extract the time bounds.
     t_min, t_max = ops_data.time_bounds()
     assert t_min == 0.0
@@ -149,6 +155,10 @@ def test_create_obs_table_override():
     ops_data2.radius = 5.0
     assert ops_data2.survey_values["radius"] == 5.0
 
+    # If we try to set a bad radius value, we get an error.
+    with pytest.raises(ValueError):
+        ops_data2.radius = -1.0
+
 
 def test_create_obs_table_custom_names():
     """Create a minimal ObsTable object from alternate column names."""
@@ -220,6 +230,71 @@ def test_obs_table_copy():
     ops_data_copy._table["ra"] += 10.0
     assert np.allclose(ops_data_copy["ra"], values["ra"] + 10.0)
     assert np.allclose(ops_data["ra"], values["ra"])
+
+
+def test_get_value_per_row():
+    """Test that we can override the default obs table values."""
+    values = {
+        "time": np.array([0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0]),
+        "ra": np.array([15.0, 30.0, 15.0, 0.0, 60.0, 45.0, 30.0, 15.0]),
+        "dec": np.array([-10.0, -5.0, 0.0, 5.0, 10.0, 15.0, 20.0, 25.0]),
+        "renamed": np.array([5.0, 4.0, 3.0, 2.0, 1.0, 0.0, -1.0, -2.0]),
+        "zp": np.ones(8),
+        "filter": np.array(["r", "g", "r", "i", "g", "r", "i", "g"]),
+    }
+    ops_data = ObsTable(
+        values,
+        dark_current=0.1,
+        ext_coeff={"u": 0.1, "g": 0.2, "r": 0.3, "i": 0.4, "z": 0.5, "y": 0.6},
+        pixel_scale=0.1,
+        radius=1.0,
+        read_noise=None,
+        other_value="STRING",
+        zp_per_sec={"u": 25.0, "g": 26.0, "r": 27.0, "i": 28.0, "z": 29.0, "y": 30.0},
+        bad_mapping={"a": 1.0, "b": 2.0, "r": 3.0},
+        colmap={"custom_col": "renamed"},
+    )
+
+    # We can get the value per row for a column (including renamed ones).
+    assert np.allclose(ops_data.get_value_per_row("ra"), values["ra"])
+    assert np.allclose(ops_data.get_value_per_row("dec"), values["dec"])
+    assert np.allclose(ops_data.get_value_per_row("custom_col"), values["renamed"])
+
+    # We can provide indices.
+    inds = [0, 2, 4, 6]
+    assert np.allclose(ops_data.get_value_per_row("ra", indices=inds), values["ra"][inds])
+    assert np.allclose(
+        ops_data.get_value_per_row("custom_col", indices=inds),
+        values["renamed"][inds],
+    )
+
+    # We can get a constant from the survey values.
+    assert np.allclose(ops_data.get_value_per_row("dark_current"), np.full(len(ops_data), 0.1))
+    assert np.allclose(
+        ops_data.get_value_per_row("dark_current", indices=inds),
+        np.full(len(inds), 0.1),
+    )
+
+    # If we look up a dictionary, map the values using the filter column.
+    assert np.allclose(
+        ops_data.get_value_per_row("ext_coeff"), np.array([0.3, 0.2, 0.3, 0.4, 0.2, 0.3, 0.4, 0.2])
+    )
+    assert np.allclose(
+        ops_data.get_value_per_row("ext_coeff", indices=inds),
+        np.array([0.3, 0.2, 0.3, 0.4, 0.2, 0.3, 0.4, 0.2])[inds],
+    )
+
+    # We fail if we have a dictionary that doesn't have all the needed filters.
+    with pytest.raises(ValueError):
+        _ = ops_data.get_value_per_row("bad_mapping")
+
+    # If we look up a value that isn't there we return either None of the given default.
+    assert all(ops_data.get_value_per_row("non_existent_col") == None)  # noqa: E711
+    assert all(ops_data.get_value_per_row("non_existent_col", default=5.0) == 5.0)
+
+    # We don't know how to handle strings.
+    with pytest.raises(TypeError):
+        _ = ops_data.get_value_per_row("other_value")
 
 
 def test_obs_table_add_columns():

--- a/tests/lightcurvelynx/obstable/test_opsim.py
+++ b/tests/lightcurvelynx/obstable/test_opsim.py
@@ -533,6 +533,10 @@ def test_create_random_opsim():
     opsim = create_random_opsim(1000)
     assert len(opsim) == 1000
 
+    # We fail if we try to create an opsim with a non-positive number of rows.
+    with pytest.raises(ValueError):
+        _ = create_random_opsim(0)
+
 
 def test_oversample_opsim(opsim_shorten):
     """Test that we can oversample an OpSim file."""

--- a/tests/lightcurvelynx/obstable/test_skymapper_obstable.py
+++ b/tests/lightcurvelynx/obstable/test_skymapper_obstable.py
@@ -28,6 +28,7 @@ def test_skymapper_obstable_init():
     assert isinstance(obs_table.noise_model, PoissonFluxNoiseModel)
 
     assert "zp" in obs_table
+    assert "psf_footprint" in obs_table
     assert np.allclose(survey_data["ra_deg"], obs_table["ra"])
     assert np.allclose(survey_data["dec_deg"], obs_table["dec"])
     assert np.allclose(survey_data["mjd_midpt"], obs_table["time"])
@@ -55,3 +56,40 @@ def test_skymapper_obstable_init():
     # We can build a MOC at level 14
     moc = obs_table.build_moc(max_depth=14)
     assert moc.flatten().size == 5
+
+
+def test_skymapper_obstable_init_alt():
+    """Test initializing SkyMapperObsTable with alternative parameters."""
+    survey_data = {
+        "image_id": [20180101162801, 20171215114730, 20171222125008, 20171222142830, 20171223140648],
+        "ccd": [25, 32, 29, 32, 29],
+        "ra_deg": [314.32684, 310.79913, 311.33861, 312.05752, 310.9527],
+        "dec_deg": [-86.77332, -88.21006, -88.16419, -88.24684, -88.18184],
+        "pa_deg": [300.0, 180.0, 90.0, 180.0, 90.0],
+        "filter": ["r", "g", "g", "r", "v"],
+        "mjd_midpt": [58119.6863, 58102.4915, 58109.5351, 58109.6033, 58110.5882],
+        "exp_time": [30.0, 30.0, 30.0, 30.0, 30.0],
+        "zp_mag_e": [26.979, 27.103, 27.176, 27.054, 24.444],
+        "sb_mag": [17.894, 21.522, 21.506, 20.941, 22.176],
+        "seeing": [2.77, 3.62, 3.34, 2.94, 3.89],
+        "elong": [1.109, 1.121, 1.081, 1.07, 1.077],
+    }
+    survey_data_table = pd.DataFrame(survey_data)
+    obs_table = SkyMapperObsTable(table=survey_data_table, make_detector_footprint=False)
+
+    # We compute zero point from the zp_mag_e column.
+    assert "zp" in obs_table
+    assert np.allclose(obs_table["zp"], mag2flux(survey_data_table["zp_mag_e"]))
+
+    # We can derive psf_footprint from the seeing column.
+    assert "psf_footprint" in obs_table
+    assert np.all(obs_table["psf_footprint"] > 0.0)
+
+    # Replace the seeing column with the default per-filter mapping. The two reds and
+    # two greens should be close to each other.
+    survey_data_table = survey_data_table.drop(columns=["seeing"])
+    obs_table2 = SkyMapperObsTable(table=survey_data_table, make_detector_footprint=False)
+    assert "psf_footprint" in obs_table2
+    assert np.all(obs_table2["psf_footprint"] > 0.0)
+    assert np.isclose(obs_table2["psf_footprint"][0], obs_table2["psf_footprint"][3])  # Both reds
+    assert np.isclose(obs_table2["psf_footprint"][1], obs_table2["psf_footprint"][2])  # Both greens

--- a/tests/lightcurvelynx/obstable/test_ztf_obstable.py
+++ b/tests/lightcurvelynx/obstable/test_ztf_obstable.py
@@ -50,21 +50,40 @@ def test_create_ztf_obstable_no_zp():
         "2020-01-03 12:00:00.000",
         "2020-01-04 12:00:00.000",
         "2020-01-05 12:00:00.000",
+        "2020-01-06 12:00:00.000",
+        "2020-01-07 12:00:00.000",
+        "2020-01-08 12:00:00.000",
     ]
     values = {
         "obsdate": dates,
-        "ra": np.array([15.0, 30.0, 15.0, 0.0, 60.0]),
-        "dec": np.array([-10.0, -5.0, 0.0, 5.0, 10.0]),
+        "ra": np.array([15.0, 30.0, 15.0, 0.0, 60.0, 45.0, 30.0, 15.0]),
+        "dec": np.array([-10.0, -5.0, 0.0, 5.0, 10.0, 15.0, 20.0, 25.0]),
+        "filter": np.array(["r", "g", "r", "g", "i", "g", "r", "g"]),
     }
 
-    values["exptime"] = 0.005 * np.ones(5)
-    values["maglim"] = 20.0 * np.ones(5)
-    values["scibckgnd"] = np.ones(5)
-    values["fwhm"] = 2.3 * np.ones(5)
-    survey_data = ZTFObsTable(values)
+    values["exptime"] = 0.005 * np.ones(8)
+    values["maglim"] = 20.0 * np.ones(8)
+    values["scibckgnd"] = np.ones(8)
+    values["fwhm"] = 2.3 * np.ones(8)
 
+    # Make one of the fwhm values invalid to test that it gets dropped.
+    values["fwhm"][4] = np.nan
+
+    survey_data = ZTFObsTable(values)
+    assert len(survey_data) == 7  # One dropped value due to invalid fwhm.
+
+    # We derived the zeropoint column.
     assert "zp" in survey_data
     assert np.all(survey_data["zp"] >= 0.0)
+
+    # The indexing, filter list, and size of the spatial data structure are all
+    # correct after dropping the invalid value.
+    assert np.allclose(
+        survey_data.get_value_per_row("ra", indices=[0, 1, 2, 3, 4, 6]),
+        np.array([15.0, 30.0, 15.0, 0.0, 45.0, 15.0]),
+    )
+    assert set(survey_data.filters) == {"g", "r"}
+    assert survey_data._spatial_data.n == 7
 
 
 def test_noise_calculation():


### PR DESCRIPTION
Add a second batch of ObsTable-based tests and fix a few small bugs found in the process:
- The per-row dictionary mapping's check is backward (this only matters if the dictionary was missing elements).
- Reset the indices for the ZTF dropna

In addition this moves the different ObsTable update caching information (building a new KDTree, reseting indices, etc.) into a helper function so that users don't have to remember doing everything.
