### PR TITLE
Fix error when sampling scipy distribution with too small a domain

### DIFF
--- a/src/lightcurvelynx/math_nodes/scipy_random.py
+++ b/src/lightcurvelynx/math_nodes/scipy_random.py
@@ -11,6 +11,44 @@ from lightcurvelynx.base_models import FunctionNode
 from lightcurvelynx.graph_state import transpose_dict_of_list
 
 
+def _safe_make_inv_polynomial(*args, **kwargs):
+    """A wrapper function around the NumericalInversePolynomial constructor that:
+    1) catches a potential error about that can arise when the domain is too small.
+    2) ignores a potential warning about the mean of the sampling distribution being moved.
+
+    Parameters
+    ----------
+    *args
+        The positional arguments to use for the NumericalInversePolynomial constructor.
+    **kwargs
+        The keyword arguments to use for the NumericalInversePolynomial constructor.
+
+    Returns
+    -------
+    inv_poly : NumericalInversePolynomial
+        The created NumericalInversePolynomial object.
+    """
+    with warnings.catch_warnings():
+        # Catch a potential warning about the mean of the sampling distribution being moved.
+        warnings.filterwarnings("ignore", category=RuntimeWarning, message=r".*moved.*")
+
+        # Catch the potential error (internal scipy type is not public so we have to check the message)
+        # That can result from the domain being too small for the sampling distribution to find.
+        try:
+            inv_poly = NumericalInversePolynomial(*args, **kwargs)
+        except Exception as err:
+            if "condition for method violated" in str(err):
+                raise ValueError(
+                    "Error creating the NumericalInversePolynomial object. This can arise when "
+                    "the domain is too small for the sampling distribution to find. You can use the "
+                    "'domain' parameter to explicitly set the bounds for the sampling distribution. "
+                    f"Original error message: {str(err)}. "
+                ) from err
+            else:
+                raise
+    return inv_poly
+
+
 class NumericalInversePolynomialFunc(FunctionNode):
     """A class for sampling from scipy's NumericalInversePolynomial
     given a distribution function, an object with a pdf function,
@@ -49,11 +87,7 @@ class NumericalInversePolynomialFunc(FunctionNode):
             self._inv_poly = None
             self._vect_sample = np.vectorize(self._create_and_sample)
         else:
-            with warnings.catch_warnings():
-                # Catch a potential warning about the mean of the sampling distribution
-                # being moved.
-                warnings.filterwarnings("ignore", category=RuntimeWarning, message=r".*moved.*")
-                self._inv_poly = NumericalInversePolynomial(self._dist, domain=self._domain)
+            self._inv_poly = _safe_make_inv_polynomial(self._dist, domain=self._domain)
             self._vect_sample = None
 
         # Get a default random number generator for this object, using the
@@ -97,11 +131,7 @@ class NumericalInversePolynomialFunc(FunctionNode):
             The result of sampling the function.
         """
         dist = self._dist(**args)
-        with warnings.catch_warnings():
-            # Catch a potential warning about the mean of the sampling distribution
-            # being moved.
-            warnings.filterwarnings("ignore", category=RuntimeWarning, message=r".*moved.*")
-            sample = NumericalInversePolynomial(dist, domain=self._domain).rvs(1, rng)[0]
+        sample = _safe_make_inv_polynomial(dist, domain=self._domain).rvs(1, rng)[0]
         return sample
 
     def compute(self, graph_state, rng_info=None, **kwargs):
@@ -140,11 +170,7 @@ class NumericalInversePolynomialFunc(FunctionNode):
 
             if graph_state.num_samples == 1:
                 dist = self._dist(**args)
-                with warnings.catch_warnings():
-                    # Catch a potential warning about the mean of the sampling distribution
-                    # being moved.
-                    warnings.filterwarnings("ignore", category=RuntimeWarning, message=r".*moved.*")
-                    results = NumericalInversePolynomial(dist, domain=self._domain).rvs(1, rng)[0]
+                results = _safe_make_inv_polynomial(dist, domain=self._domain).rvs(1, rng)[0]
             else:
                 # Transpose the dict of arrays to a list of dicts.
                 arg_list = transpose_dict_of_list(args, graph_state.num_samples)

--- a/src/lightcurvelynx/math_nodes/scipy_random.py
+++ b/src/lightcurvelynx/math_nodes/scipy_random.py
@@ -21,19 +21,6 @@ class NumericalInversePolynomialFunc(FunctionNode):
     If a class is provided, then the sampling function will create a new
     object (with the sampled parameters) for each sampling. This is very expensive.
 
-    Attributes
-    ----------
-    _dist : object or class
-        An object or class with either a pdf() or logpdf() method that defines
-        the distribution from which to sample.
-    _inv_poly: scipy.stats.sampling.NumericalInversePolynomial
-        The scipy object to use for sampling. Set to None if _dist is a class.
-    _vect_sample : numpy.vectorize
-        The vectorized function to create a distribution from a class and sample it.
-        Set to None if _dist is an object.
-    _rng : numpy.random._generator.Generator
-        This object's random number generator.
-
     Parameters
     ----------
     dist : object or class
@@ -53,6 +40,9 @@ class NumericalInversePolynomialFunc(FunctionNode):
             raise ValueError("Distribution must have either pdf() or logpdf().")
         self._dist = dist
 
+        # Save the domain.
+        self._domain = domain
+
         # Classes show up as type="type". In this case we will need to create
         # a concrete object from the class and any given parameters.
         if isinstance(dist, type):
@@ -62,8 +52,8 @@ class NumericalInversePolynomialFunc(FunctionNode):
             with warnings.catch_warnings():
                 # Catch a potential warning about the mean of the sampling distribution
                 # being moved.
-                warnings.filterwarnings("ignore", category=RuntimeWarning)
-                self._inv_poly = NumericalInversePolynomial(self._dist, domain=domain)
+                warnings.filterwarnings("ignore", category=RuntimeWarning, message=r".*moved.*")
+                self._inv_poly = NumericalInversePolynomial(self._dist, domain=self._domain)
             self._vect_sample = None
 
         # Get a default random number generator for this object, using the
@@ -107,7 +97,11 @@ class NumericalInversePolynomialFunc(FunctionNode):
             The result of sampling the function.
         """
         dist = self._dist(**args)
-        sample = NumericalInversePolynomial(dist).rvs(1, rng)[0]
+        with warnings.catch_warnings():
+            # Catch a potential warning about the mean of the sampling distribution
+            # being moved.
+            warnings.filterwarnings("ignore", category=RuntimeWarning, message=r".*moved.*")
+            sample = NumericalInversePolynomial(dist, domain=self._domain).rvs(1, rng)[0]
         return sample
 
     def compute(self, graph_state, rng_info=None, **kwargs):
@@ -146,7 +140,11 @@ class NumericalInversePolynomialFunc(FunctionNode):
 
             if graph_state.num_samples == 1:
                 dist = self._dist(**args)
-                results = NumericalInversePolynomial(dist).rvs(1, rng)[0]
+                with warnings.catch_warnings():
+                    # Catch a potential warning about the mean of the sampling distribution
+                    # being moved.
+                    warnings.filterwarnings("ignore", category=RuntimeWarning, message=r".*moved.*")
+                    results = NumericalInversePolynomial(dist, domain=self._domain).rvs(1, rng)[0]
             else:
                 # Transpose the dict of arrays to a list of dicts.
                 arg_list = transpose_dict_of_list(args, graph_state.num_samples)

--- a/src/lightcurvelynx/math_nodes/scipy_random.py
+++ b/src/lightcurvelynx/math_nodes/scipy_random.py
@@ -1,5 +1,6 @@
 """Wrapper classes for some of scipy's sampling functions."""
 
+import warnings
 from os import urandom
 
 import numpy as np
@@ -38,11 +39,14 @@ class NumericalInversePolynomialFunc(FunctionNode):
     dist : object or class
         An object or class with either a pdf() or logpdf() method that defines
         the distribution from which to sample.
+    domain : tuple, optional
+        A tuple of (min, max) values to use as bounds for the sampling. If
+        not provided, the sampling will be unbounded.
     seed : int, optional
         The seed to use.
     """
 
-    def __init__(self, dist=None, seed=None, **kwargs):
+    def __init__(self, dist=None, *, domain=None, seed=None, **kwargs):
         # Check that the distribution object/class has a pdf or logpdf function
         # or that we have provided a function directly.
         if not hasattr(dist, "pdf") and not hasattr(dist, "logpdf"):
@@ -55,7 +59,11 @@ class NumericalInversePolynomialFunc(FunctionNode):
             self._inv_poly = None
             self._vect_sample = np.vectorize(self._create_and_sample)
         else:
-            self._inv_poly = NumericalInversePolynomial(self._dist)
+            with warnings.catch_warnings():
+                # Catch a potential warning about the mean of the sampling distribution
+                # being moved.
+                warnings.filterwarnings("ignore", category=RuntimeWarning)
+                self._inv_poly = NumericalInversePolynomial(self._dist, domain=domain)
             self._vect_sample = None
 
         # Get a default random number generator for this object, using the
@@ -170,16 +178,19 @@ class SamplePDF(NumericalInversePolynomialFunc):
     ----------
     dist : function, class, or object
         The pdf function from which to sample or a class/object with that function.
+    domain : tuple, optional
+        A tuple of (min, max) values to use as bounds for the sampling. If
+        not provided, the sampling will be unbounded.
     """
 
-    def __init__(self, dist, **kwargs):
+    def __init__(self, dist, *, domain=None, **kwargs):
         if hasattr(dist, "pdf"):
             self.dist_obj = dist
         elif callable(dist):
             self.dist_obj = PDFFunctionWrapper(dist)
         else:
             raise ValueError("No pdf function detected.")
-        super().__init__(self.dist_obj, **kwargs)
+        super().__init__(self.dist_obj, domain=domain, **kwargs)
 
 
 class LogPDFFunctionWrapper:

--- a/src/lightcurvelynx/math_nodes/scipy_random.py
+++ b/src/lightcurvelynx/math_nodes/scipy_random.py
@@ -5,7 +5,7 @@ from os import urandom
 
 import numpy as np
 import scipy.stats
-from scipy.stats.sampling import NumericalInversePolynomial
+from scipy.stats.sampling import NumericalInversePolynomial, UNURANError
 
 from lightcurvelynx.base_models import FunctionNode
 from lightcurvelynx.graph_state import transpose_dict_of_list
@@ -13,7 +13,7 @@ from lightcurvelynx.graph_state import transpose_dict_of_list
 
 def _safe_make_inv_polynomial(*args, **kwargs):
     """A wrapper function around the NumericalInversePolynomial constructor that:
-    1) catches a potential error about that can arise when the domain is too small.
+    1) catches a potential error that can arise when the domain is too small.
     2) ignores a potential warning about the mean of the sampling distribution being moved.
 
     Parameters
@@ -36,7 +36,7 @@ def _safe_make_inv_polynomial(*args, **kwargs):
         # That can result from the domain being too small for the sampling distribution to find.
         try:
             inv_poly = NumericalInversePolynomial(*args, **kwargs)
-        except Exception as err:
+        except UNURANError as err:
             if "condition for method violated" in str(err):
                 raise ValueError(
                     "Error creating the NumericalInversePolynomial object. This can arise when "
@@ -66,7 +66,7 @@ class NumericalInversePolynomialFunc(FunctionNode):
         the distribution from which to sample.
     domain : tuple, optional
         A tuple of (min, max) values to use as bounds for the sampling. If
-        not provided, the sampling will be unbounded.
+        not provided, scipy will try to infer the domain.
     seed : int, optional
         The seed to use.
     """
@@ -204,7 +204,7 @@ class SamplePDF(NumericalInversePolynomialFunc):
         The pdf function from which to sample or a class/object with that function.
     domain : tuple, optional
         A tuple of (min, max) values to use as bounds for the sampling. If
-        not provided, the sampling will be unbounded.
+        not provided, scipy will try to infer the domain.
     """
 
     def __init__(self, dist, *, domain=None, **kwargs):

--- a/tests/lightcurvelynx/math_nodes/test_scipy_random.py
+++ b/tests/lightcurvelynx/math_nodes/test_scipy_random.py
@@ -118,6 +118,20 @@ def test_numerical_inverse_polynomial_func_object_seed():
     assert not np.allclose(values1, values3)
 
 
+def test_numerical_inverse_polynomial_func_object_domain():
+    """Test that we can specify a domain for the distribution."""
+    dist = FlatDist(min_val=0.0, max_val=1.0)
+    scipy_node = NumericalInversePolynomialFunc(dist, domain=(0.25, 0.75), seed=100)
+
+    # Test that the values are within the specified domain.
+    num_samples = 1000
+    states = scipy_node.sample_parameters(num_samples=num_samples)
+    samples = scipy_node.get_param(states, "function_node_result")
+    assert len(samples) == num_samples
+    assert np.all(samples >= 0.25)
+    assert np.all(samples <= 0.75)
+
+
 def test_numerical_inverse_polynomial_func_class():
     """Test that we can generate numbers from a uniform distribution."""
     scipy_node = NumericalInversePolynomialFunc(
@@ -227,9 +241,9 @@ def test_numerical_sample_pdf_with_domain():
     assert np.all(samples <= 0.3)
     assert np.all(samples >= 0.2)
 
-    # The distribution of samples should be monotinically inreasing with x.
-    # Use 90% buffer to account for noise in the sampling. We ignore the first
-    # and last bin because of edge with binning.
+    # The distribution of samples should be monotonically increasing with x.
+    # Use a 90% buffer to account for noise in the sampling. We ignore the first two
+    # and last bin because of edge effects from binning.
     hist, _ = np.histogram(samples, bins=10, range=(0.2, 0.3))
     for i in range(2, len(hist) - 1):
         assert hist[i] >= 0.9 * hist[i - 1]

--- a/tests/lightcurvelynx/math_nodes/test_scipy_random.py
+++ b/tests/lightcurvelynx/math_nodes/test_scipy_random.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 from lightcurvelynx.math_nodes.given_sampler import GivenValueList
 from lightcurvelynx.math_nodes.np_random import NumpyRandomFunc
 from lightcurvelynx.math_nodes.scipy_random import (
@@ -232,6 +233,11 @@ def test_numerical_sample_pdf_with_domain():
         ]
     )
     zpdf = interp1d(x, y, bounds_error=False, fill_value=0)
+
+    # We fail if we try to create a SamplePDF node without specifying the domain,
+    # because the sampling distribution can't find a valid domain to sample from.
+    with pytest.raises(ValueError, match="Error creating the NumericalInversePolynomial object"):
+        _ = SamplePDF(zpdf, seed=100, node_label="zpdf_sampler_no_domain")
 
     # Check that we sample correctly given the domain of the distribution.
     scipy_node = SamplePDF(zpdf, seed=100, domain=(0.2, 0.3), node_label="zpdf_sampler")

--- a/tests/lightcurvelynx/math_nodes/test_scipy_random.py
+++ b/tests/lightcurvelynx/math_nodes/test_scipy_random.py
@@ -7,6 +7,7 @@ from lightcurvelynx.math_nodes.scipy_random import (
     SamplePDF,
     ScipyRandomDist,
 )
+from scipy.interpolate import interp1d
 
 
 class FlatDist:
@@ -167,6 +168,71 @@ def test_numerical_sample_pdf():
     expected = mid_heights * 0.2 * num_samples
     for idx in range(10):
         assert np.abs(counts[idx] - expected[idx]) < 200.0
+
+
+def test_numerical_sample_pdf_interp():
+    """Test that we can create a SamplePDF node from an interpolated function."""
+    # A bimodal distribution with a wide peak at 1.5 and a sharper peak at 4.0
+    x = np.array([0.0, 0.5, 1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0, 4.5, 5.0])
+    y = np.array([0.001, 0.5, 0.5, 0.5, 0.5, 0.5, 0.001, 0.001, 0.001, 2.5, 0.001])
+    pdf = interp1d(x, y, bounds_error=False, fill_value=0)
+
+    # Sample the distribution.
+    num_samples = 50_000
+    scipy_node = SamplePDF(pdf, seed=100, node_label="test_node")
+    state = scipy_node.sample_parameters(num_samples=num_samples)
+    samples = scipy_node.get_param(state, "function_node_result")
+
+    # Approximately half the samples should be between 0.0 and 3.0 (with a plateau
+    # between 0.5 and 2.5), and the other half should be between 4.0 and 5.0.
+    assert np.all(samples >= 0.0)
+    assert np.all(samples <= 5.0)
+    assert np.sum((samples >= 0.0) & (samples <= 3.0)) > 0.45 * num_samples
+    assert np.sum((samples >= 0.5) & (samples <= 1.0)) > 0.05 * num_samples
+    assert np.sum((samples >= 1.0) & (samples <= 1.5)) > 0.05 * num_samples
+    assert np.sum((samples >= 1.5) & (samples <= 2.0)) > 0.05 * num_samples
+    assert np.sum((samples >= 2.0) & (samples <= 2.5)) > 0.05 * num_samples
+    assert np.sum((samples >= 4.0) & (samples <= 5.0)) > 0.45 * num_samples
+
+
+def test_numerical_sample_pdf_with_domain():
+    """Test that we can create a SamplePDF node from a function with a specified domain.
+    This addresses a previous error where the code was failing because the valid
+    domain of the distribution was too small.
+    """
+    # Data comes from num_snia_per_redshift_bin() function. We use a 1-d interpolation
+    # of the data to create a pdf that we can sample from.
+    x = np.array([0.205, 0.215, 0.225, 0.235, 0.245, 0.255, 0.265, 0.275, 0.285, 0.295])
+    y = np.array(
+        [
+            8793.8721014,
+            9628.46268465,
+            10495.70909757,
+            11394.86207448,
+            12325.16647819,
+            13285.86241747,
+            14276.18632372,
+            15295.37198651,
+            16342.65154774,
+            17417.25645436,
+        ]
+    )
+    zpdf = interp1d(x, y, bounds_error=False, fill_value=0)
+
+    # Check that we sample correctly given the domain of the distribution.
+    scipy_node = SamplePDF(zpdf, seed=100, domain=(0.2, 0.3), node_label="zpdf_sampler")
+    state = scipy_node.sample_parameters(num_samples=10_000)
+    samples = scipy_node.get_param(state, "function_node_result")
+    assert len(samples) == 10_000
+    assert np.all(samples <= 0.3)
+    assert np.all(samples >= 0.2)
+
+    # The distribution of samples should be monotinically inreasing with x.
+    # Use 90% buffer to account for noise in the sampling. We ignore the first
+    # and last bin because of edge with binning.
+    hist, _ = np.histogram(samples, bins=10, range=(0.2, 0.3))
+    for i in range(2, len(hist) - 1):
+        assert hist[i] >= 0.9 * hist[i - 1]
 
 
 def test_numerical_sample_logpdf():


### PR DESCRIPTION
Fix an error that Sam encountered where the `SamplePDF` node could give the error

```
UNURANError: [objid: PINV.003] 51 : PDF(center) <= 0. => (generator) condition for method violated
```

When given a PDF with too small a domain. In this case users will need to pass in a domain explicitly to constrain the sampler.