### PR TITLE
Small Optimization for GraphState

### DIFF
--- a/src/lightcurvelynx/graph_state.py
+++ b/src/lightcurvelynx/graph_state.py
@@ -49,7 +49,8 @@ class GraphState:
         The total number of parameters stored in a single sample within GraphState.
     fixed_vars : dict
         A dictionary mapping the node name to a set of the variable names that
-        are fixed (not changed by resampling) in this GraphState instance.
+        are fixed (not changed by resampling) in this GraphState instance. Nodes are only
+        included if they have at least one fixed variable.
     sample_offset : int
         An optional offset to add to the graph state for any stateful nodes.
         Default: 0
@@ -452,15 +453,14 @@ class GraphState:
         if "." in node_name or "." in var_name:
             raise ValueError("GraphState names (node or variable) cannot contain the character '.'")
 
-        # Update the meta data.
+        # Update the meta data. We don't add an entry to fixed_vars until we need it.
         if node_name not in self.states:
             self.states[node_name] = {}
-            self.fixed_vars[node_name] = set()
         if var_name not in self.states[node_name]:
             self.num_parameters += 1
 
         # Check if this parameter is fixed. If so, skip the set.
-        if var_name in self.fixed_vars[node_name]:
+        if node_name in self.fixed_vars and var_name in self.fixed_vars[node_name]:
             return
 
         # Set the actual values.
@@ -480,8 +480,11 @@ class GraphState:
         else:
             self.states[node_name][var_name] = np.asarray(value)
 
-        # Mark the variable as fixed if needed.
+        # Mark the variable as fixed if needed. We create the entry for this node the
+        # first time we need it.
         if fixed:
+            if node_name not in self.fixed_vars:
+                self.fixed_vars[node_name] = set()
             self.fixed_vars[node_name].add(var_name)
 
     def update(self, inputs, force_copy=False, all_fixed=False):

--- a/tests/lightcurvelynx/test_graph_state.py
+++ b/tests/lightcurvelynx/test_graph_state.py
@@ -20,7 +20,7 @@ def test_create_single_sample_graph_state():
 
     state.set("a", "v1", 1.0)
     state.set("a", "v2", 2.0)
-    state.set("b", "v1", 3.0)
+    state.set("b", "v1", 3.0, fixed=True)
     assert len(state) == 3
     assert state["a"]["v1"] == 1.0
     assert state["a"]["v2"] == 2.0
@@ -85,10 +85,7 @@ def test_create_single_sample_graph_state():
     assert state["a"]["v1"] == 1.0
     assert state["a"]["v2"] == 2.0
     assert state["b"]["v1"] == 3.0
-
-    # Both nodes are in the fixed vars (empty sets).
-    assert len(new_state.fixed_vars) == 2
-    assert "a" in new_state.fixed_vars
+    assert len(new_state.fixed_vars) == 1  # "b.v1" should still be fixed
     assert "b" in new_state.fixed_vars
 
     # We can overwrite settings.
@@ -343,7 +340,7 @@ def test_graph_state_copy():
     state = GraphState()
     state.set("a", "v1", 1.0)
     state.set("a", "v2", 2.0)
-    state.set("b", "v1", 3.0)
+    state.set("b", "v1", 3.0, fixed=True)
 
     state2 = state.copy()
 
@@ -351,14 +348,14 @@ def test_graph_state_copy():
     assert state2.num_parameters == 3
     assert state2.sample_offset == 0
     assert state2.sample_idx is None
-    assert len(state2.fixed_vars) == 2  # empty set for each node
-    assert "a" in state2.fixed_vars
+    assert len(state2.fixed_vars) == 1  # Only a set for node "b"
+    assert len(state2.fixed_vars["b"]) == 1  # Only variable "v1" is fixed
     assert "b" in state2.fixed_vars
 
     # Test with single values.
     state2.set("a", "v1", 10.0)
     state2.set("a", "v2", 20.0)
-    state2.set("b", "v1", 30.0)
+    state2.set("b", "v1", 30.0)  # No effect since this variable is fixed.
 
     # State 1 is unchanged
     assert state["a"]["v1"] == 1.0
@@ -368,7 +365,7 @@ def test_graph_state_copy():
     # State 2 has the new values.
     assert state2["a"]["v1"] == 10.0
     assert state2["a"]["v2"] == 20.0
-    assert state2["b"]["v1"] == 30.0
+    assert state2["b"]["v1"] == 3.0  # No effect since this variable is fixed.
 
     # Test with arrays.
     state = GraphState(3, sample_offset=2)
@@ -380,7 +377,7 @@ def test_graph_state_copy():
     state2 = state.copy()
     assert state2.num_parameters == 3
     assert state2.sample_offset == 2
-    assert len(state2.fixed_vars) == 2  # empty set for each node
+    assert len(state2.fixed_vars) == 0  # No sets until needed.
 
     state2["a.v1"][1] = 10.0
     state2["a.v2"][0] = 20.0


### PR DESCRIPTION
Currently we are creating a bunch of empty sets in the GraphState for unfixed variables. This only creates a set if the node has at least one fixed variable. It should save a little memory and computation time.
