### PR TITLE
Remove a confusing access pattern

### DIFF
--- a/src/lightcurvelynx/base_models.py
+++ b/src/lightcurvelynx/base_models.py
@@ -498,13 +498,14 @@ class ParameterizedNode:
             output_name = name if name in value.outputs else "function_node_result"
             self.setters[name].set_as_function(value, output_name)
         elif isinstance(value, ParameterizedNode):
-            # Case 3: We are trying to access a parameter of a ParameterizedNode
-            # with the same name.
-            if value == self:
-                raise ValueError(f"Parameter '{name}' is recursively assigned to self.{name}.")
-            if name not in value.setters:
-                raise ValueError(f"Parameter '{name}' missing from {str(value)}.")
-            self.setters[name].set_as_parameter(value, name)
+            # Case 3 [No longer supported]: We are trying to access a parameter of a
+            # ParameterizedNode with the same name as the current parameter (implicit linking).
+            # We removed this pattern because it increases the potential for user confusion.
+            raise ValueError(
+                "Setting a parameter to a ParameterizedNode and implicitly determining that "
+                "parameter name (e.g. using 'ra=host' to link host.ra) is no longer supported. "
+                "You must specify the parameter name using the dot notation (e.g. 'ra=host.ra')."
+            )
         else:
             # Case 4: The value is constant (including None).
             self.setters[name].set_as_constant(value)

--- a/src/lightcurvelynx/base_models.py
+++ b/src/lightcurvelynx/base_models.py
@@ -502,9 +502,10 @@ class ParameterizedNode:
             # ParameterizedNode with the same name as the current parameter (implicit linking).
             # We removed this pattern because it increases the potential for user confusion.
             raise ValueError(
-                "Setting a parameter to a ParameterizedNode and implicitly determining that "
-                "parameter name (e.g. using 'ra=host' to link host.ra) is no longer supported. "
-                "You must specify the parameter name using the dot notation (e.g. 'ra=host.ra')."
+                f"Error setting parameter '{name}': Setting a parameter to a ParameterizedNode "
+                f"and implicitly determining that parameter name (e.g. using '{name}=other_node' "
+                f"to link other_node.{name}) is no longer supported. You must explicitly specify "
+                f"the parameter name using the dot notation (e.g. '{name}=other_node.{name}')."
             )
         else:
             # Case 4: The value is constant (including None).

--- a/tests/lightcurvelynx/test_base_models.py
+++ b/tests/lightcurvelynx/test_base_models.py
@@ -319,21 +319,12 @@ def test_parameterized_build_dependency_graph():
 
 
 def test_parameterized_node_from_node():
-    """Test that we can set the values of a parameterized node directly
-    from the values of another parameterized node.
+    """Test that we can no longer set the values of a parameterized node directly
+    from the values of another parameterized node as this is a confusing pattern.
     """
     model1 = PairModel(value1=0.5, value2=1.5, node_label="A")
-    model2 = PairModel(value1=model1, value2=model1, node_label="B")
-
-    # The "value1" and "value2" of model2 should be the same as model1.
-    state = model2.sample_parameters()
-    assert state["B"]["value1"] == 0.5
-    assert state["B"]["value2"] == 1.5
-
-    # We fail if we try to reference a parameter in a node that does not have it.
-    model3 = SingleVariableNode("value1", 0.5, node_label="C")
     with pytest.raises(ValueError):
-        _ = PairModel(value1=model3, value2=model3)
+        _ = PairModel(value1=model1, value2=model1, node_label="B")
 
 
 def test_parameterized_node_overwrite_fun():


### PR DESCRIPTION
Setting a parameter by pointing to the node and implicitly determining the name, such as:

```
my_model_node(
    dec=host,  # implicitly this means host.dec
    ra=host,  # implicitly this means host.ra
    ra=other_node,   # this could mean other_node's result if it is a function node and other_node.t0 if not!!!!
    ...
)
```
is a confusing pattern that is not being used to our knowledge.  It is not mentioned in the documentation.

This PR removes the feature and displays an error that will help the user change their code to use the explicit `node_name.param_name` format.