### PR TITLE
Allow programmatic access in 

### DIFF
--- a/docs/notebooks/lightcurve_source_demo.ipynb
+++ b/docs/notebooks/lightcurve_source_demo.ipynb
@@ -343,7 +343,7 @@
    "source": [
     "## Multi-Lightcurve Models\n",
     "\n",
-    "Users can also load in a series of light curves and randomly sample which light curve to use for each evaluation.  The `MultiLightcurveTemplateModel` class takes in a list of `LightcurveBandData` with information about each light curve's time range, values, periodicity, etc.\n",
+    "Users can also load in a series of light curves and randomly (or programmatically) sample which light curve to use for each evaluation.  The `MultiLightcurveTemplateModel` class takes in a list of `LightcurveBandData` with information about each light curve's time range, values, periodicity, etc. Below we show an example of random sampling. See the \"Simulating Known Objects\" section for an example of programmatic sampling.\n",
     "\n",
     "Unlike the `LightcurveTemplateModel` class, the `MultiLightcurveTemplateModel` class requires the user to provide the input as prepackaged `LightcurveBandData` objects.  Here we create a source that randomly samples from two light curves. The first is a non-periodic light curve in u and g.  The second is a periodic light curve in r and g.  We provide weights so second light curve is more likely to be sampled than the first."
    ]
@@ -399,11 +399,74 @@
     "state = source.sample_parameters(num_samples=10)\n",
     "print(f\"selected_lightcurve: {state['source']['selected_lightcurve']}\")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "89751f83",
+   "metadata": {},
+   "source": [
+    "## Simulating Known Objects\n",
+    "\n",
+    "As mentioned in the previous section, the `MultiLightcurveTemplateModel` model can be used to programmatically evaluate a series of light curves. We do this by providing the indices (in order) of the light curves that we want to evaluate. \n",
+    "\n",
+    "We can combine this approach with a `TableSampler` to sample a list of known light curves with other known parameters, such as position."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ec62e8e9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "from lightcurvelynx.math_nodes.given_sampler import TableSampler\n",
+    "\n",
+    "# Add a third light curve with r, g, u for the example.\n",
+    "lc3_times = np.arange(0.0, 11.5, 0.5)\n",
+    "lc3_lightcurves = {\n",
+    "    \"u\": np.array([lc3_times + 0.1, 2.0 * np.ones_like(lc3_times)]).T,\n",
+    "    \"g\": np.array([lc3_times, 3.0 * np.ones_like(lc3_times)]).T,\n",
+    "    \"r\": np.array([lc3_times, 1.0 * np.ones_like(lc3_times)]).T,\n",
+    "}\n",
+    "lc3_data = LightcurveBandData(lc3_lightcurves, lc_data_t0=0.0, baseline={\"u\": 0.1, \"g\": 0.2, \"r\": 0.3})\n",
+    "\n",
+    "# Create a TableSampler with the light curve index, ra, and dec. We use in_order=True to\n",
+    "# sample each row exactly once and in order.\n",
+    "table = pd.DataFrame(\n",
+    "    {\n",
+    "        \"lightcurve_index\": [0, 1, 2],\n",
+    "        \"ra\": [10.0, 20.0, 30.0],\n",
+    "        \"dec\": [-10.0, -20.0, -30.0],\n",
+    "    }\n",
+    ")\n",
+    "sampler = TableSampler(table, in_order=True)\n",
+    "\n",
+    "# Create the MultiLightcurveTemplateModel with parameters pulled from the TableSampler.\n",
+    "# For each sample the model with use the ra, dec, and light curve index from the same line.\n",
+    "source = MultiLightcurveTemplateModel(\n",
+    "    [lc1_data, lc2_data, lc3_data],\n",
+    "    passband_group,\n",
+    "    ra=sampler.ra,\n",
+    "    dec=sampler.dec,\n",
+    "    indices=sampler.lightcurve_index,\n",
+    "    t0=0.0,\n",
+    "    node_label=\"source\",\n",
+    ")\n",
+    "\n",
+    "# Note that we can sample *at most* 3 samples since there are only 3 lines in the table.\n",
+    "state = source.sample_parameters(num_samples=3)\n",
+    "for idx in range(3):\n",
+    "    print(\n",
+    "        f\"Sample {idx}: lightcurve_index={state['source']['selected_lightcurve'][idx]}, \"\n",
+    "        f\"ra={state['source']['ra'][idx]}, dec={state['source']['dec'][idx]}\",\n",
+    "    )"
+   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "lightcurvelynx",
+   "display_name": "lightcurvelynx (3.13.8)",
    "language": "python",
    "name": "python3"
   },
@@ -417,7 +480,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.4"
+   "version": "3.13.8"
   }
  },
  "nbformat": 4,

--- a/src/lightcurvelynx/math_nodes/given_sampler.py
+++ b/src/lightcurvelynx/math_nodes/given_sampler.py
@@ -80,7 +80,7 @@ class GivenValueList(FunctionNode):
 
     Attributes
     ----------
-    values : float, list, or numpy.ndarray
+    values : list or numpy.ndarray
         The values to return.
     next_ind : int
         The index of the next value.

--- a/src/lightcurvelynx/math_nodes/given_sampler.py
+++ b/src/lightcurvelynx/math_nodes/given_sampler.py
@@ -65,12 +65,18 @@ class BinarySampler(NumpyRandomFunc):
 
 class GivenValueList(FunctionNode):
     """A FunctionNode that returns given results for a single parameter
-    in the order in which they are provided.
+    in the order in which they are provided. This node can be used as either
+    stateful or stateless. If stateful, the node will keep track of the next index to
+    return and will return the values in order. If stateless, the node will always
+    return the first N values in the list.
 
     Note
     ----
-    This is a stateful node that keeps track of the next index to return
-    that cannot be used in parallel sampling.
+    The stateful version of this node does not support parallel sampling, because it keeps
+    track of a single index for the next value to return. If you need to use this node in
+    parallel sampling, you should set stateful=False, but be aware that this will cause the
+    node to always return the first N values in the list, where N is the number of samples
+    requested, instead of iterating through the list.
 
     Attributes
     ----------
@@ -78,18 +84,28 @@ class GivenValueList(FunctionNode):
         The values to return.
     next_ind : int
         The index of the next value.
+    stateful : bool
+        Whether this node is stateful. If True, the node will keep track of the next
+        index to return. If False, the node will always return the first N values in the list,
+        where N is the number of samples requested.
+        Default: True
     """
 
-    def __init__(self, values, **kwargs):
+    def __init__(self, values, *, stateful=True, **kwargs):
         self.values = np.asarray(values)
         if len(values) == 0:
             raise ValueError("No values provided for GivenValueList")
         self.next_ind = 0
+        self._stateful = stateful
 
         super().__init__(self._non_func, **kwargs)
 
     def __getstate__(self):
-        raise RuntimeError("GivenValueList cannot be pickled. This node does not support parallel sampling.")
+        if self._stateful:
+            raise RuntimeError(
+                "A stateful GivenValueList cannot be pickled. This node does not support parallel sampling."
+            )
+        return super().__getstate__()
 
     def reset(self):
         """Reset the next index to use."""
@@ -127,7 +143,8 @@ class GivenValueList(FunctionNode):
                 )
 
             results = self.values[sample_ind]
-            self.next_ind += 1
+            if self._stateful:
+                self.next_ind += 1
         else:
             end_ind = sample_ind + graph_state.num_samples
             if end_ind > len(self.values):
@@ -137,7 +154,8 @@ class GivenValueList(FunctionNode):
                 )
 
             results = self.values[sample_ind:end_ind]
-            self.next_ind += graph_state.num_samples
+            if self._stateful:
+                self.next_ind += graph_state.num_samples
 
         # Save and return the results.
         self._save_results(results, graph_state)

--- a/src/lightcurvelynx/models/lightcurve_template_model.py
+++ b/src/lightcurvelynx/models/lightcurve_template_model.py
@@ -840,7 +840,7 @@ class MultiLightcurveTemplateModel(BaseLightcurveBandTemplateModel):
                 # Assume it is already a parameter or sampler.
                 indices_sampler = indices
         else:
-            all_inds = [i for i in range(len(lightcurves))]
+            all_inds = np.arange(len(lightcurves))
             indices_sampler = GivenValueSampler(all_inds, weights=weights)
 
         self.add_parameter(

--- a/src/lightcurvelynx/models/lightcurve_template_model.py
+++ b/src/lightcurvelynx/models/lightcurve_template_model.py
@@ -745,7 +745,7 @@ class LightcurveTemplateModel(BaseLightcurveBandTemplateModel):
 
 class MultiLightcurveTemplateModel(BaseLightcurveBandTemplateModel):
     """A MultiLightcurveTemplateModel either randomly or programmatically selects a light
-    curve at each evaluation computes the flux from that source. If the 'indices' parameter
+    curve at each evaluation and computes the flux from that source. If the 'indices' parameter
     is provided, the model uses those indices to select the light curve (in order). Otherwise,
     the model randomly samples from the available light curves (with replacement).
 
@@ -797,10 +797,10 @@ class MultiLightcurveTemplateModel(BaseLightcurveBandTemplateModel):
         Default: None
     weights : numpy.ndarray, optional
         A length N array indicating the relative weight from which to select
-        a light curve at random. Cannot be used if the 'index' parameter is provided.
+        a light curve at random. Cannot be used if the 'indices' parameter is provided.
         If None, all light curves will be weighted equally.
         Default: None
-    indices : parameter or array-like, optional
+    indices : parameter, list, or numpy.ndarray, optional
         An array-like parameter that provides the indices of the light curves to select.
         If provided, the model will use these indices to select the light curves instead
         of sampling randomly.
@@ -832,6 +832,9 @@ class MultiLightcurveTemplateModel(BaseLightcurveBandTemplateModel):
             if weights is not None:
                 raise ValueError("Cannot provide both 'weights' and 'indices' parameters.")
             if isinstance(indices, list | np.ndarray):
+                indices = np.asarray(indices)
+                if np.any((indices < 0) | (indices >= len(lightcurves))):
+                    raise ValueError("Indices must be between 0 and the number of light curves.")
                 indices_sampler = GivenValueList(indices)
             else:
                 # Assume it is already a parameter or sampler.
@@ -1035,6 +1038,8 @@ class MultiLightcurveTemplateModel(BaseLightcurveBandTemplateModel):
         """
         params = self.get_local_params(state)
         model_ind = params["selected_lightcurve"]
+        if model_ind < 0 or model_ind >= len(self.lightcurves):  # pragma: no cover
+            raise ValueError(f"Selected light curve index {model_ind} is out of bounds.")
         lc = self.lightcurves[model_ind]
 
         # Check that the filter is supported by the model.

--- a/src/lightcurvelynx/models/lightcurve_template_model.py
+++ b/src/lightcurvelynx/models/lightcurve_template_model.py
@@ -740,12 +740,16 @@ class LightcurveTemplateModel(BaseLightcurveBandTemplateModel):
 
 
 class MultiLightcurveTemplateModel(BaseLightcurveBandTemplateModel):
-    """A MultiLightcurveTemplateModel randomly selects a light curve at each evaluation
-    computes the flux from that source. The models can generate either the SED or
-    bandflux of a source based of given light curves in each band. When generating
-    the bandflux, the model interpolates the light curves directly. When generating the SED,
-    the model uses a box-shaped SED for each filter such that the resulting flux density
-    is equal to the light curve's value after passing through the passband filter.
+    """A MultiLightcurveTemplateModel either randomly or programmatically selects a light
+    curve at each evaluation computes the flux from that source. If the 'indices' parameter
+    is provided, the model uses those indices to select the light curve (in order). Otherwise,
+    the model randomly samples from the available light curves (with replacement).
+
+    The models can generate either the SED or bandflux of a source based of given light curves
+    in each band. When generating the bandflux, the model interpolates the light curves directly.
+    When generating the SED, the model uses a box-shaped SED for each filter such that the
+    resulting flux density is equal to the light curve's value after passing through the passband
+    filter.
 
     MultiLightcurveTemplateModel supports both periodic and non-periodic light curves. If the
     light curve is not periodic then each light curve's given values will be interpolated
@@ -789,7 +793,14 @@ class MultiLightcurveTemplateModel(BaseLightcurveBandTemplateModel):
         Default: None
     weights : numpy.ndarray, optional
         A length N array indicating the relative weight from which to select
-        a light curve at random. If None, all light curves will be weighted equally.
+        a light curve at random. Cannot be used if the 'index' parameter is provided.
+        If None, all light curves will be weighted equally.
+        Default: None
+    indices : parameter, optional
+        An array-like parameter that provides the indices of the light curves to select.
+        If provided, the model will use these indices to select the light curves instead
+        of sampling randomly.
+        Default: None
     """
 
     def __init__(
@@ -798,6 +809,7 @@ class MultiLightcurveTemplateModel(BaseLightcurveBandTemplateModel):
         passbands=None,
         *,
         weights=None,
+        indices=None,
         **kwargs,
     ):
         # Validate the light curve input and create a union of all filters used.
@@ -811,11 +823,18 @@ class MultiLightcurveTemplateModel(BaseLightcurveBandTemplateModel):
 
         super().__init__(passbands=passbands, filters=self.filters, **kwargs)
 
-        all_inds = [i for i in range(len(lightcurves))]
-        self._sampler_node = GivenValueSampler(all_inds, weights=weights)
+        # Either choose from the indices (in order)
+        if indices is not None:
+            if weights is not None:
+                raise ValueError("Cannot provide both 'weights' and 'indices' parameters.")
+            indices_sampler = indices
+        else:
+            all_inds = [i for i in range(len(lightcurves))]
+            indices_sampler = GivenValueSampler(all_inds, weights=weights)
+
         self.add_parameter(
             "selected_lightcurve",
-            value=self._sampler_node,
+            value=indices_sampler,
             allow_gradient=False,
             description="Index of the light curve selected for sampling.",
         )

--- a/src/lightcurvelynx/models/lightcurve_template_model.py
+++ b/src/lightcurvelynx/models/lightcurve_template_model.py
@@ -22,7 +22,11 @@ from lightcurvelynx.astro_utils.mag_flux import mag2flux
 from lightcurvelynx.astro_utils.passbands import Passband, PassbandGroup
 from lightcurvelynx.astro_utils.sed_basis_models import SEDBasisModel
 from lightcurvelynx.consts import lsst_filter_plot_colors
-from lightcurvelynx.math_nodes.given_sampler import GivenValueSampler, GivenValueSelector
+from lightcurvelynx.math_nodes.given_sampler import (
+    GivenValueList,
+    GivenValueSampler,
+    GivenValueSelector,
+)
 from lightcurvelynx.models.physical_model import BandfluxModel
 from lightcurvelynx.utils.io_utils import read_lclib_data
 
@@ -796,7 +800,7 @@ class MultiLightcurveTemplateModel(BaseLightcurveBandTemplateModel):
         a light curve at random. Cannot be used if the 'index' parameter is provided.
         If None, all light curves will be weighted equally.
         Default: None
-    indices : parameter, optional
+    indices : parameter or array-like, optional
         An array-like parameter that provides the indices of the light curves to select.
         If provided, the model will use these indices to select the light curves instead
         of sampling randomly.
@@ -827,7 +831,11 @@ class MultiLightcurveTemplateModel(BaseLightcurveBandTemplateModel):
         if indices is not None:
             if weights is not None:
                 raise ValueError("Cannot provide both 'weights' and 'indices' parameters.")
-            indices_sampler = indices
+            if isinstance(indices, list | np.ndarray):
+                indices_sampler = GivenValueList(indices)
+            else:
+                # Assume it is already a parameter or sampler.
+                indices_sampler = indices
         else:
             all_inds = [i for i in range(len(lightcurves))]
             indices_sampler = GivenValueSampler(all_inds, weights=weights)

--- a/tests/lightcurvelynx/math_nodes/test_given_sampler.py
+++ b/tests/lightcurvelynx/math_nodes/test_given_sampler.py
@@ -109,7 +109,7 @@ def test_given_value_list_offset():
         _ = given_node.compute(state3)
 
 
-def test_test_given_value_list_compound():
+def test_given_value_list_compound():
     """Test that we can use the GivenValueList as input into another node."""
     values = [1.0, 1.5, 2.0, 2.5, 3.0, -1.0, 3.5, 4.0, 10.0, -2.0]
     given_node = GivenValueList(values)
@@ -144,6 +144,40 @@ def test_given_value_list_of_list():
     state2 = given_node.sample_parameters(num_samples=1)
     assert len(state2["node"]["function_node_result"]) == 2
     assert np.array_equal(state2["node"]["function_node_result"], [3, 4])
+
+
+def test_given_value_list_stateless():
+    """Test that we can retrieve numbers from a stateless GivenValueList."""
+    given_node = GivenValueList(
+        [1.0, 1.5, 2.0, 2.5, 3.0, -1.0, 3.5],
+        stateful=False,
+        node_label="node",
+    )
+
+    # Check that we generate the correct result and save it in the GraphState.
+    state = given_node.sample_parameters(num_samples=2)
+    assert np.array_equal(state["node"]["function_node_result"], [1.0, 1.5])
+
+    # If we generate more samples, we should get the same first values again since
+    # the node is stateless.
+    state = given_node.sample_parameters(num_samples=1)
+    assert state["node"]["function_node_result"] == 1.0
+
+    state = given_node.sample_parameters(num_samples=3)
+    assert np.array_equal(state["node"]["function_node_result"], [1.0, 1.5, 2.0])
+
+    # We can use a sample offset to get later values, but the node will still not
+    # keep track of the next index.
+    state = GraphState(num_samples=2, sample_offset=3)
+    results = given_node.compute(state)
+    assert np.array_equal(results, [2.5, 3.0])
+
+    # Check that GivenValueList raises an error when it has run out of samples.
+    with pytest.raises(IndexError):
+        _ = given_node.compute(given_node.sample_parameters(num_samples=100))
+
+    # GivenValueList can be used in distributed computation.
+    assert pickle.dumps(given_node) is not None
 
 
 def test_given_value_sampler():

--- a/tests/lightcurvelynx/models/test_lightcurve_template_model.py
+++ b/tests/lightcurvelynx/models/test_lightcurve_template_model.py
@@ -868,6 +868,18 @@ def test_create_multilightcurve_template_model_indices() -> None:
         else:
             assert np.allclose(fluxes[idx], expected_1)
 
+    # We can also create a model with the indices in list form.
+    indices_list = [0, 0, 0, 1, 0, 1, 0, 1, 1, 0]
+    model2 = MultiLightcurveTemplateModel(
+        [lc1_data, lc2_data],
+        pb_group,
+        t0=0.0,
+        indices=indices_list,
+        node_label="source",
+    )
+    graph_state2 = model2.sample_parameters(num_samples=10)
+    assert np.array_equal(graph_state2["source"]["selected_lightcurve"], indices_list)
+
 
 def test_create_multilightcurve_template_model_fail() -> None:
     """Test creating a MultiLightcurveTemplateModel with invalid parameters."""

--- a/tests/lightcurvelynx/models/test_lightcurve_template_model.py
+++ b/tests/lightcurvelynx/models/test_lightcurve_template_model.py
@@ -880,6 +880,16 @@ def test_create_multilightcurve_template_model_indices() -> None:
     graph_state2 = model2.sample_parameters(num_samples=10)
     assert np.array_equal(graph_state2["source"]["selected_lightcurve"], indices_list)
 
+    # We fail if the indices are out of bounds.
+    with pytest.raises(ValueError):
+        _ = MultiLightcurveTemplateModel(
+            [lc1_data, lc2_data],
+            pb_group,
+            t0=0.0,
+            indices=[0, 0, 2, 0, 0, 1, 1, 1, 0, 0],  # Index of 2 is out of bounds
+            node_label="source",
+        )
+
 
 def test_create_multilightcurve_template_model_fail() -> None:
     """Test creating a MultiLightcurveTemplateModel with invalid parameters."""

--- a/tests/lightcurvelynx/models/test_lightcurve_template_model.py
+++ b/tests/lightcurvelynx/models/test_lightcurve_template_model.py
@@ -9,6 +9,7 @@ from citation_compass import find_in_citations
 from lightcurvelynx.astro_utils.mag_flux import mag2flux
 from lightcurvelynx.astro_utils.passbands import Passband, PassbandGroup
 from lightcurvelynx.effects.basic_effects import ScaleFluxEffect
+from lightcurvelynx.math_nodes.given_sampler import GivenValueList
 from lightcurvelynx.models.lightcurve_template_model import (
     LightcurveBandData,
     LightcurveTemplateModel,
@@ -799,6 +800,73 @@ def test_create_multilightcurve_template_model() -> None:
     single_state = model.sample_parameters(num_samples=1)
     assert model.minphase(filter="g", graph_state=single_state) is None
     assert model.maxphase(filter="g", graph_state=single_state) is None
+
+
+def test_create_multilightcurve_template_model_indices() -> None:
+    """Test that we can create a simple MultiLightcurveTemplateModel object
+    with pre-specified indices."""
+    pb_group = _create_toy_passbands()
+
+    # Lightcurve 1 is non-periodic and covers u and g.
+    lc1_times = np.arange(0.0, 10.5, 0.5)
+    lc1_lightcurves = {
+        "u": np.array([lc1_times + 0.1, 2.0 * np.ones_like(lc1_times)]).T,
+        "g": np.array([lc1_times, 3.0 * np.ones_like(lc1_times)]).T,
+    }
+    lc1_data = LightcurveBandData(lc1_lightcurves, lc_data_t0=0.0, baseline={"u": 0.1, "g": 0.2})
+
+    # Light curve 2 is periodic and covers r and g.
+    lc2_times = np.arange(0.0, 19.0, 1.0)
+    lc2_lightcurves = {
+        "r": np.array([lc2_times, lc2_times % 2]).T,
+        "g": np.array([lc2_times, lc2_times % 2 + 0.5]).T,
+    }
+    lc2_data = LightcurveBandData(lc2_lightcurves, lc_data_t0=0.0, periodic=True)
+
+    # Create the MultiLightcurveTemplateModel with both light curves and predefined indices.
+    indices = GivenValueList([0, 0, 1, 0, 0, 1, 1, 1, 0, 0, 1, 0, 1, 1])
+    model = MultiLightcurveTemplateModel(
+        [lc1_data, lc2_data],
+        pb_group,
+        t0=0.0,
+        indices=indices,
+        node_label="source",
+    )
+    assert len(model.lightcurves) == 2
+    assert set(model.filters) == {"u", "g", "r"}
+
+    # Check that we sample the light curves correctly.
+    graph_state = model.sample_parameters(num_samples=10)
+    lc_used = graph_state["source"]["selected_lightcurve"]
+    assert np.array_equal(lc_used, [0, 0, 1, 0, 0, 1, 1, 1, 0, 0])
+
+    # Check that the baseline values are set correctly for the selected light curves.
+    # Light curve 0 has values given for u and g. Light curve 1 does not have any given
+    # baseline values, so it should default to 0.0 in all bands.
+    lc0_mask = lc_used == 0
+    assert np.all(graph_state["source"]["baseline_u"][lc0_mask] == 0.1)
+    assert np.all(graph_state["source"]["baseline_g"][lc0_mask] == 0.2)
+    assert np.all(graph_state["source"]["baseline_r"][lc0_mask] == 0.0)  # Default
+
+    lc1_mask = lc_used == 1
+    assert np.all(graph_state["source"]["baseline_u"][lc1_mask] == 0.0)
+    assert np.all(graph_state["source"]["baseline_g"][lc1_mask] == 0.0)
+    assert np.all(graph_state["source"]["baseline_r"][lc1_mask] == 0.0)
+
+    query_times = np.array([-1.0, 1.0, 2.0, 3.0, 4.0, 20.0, 21.0])
+    query_filters = np.full(len(query_times), "g")
+    fluxes = model.evaluate_bandfluxes(pb_group, query_times, query_filters, graph_state)
+    assert len(fluxes) == 10
+
+    # Check that we sampled from the light curve that we said we did.
+    expected_0 = np.array([0.2, 3.0, 3.0, 3.0, 3.0, 0.2, 0.2])
+    expected_1 = np.array([1.5, 1.5, 0.5, 1.5, 0.5, 0.5, 1.5])
+    for idx in range(10):
+        if lc_used[idx] == 0:
+            # The first light curve is 3.0 when active
+            assert np.allclose(fluxes[idx], expected_0)
+        else:
+            assert np.allclose(fluxes[idx], expected_1)
 
 
 def test_create_multilightcurve_template_model_fail() -> None:


### PR DESCRIPTION
Closes #865 

## Solution Description
Allow programmatic access to the light curves in `MultiLightcurveTemplateModel` through an optional `indices` parameter. Adds a demo notebook showing how this can be used to re-simulate known objects (with given ra/dec).

Also allows a non-stateful `GivenValueList` which is useful for testing and distributed computation.