### PR TITLE
Add the ability to expand GraphState

### DIFF
--- a/src/lightcurvelynx/graph_state.py
+++ b/src/lightcurvelynx/graph_state.py
@@ -558,7 +558,7 @@ class GraphState:
             repeats = np.asarray(repeats)
             if repeats.ndim != 1:
                 raise TypeError("repeats must be an int or a 1D array-like of integers.")
-            if repeats.dtype.kind not in {"i", "u"}:
+            if not np.issubdtype(repeats.dtype, np.integer):
                 raise TypeError("Entries in repeats must be integers.")
             if len(repeats) != self.num_samples:
                 raise ValueError(

--- a/src/lightcurvelynx/graph_state.py
+++ b/src/lightcurvelynx/graph_state.py
@@ -535,6 +535,64 @@ class GraphState:
             for var_name, value in node_vars.items():
                 self.set(node_name, var_name, value, force_copy=force_copy, fixed=all_fixed)
 
+    def repeat(self, repeats):
+        """Expand the GraphState to a new number of samples by repeating the existing values
+        for all node.parameter combinations.
+
+        Note
+        ----
+        This method is experimental and may be removed in the future.
+
+        Parameters
+        ----------
+        repeats : array-like or int
+            An array of the number of repetitions for each of the current samples.
+            The length of this array must match the current number of samples.
+            If an integer is provided, all samples will be repeated that many times.
+            The sum of the entries in this array will determine the new number of samples.
+        """
+        # If we get a scalar integer, repeat all samples by that amount.
+        if isinstance(repeats, int):
+            repeats = np.full(self.num_samples, int(repeats), dtype=int)
+        else:
+            repeats = np.asarray(repeats)
+            if repeats.dtype.kind not in {"i", "u"}:
+                raise TypeError("Entries in repeats must be integers.")
+            if len(repeats) != self.num_samples:
+                raise ValueError(
+                    f"Length of repeats must match the current number of samples. "
+                    f"Received {len(repeats)} and {self.num_samples}."
+                )
+
+        # Check that the entries are valid.
+        if np.any(repeats < 0):
+            raise ValueError("Entries in repeats must be non-negative.")
+
+        # Check how many samples we will have after the repeats.
+        new_num_samples = np.sum(repeats)
+        if new_num_samples == 0:
+            raise ValueError("Cannot have zero samples in GraphState.")
+
+        # Update each the array (or value) for each node+parameter in the GraphState by
+        # repeating the values according to repeats.
+        for node_name, node_vars in self.states.items():
+            for var_name, value in node_vars.items():
+                # Compute the new values as an array.
+                if self.num_samples == 1:
+                    new_values = np.full(repeats[0], value)
+                else:
+                    new_values = np.repeat(value, repeats)
+
+                # If we only have a single sample at the end, store its value.
+                if new_num_samples == 1:
+                    new_values = new_values[0]
+
+                # Save the updated values.
+                self.states[node_name][var_name] = new_values
+
+        # Update the number of samples.
+        self.num_samples = new_num_samples
+
     def extract_single_sample(self, sample_num):
         """Create a new GraphState with a single sample state and all scalar values.
 

--- a/src/lightcurvelynx/graph_state.py
+++ b/src/lightcurvelynx/graph_state.py
@@ -552,10 +552,12 @@ class GraphState:
             The sum of the entries in this array will determine the new number of samples.
         """
         # If we get a scalar integer, repeat all samples by that amount.
-        if isinstance(repeats, int):
+        if isinstance(repeats, (int, np.integer)):
             repeats = np.full(self.num_samples, int(repeats), dtype=int)
         else:
             repeats = np.asarray(repeats)
+            if repeats.ndim != 1:
+                raise TypeError("repeats must be an int or a 1D array-like of integers.")
             if repeats.dtype.kind not in {"i", "u"}:
                 raise TypeError("Entries in repeats must be integers.")
             if len(repeats) != self.num_samples:
@@ -563,7 +565,6 @@ class GraphState:
                     f"Length of repeats must match the current number of samples. "
                     f"Received {len(repeats)} and {self.num_samples}."
                 )
-
         # Check that the entries are valid.
         if np.any(repeats < 0):
             raise ValueError("Entries in repeats must be non-negative.")
@@ -592,6 +593,8 @@ class GraphState:
 
         # Update the number of samples.
         self.num_samples = new_num_samples
+        if self.num_samples != 1:
+            self.sample_idx = None
 
     def extract_single_sample(self, sample_num):
         """Create a new GraphState with a single sample state and all scalar values.

--- a/src/lightcurvelynx/graph_state.py
+++ b/src/lightcurvelynx/graph_state.py
@@ -552,7 +552,7 @@ class GraphState:
             The sum of the entries in this array will determine the new number of samples.
         """
         # If we get a scalar integer, repeat all samples by that amount.
-        if isinstance(repeats, (int, np.integer)):
+        if isinstance(repeats, int | np.integer):
             repeats = np.full(self.num_samples, int(repeats), dtype=int)
         else:
             repeats = np.asarray(repeats)

--- a/src/lightcurvelynx/math_nodes/state_expansion_node.py
+++ b/src/lightcurvelynx/math_nodes/state_expansion_node.py
@@ -1,0 +1,166 @@
+"""The StateExpansionNode is a special FunctionNode that expands the graph state
+to flatten out subparameters -- where a single row is transformed into multiple related
+rows. This node is meant to be used in the rare case that a single step in the parameter
+sampling process needs to change the number of samples (one sample branching into multiple
+results).
+
+Note
+----
+This class is experimental and may be removed in the future.
+"""
+
+import numpy as np
+
+from lightcurvelynx.base_models import FunctionNode
+
+
+class StateExpansionNode(FunctionNode):
+    """A special FunctionNode that expands the graph state to flatten out the subparameters
+    that indicate multiple different behaviors per-row. For example, strong lensing will split
+    a single object into multiple light curves (with different magnifications and time delays).
+    The user provides a list of subparameter dictionaries where each dictionary lists the values
+    for the new columns to be added for each sample. Alternatively, the user can directly provide
+    the number of repeats for each sample to produce identical copies of the rows without adding
+    any new columns.
+
+    Because of the structure of sampling, each ExpansionNode will only be triggered
+    once during each sampling process.
+
+    Note
+    ----
+    This class is experimental and may be removed in the future.
+
+    Parameters
+    ----------
+    param_names : list of str, optional
+        A list of parameters to unpack from the param_values argument.
+        Default: None
+    param_values : parameter
+        A list of dictionaries where each dictionary contains the same keys (new column names)
+        and the values for each parameter. The number of dictionaries must be the same as the
+        number of samples in the graph state.
+        Default: None
+    repeats: int or list of int, optional
+        The number of repeats for each sample. If an int is provided, it is applied to
+        all samples. If a list is provided, it must be the same length as the number
+        of samples in the graph state and specifies the number of repeats for each sample.
+        Only used if param_values is not provided.
+        Default: None
+    **kwargs : dict, optional
+         Additional keyword arguments.
+    """
+
+    def __init__(self, *, param_names=None, param_values=None, repeats=None, **kwargs):
+        if param_values is not None:
+            if repeats is not None:
+                raise ValueError(
+                    "You cannot provide both 'repeats' and 'param_values' to StateExpansionNode."
+                )
+            if param_names is None or len(param_names) == 0:
+                raise ValueError(
+                    "You must provide a non-empty 'param_names' list when using 'param_values' "
+                    "in StateExpansionNode."
+                )
+            for name in param_names:
+                if not isinstance(name, str):
+                    raise ValueError("All entries in 'param_names' must be strings.")
+            self.new_param_names = param_names
+        elif param_names is not None:
+            raise ValueError("You cannot provide 'param_names' without 'param_values' to StateExpansionNode.")
+        elif repeats is None:
+            raise ValueError("You must provide either 'repeats' or 'param_values' to StateExpansionNode.")
+        else:
+            # No new parameters to add, just repeat the rows.
+            self.new_param_names = []
+
+        super().__init__(
+            func=self._non_func,  # We will override compute() so the function doesn't matter.
+            repeats=repeats,
+            param_values=param_values,
+            outputs=["org_inds", "sub_inds"] + self.new_param_names,
+            **kwargs,
+        )
+
+    def compute(self, graph_state, rng_info=None, **kwargs):
+        """Expand the graph state by applying the repeat() method.
+
+        Parameters
+        ----------
+        graph_state : GraphState
+            An object mapping graph parameters to their values. This object is modified
+            in place as it is sampled.
+        rng_info : numpy.random._generator.Generator, optional
+            A given numpy random number generator to use for this computation. If not
+            provided, the function uses the node's random number generator.
+        **kwargs : dict, optional
+            Additional function arguments.
+
+        Returns
+        -------
+        list
+            A list containing the original indices and sub-indices for each sample after expansion,
+            as well as any new parameter values if provided. The order of the returned list is:
+            [org_inds, sub_inds, new_param_1_values, new_param_2_values, ...] where the new parameter
+            values match the order of the param_names provided during initialization.
+        """
+        # Get the parameters for the number of repeats and subparameters.
+        args = self._build_inputs(graph_state, **kwargs)
+        repeats = args.get("repeats", None)
+        param_values = args.get("param_values", None)
+
+        # If new parameters to add are not None, we compute the repeats array from the length
+        # of the subparameters for each sample.
+        if len(self.new_param_names) > 0:
+            if len(param_values) != graph_state.num_samples:
+                raise ValueError(
+                    f"The number of subparameter dictionaries ({len(param_values)}) must match the "
+                    f"number of samples in the graph state ({graph_state.num_samples})."
+                )
+            repeats = [0] * graph_state.num_samples
+
+            # We get the first dictionary to compute the column names.
+            column_names_set = set(self.new_param_names)
+            concat_values = {col: [] for col in self.new_param_names}
+            for idx, subparam_dict in enumerate(param_values):
+                # Make sure each dictionary has the required column names (keys).
+                if not column_names_set.issubset(subparam_dict.keys()):
+                    missing_cols = column_names_set - set(subparam_dict.keys())
+                    raise ValueError(
+                        f"Each subparameter dictionary at index {idx} must contain the following keys: "
+                        f"{', '.join(column_names_set)}. Missing keys: {', '.join(missing_cols)}."
+                    )
+
+                # Use the first column to compute the number of repeats for this sample.
+                repeats[idx] = len(subparam_dict[self.new_param_names[0]])
+
+                # For each entry in the dictionary, check that the length matches the number of repeats
+                # and concatenate the values for this new column.
+                for col in self.new_param_names:
+                    if len(subparam_dict[col]) != repeats[idx]:
+                        raise ValueError(
+                            f"All values in each subparameter dictionary {idx} must have the same length. "
+                            f"Found mismatched lengths for column '{col}': expected {repeats[idx]}, "
+                            f"but got {len(subparam_dict[col])}."
+                        )
+                    concat_values[col].extend(subparam_dict[col])
+        else:
+            # We are given the repeat values directly. We do not add any new columns.
+            if np.isscalar(repeats):
+                repeats = [repeats] * graph_state.num_samples
+            concat_values = {}
+
+        # Use the repeats list to expand the graph state. Save the information about the
+        # original indices and the sub-indices for each sample before and after expansion.
+        org_inds = np.arange(graph_state.num_samples).repeat(repeats)
+        sub_inds = np.concatenate([np.arange(r) for r in repeats])
+        graph_state.repeat(repeats)
+        results = [org_inds, sub_inds]
+
+        # Add columns for any subparameters we need to concatenate.
+        for col, values in concat_values.items():
+            graph_state.set(self.node_string, col, values)
+            results.append(values)
+
+        # Save and return the old incides and the subindices as the result.
+        self._save_results(results, graph_state)
+        return results

--- a/src/lightcurvelynx/math_nodes/state_expansion_node.py
+++ b/src/lightcurvelynx/math_nodes/state_expansion_node.py
@@ -161,6 +161,6 @@ class StateExpansionNode(FunctionNode):
             graph_state.set(self.node_string, col, values)
             results.append(values)
 
-        # Save and return the old incides and the subindices as the result.
+        # Save and return the old indices and the subindices as the result.
         self._save_results(results, graph_state)
         return results

--- a/tests/lightcurvelynx/effects/test_hypothetical_effects.py
+++ b/tests/lightcurvelynx/effects/test_hypothetical_effects.py
@@ -1,0 +1,125 @@
+"""This file includes tests for combinations of effects and settings that will not be used
+in production, but help stress test the underlying machinery and make sure that the models
+are working as expected in a variety of scenarios.
+"""
+
+from lightcurvelynx.effects.effect_model import EffectModel
+from lightcurvelynx.math_nodes.given_sampler import GivenValueList
+from lightcurvelynx.math_nodes.state_expansion_node import StateExpansionNode
+from lightcurvelynx.models.basic_models import ConstantSEDModel
+
+
+class _DuplicatingObservationEffect(EffectModel):
+    """An effect that duplcates the observations of an object a specified number of
+    times with the same parameters.
+
+    Attributes
+    ----------
+    repeats : parameter
+        The number of times to duplicate the observations.
+    """
+
+    def __init__(self, repeats, **kwargs):
+        super().__init__(**kwargs)
+        self.add_effect_parameter(
+            "number_of_duplicates",
+            StateExpansionNode(repeats=repeats).repeats,
+        )
+
+    def apply(
+        self,
+        flux_density,
+        times=None,
+        wavelengths=None,
+        flux_scale=None,
+        **kwargs,
+    ):
+        """Apply the effect to observations (flux_density values).
+
+        Parameters
+        ----------
+        flux_density : numpy.ndarray
+            A length T X N matrix of flux density values (in nJy).
+        times : numpy.ndarray, optional
+            A length T array of times (in MJD). Not used for this effect.
+        wavelengths : numpy.ndarray, optional
+            A length N array of wavelengths (in angstroms). Not used for this effect.
+        flux_scale : float, optional
+            The multiplicative factor by which to scale the flux. Raises an error if None is provided.
+        **kwargs : `dict`, optional
+           Any additional keyword arguments, including any additional
+           parameters needed to apply the effect.
+
+        Returns
+        -------
+        flux_density : numpy.ndarray
+            A length T x N matrix of flux densities after the effect is applied (in nJy).
+        """
+        # No change tothe flux density values.
+        return flux_density
+
+    def apply_bandflux(
+        self,
+        bandfluxes,
+        *,
+        times=None,
+        filters=None,
+        flux_scale=None,
+        **kwargs,
+    ):
+        """Apply the effect to band fluxes.
+
+        Parameters
+        ----------
+        bandfluxes : numpy.ndarray
+            A length T array of band fluxes (in nJy).
+        times : numpy.ndarray, optional
+            A length T array of times (in MJD).
+        filters : numpy.ndarray, optional
+            A length N array of filters. If not provided, the effect is applied to all
+            band fluxes.
+        flux_scale : float, optional
+            The multiplicative factor by which to scale the flux. Raises an error if None is provided.
+        **kwargs : `dict`, optional
+           Any additional keyword arguments, including any additional
+           parameters needed to apply the effect.
+
+        Returns
+        -------
+        bandfluxes : numpy.ndarray
+            A length T array of band fluxes after the effect is applied (in nJy).
+        """
+        # No change to the band flux values.
+        return bandfluxes
+
+
+def test_duplicate_object_effects():
+    """Test that we can use the StateExpansionNode in an effect to duplicate the observations."""
+    basic_model = ConstantSEDModel(
+        brightness=GivenValueList([10.0, 20.0, 30.0]),
+        ra=GivenValueList([0.0, 45.0, 90.0]),
+        dec=GivenValueList([0.0, -10.0, 10.0]),
+        node_label="basic_model",
+    )
+    state = basic_model.sample_parameters(num_samples=3)
+    assert state.num_samples == 3
+    assert state["basic_model"]["ra"].tolist() == [0.0, 45.0, 90.0]
+    assert state["basic_model"]["dec"].tolist() == [0.0, -10.0, 10.0]
+    assert state["basic_model"]["brightness"].tolist() == [10.0, 20.0, 30.0]
+
+    # We can add a duplicating effect to the model that will create
+    # duplicates of the observations.
+    basic_model2 = ConstantSEDModel(
+        brightness=GivenValueList([10.0, 20.0, 30.0]),
+        ra=GivenValueList([0.0, 45.0, 90.0]),
+        dec=GivenValueList([0.0, -10.0, 10.0]),
+        node_label="basic_model",
+    )
+    effect = _DuplicatingObservationEffect(repeats=GivenValueList([2, 0, 3]))
+    basic_model2.add_effect(effect)
+
+    state2 = basic_model2.sample_parameters(num_samples=3)
+    assert state2.num_samples == 5
+    assert state2["basic_model"]["ra"].tolist() == [0.0, 0.0, 90.0, 90.0, 90.0]
+    assert state2["basic_model"]["dec"].tolist() == [0.0, 0.0, 10.0, 10.0, 10.0]
+    assert state2["basic_model"]["brightness"].tolist() == [10.0, 10.0, 30.0, 30.0, 30.0]

--- a/tests/lightcurvelynx/effects/test_hypothetical_effects.py
+++ b/tests/lightcurvelynx/effects/test_hypothetical_effects.py
@@ -10,7 +10,7 @@ from lightcurvelynx.models.basic_models import ConstantSEDModel
 
 
 class _DuplicatingObservationEffect(EffectModel):
-    """An effect that duplcates the observations of an object a specified number of
+    """An effect that duplicates the observations of an object a specified number of
     times with the same parameters.
 
     Attributes
@@ -45,8 +45,7 @@ class _DuplicatingObservationEffect(EffectModel):
         wavelengths : numpy.ndarray, optional
             A length N array of wavelengths (in angstroms). Not used for this effect.
         flux_scale : float, optional
-            The multiplicative factor by which to scale the flux. Raises an error if None is provided.
-        **kwargs : `dict`, optional
+            The multiplicative factor by which to scale the flux. Not used for this effect.
            Any additional keyword arguments, including any additional
            parameters needed to apply the effect.
 
@@ -55,7 +54,7 @@ class _DuplicatingObservationEffect(EffectModel):
         flux_density : numpy.ndarray
             A length T x N matrix of flux densities after the effect is applied (in nJy).
         """
-        # No change tothe flux density values.
+        # No change to the flux density values.
         return flux_density
 
     def apply_bandflux(

--- a/tests/lightcurvelynx/effects/test_hypothetical_effects.py
+++ b/tests/lightcurvelynx/effects/test_hypothetical_effects.py
@@ -46,6 +46,7 @@ class _DuplicatingObservationEffect(EffectModel):
             A length N array of wavelengths (in angstroms). Not used for this effect.
         flux_scale : float, optional
             The multiplicative factor by which to scale the flux. Not used for this effect.
+        **kwargs : `dict`, optional
            Any additional keyword arguments, including any additional
            parameters needed to apply the effect.
 

--- a/tests/lightcurvelynx/math_nodes/test_state_expansion_node.py
+++ b/tests/lightcurvelynx/math_nodes/test_state_expansion_node.py
@@ -1,0 +1,201 @@
+import pytest
+from lightcurvelynx.base_models import FunctionNode, ParameterizedNode
+from lightcurvelynx.math_nodes.given_sampler import GivenValueList
+from lightcurvelynx.math_nodes.single_value_node import SingleVariableNode
+from lightcurvelynx.math_nodes.state_expansion_node import StateExpansionNode
+
+
+class _AddModel(ParameterizedNode):
+    """A test class for the ParameterizedNode that adds two values.
+
+    Parameters
+    ----------
+    value1 : `float`
+        The first value.
+    value2 : `float`
+        The second value.
+    value_sum : `float`
+        The sum of the two values.
+    **kwargs : `dict`, optional
+        Any additional keyword arguments.
+    """
+
+    def __init__(self, value1, value2, **kwargs):
+        super().__init__(**kwargs)
+        self.add_parameter("value1", value1, **kwargs)
+        self.add_parameter("value2", value2, **kwargs)
+        self.add_parameter(
+            "value_sum",
+            FunctionNode(self._test_func, value1=self.value1, value2=self.value2),
+            **kwargs,
+        )
+
+    def _test_func(self, value1, value2, **kwargs):
+        return value1 + value2
+
+
+def test_state_expansion_node():
+    """Test that we can create and query a StateExpansionNode with just the repeats."""
+    exp_node = StateExpansionNode(repeats=3, node_label="exp")
+    state = exp_node.sample_parameters(num_samples=2)
+
+    # We ask for 2 samples, but force 3 repeats of each.
+    assert state.num_samples == 6
+    assert state["exp"]["org_inds"].tolist() == [0, 0, 0, 1, 1, 1]
+    assert state["exp"]["sub_inds"].tolist() == [0, 1, 2, 0, 1, 2]
+    assert state["exp"]["repeats"].tolist() == [3, 3, 3, 3, 3, 3]
+
+    # If we resample, we retrigger the expansion and get new indices.
+    new_state = exp_node.sample_parameters(num_samples=3)
+    assert new_state.num_samples == 9
+    assert new_state["exp"]["org_inds"].tolist() == [0, 0, 0, 1, 1, 1, 2, 2, 2]
+    assert new_state["exp"]["sub_inds"].tolist() == [0, 1, 2, 0, 1, 2, 0, 1, 2]
+    assert new_state["exp"]["repeats"].tolist() == [3, 3, 3, 3, 3, 3, 3, 3, 3]
+
+    # We can chain the nodes.
+    exp_node2 = StateExpansionNode(repeats=2, node_label="exp2")
+    add_node = _AddModel(
+        value1=exp_node2.org_inds,
+        value2=exp_node2.repeats,
+        node_label="add",
+    )
+    state = add_node.sample_parameters(num_samples=2)
+    assert state.num_samples == 4
+    assert state["add"]["value1"].tolist() == [0, 0, 1, 1]
+    assert state["add"]["value2"].tolist() == [2, 2, 2, 2]
+
+    # The value sum should be the sum of the number of repeats and the original
+    # indices (not meaningful beyond testing).
+    assert state["add"]["value_sum"].tolist() == [2, 2, 3, 3]
+
+    # We can use non-uniform repeats.
+    repeats_list = GivenValueList([2, 0, 3])
+    exp_node3 = StateExpansionNode(repeats=repeats_list, node_label="exp3")
+    single_model = SingleVariableNode(name="value", value=exp_node3.org_inds, node_label="single")
+    state = single_model.sample_parameters(num_samples=3)
+    assert state.num_samples == 5
+    assert state["exp3"]["org_inds"].tolist() == [0, 0, 2, 2, 2]
+    assert state["exp3"]["sub_inds"].tolist() == [0, 1, 0, 1, 2]
+    assert state["exp3"]["repeats"].tolist() == [2, 2, 3, 3, 3]
+    assert state["single"]["value"].tolist() == [0, 0, 2, 2, 2]
+
+    # We fail if we try to create a node without any repetition information.
+    with pytest.raises(ValueError):
+        _ = StateExpansionNode(node_label="bad_exp")
+
+
+def test_state_expansion_node_subparameters():
+    """Test that we can create and query a StateExpansionNode from subparameters."""
+    sub_param_list = [
+        {"a": [1, 2], "b": [3, 4]},
+        {"a": [5, 6, 7], "b": [7, 8, 9]},
+        {"a": [], "b": []},
+        {"a": [9, 10], "b": [13, 14], "c": [15, 16]},  # Extra column should be ignored.
+    ]
+    sub_param_node = GivenValueList(sub_param_list)
+    exp_node = StateExpansionNode(
+        param_names=["a", "b"],
+        param_values=sub_param_node,
+        node_label="exp",
+    )
+    state = exp_node.sample_parameters(num_samples=4)
+
+    # We ask for 4 samples, but after flattening the subparameters we have 2 + 3 + 0 + 2 = 7.
+    # We have also flattened and appended the new column data.
+    assert state.num_samples == 7
+    assert state["exp"]["org_inds"].tolist() == [0, 0, 1, 1, 1, 3, 3]
+    assert state["exp"]["sub_inds"].tolist() == [0, 1, 0, 1, 2, 0, 1]
+    assert state["exp"]["repeats"].tolist() == [None, None, None, None, None, None, None]
+    assert state["exp"]["a"].tolist() == [1, 2, 5, 6, 7, 9, 10]
+    assert state["exp"]["b"].tolist() == [3, 4, 7, 8, 9, 13, 14]
+    assert "c" not in state["exp"]
+
+    # We fail if we give bad combinations of parameters to the node.
+    with pytest.raises(ValueError):
+        # repeats and param_values
+        _ = StateExpansionNode(param_names=["a", "b"], repeats=2, param_values=sub_param_node)
+    with pytest.raises(ValueError):
+        # param_values but no names
+        _ = StateExpansionNode(param_values=sub_param_node)
+    with pytest.raises(ValueError):
+        # param_names but no values
+        _ = StateExpansionNode(param_names=["a", "b"])
+    with pytest.raises(ValueError):
+        # empty param_names
+        _ = StateExpansionNode(param_names=[], param_values=sub_param_node)
+    with pytest.raises(ValueError):
+        # param_names is not a list of strings
+        _ = StateExpansionNode(param_names=[1, "a"], param_values=sub_param_node)
+
+    # We fail if the subparameters are missing a column.
+    bad_subparameters = [
+        {"a": [1, 2], "b": [3, 4]},
+        {"a": [5, 6, 7], "c": [7, 8, 9]},  # Missing 'b'
+    ]
+    bad_node = StateExpansionNode(
+        param_names=["a", "b"],
+        param_values=GivenValueList(bad_subparameters),
+    )
+    with pytest.raises(ValueError):
+        _ = bad_node.sample_parameters(num_samples=2)
+
+    # We fail if the subparameters have different numbers of entries within a dictionary.
+    bad_subparameters2 = [
+        {"a": [1, 2], "b": [3, 4]},
+        {"a": [5, 6, 7], "b": [7, 8]},
+    ]
+    bad_node2 = StateExpansionNode(
+        param_names=["a", "b"],
+        param_values=GivenValueList(bad_subparameters2),
+    )
+    with pytest.raises(ValueError):
+        _ = bad_node2.sample_parameters(num_samples=2)
+
+
+def test_state_expansion_node_subparameters_chaining():
+    """Test that we can chain the StateExpansionNode."""
+    # The first value is just a list of integers.
+    value1 = GivenValueList([i * 10 for i in range(10)])
+
+    # The second value provides TWO values to add to each value1.
+    sub_param_list = GivenValueList([{"value2": [i, i + 1]} for i in range(10)])
+    value2 = StateExpansionNode(param_names=["value2"], param_values=sub_param_list)
+
+    # We add these two values together in a new node, which should trigger the expansion of
+    # the second value and the addition of the new parameters to the graph state.
+    add_node = _AddModel(
+        value1=value1,
+        value2=value2.value2,  # We access the newly added column.
+        node_label="add",
+    )
+
+    # We sample 4 values, but expand those to 8 because of the StateExpansionNode.
+    state = add_node.sample_parameters(num_samples=4)
+    assert state.num_samples == 8
+    assert state["add"]["value1"].tolist() == [0, 0, 10, 10, 20, 20, 30, 30]
+    assert state["add"]["value2"].tolist() == [0, 1, 1, 2, 2, 3, 3, 4]
+    assert state["add"]["value_sum"].tolist() == [0, 1, 11, 12, 22, 23, 33, 34]
+
+    # We can do the same with uneven subparameters lengths.
+    sub_param_list2 = [
+        {"value2": [0, 1]},  # 2 repeats
+        {"value2": [10, 11, 12]},  # 3 repeats
+        {"value2": []},  # 0 repeats
+        {"value2": [30], "value3": [40]},  # 1 repeat with extra (ignored) column
+    ]
+    value2_uneven = StateExpansionNode(
+        param_names=["value2"],
+        param_values=GivenValueList(sub_param_list2),
+    )
+    value1.reset()  # Reset the value1 node to trigger a new expansion with the new subparameters.
+    add_node_uneven = _AddModel(
+        value1=value1,
+        value2=value2_uneven.value2,
+        node_label="add_uneven",
+    )
+
+    state = add_node_uneven.sample_parameters(num_samples=4)
+    assert state.num_samples == 6
+    assert state["add_uneven"]["value1"].tolist() == [0, 0, 10, 10, 10, 30]
+    assert state["add_uneven"]["value2"].tolist() == [0, 1, 10, 11, 12, 30]
+    assert state["add_uneven"]["value_sum"].tolist() == [0, 1, 20, 21, 22, 60]

--- a/tests/lightcurvelynx/test_graph_state.py
+++ b/tests/lightcurvelynx/test_graph_state.py
@@ -768,6 +768,99 @@ def test_graph_state_update_multi():
         state.update(state4)
 
 
+def test_graph_state_repeat_multi_sample():
+    """Test that repeat correctly expands a multi-sample GraphState."""
+    state = GraphState(num_samples=3)
+    state.set("a", "v1", [1.0, 2.0, 3.0])
+    state.set("a", "v2", [10.0, 20.0, 30.0])
+    state.set("b", "v1", [-1.0, -2.0, -3.0])
+
+    # We fail if the length of the repeat array does not match the number of samples.
+    with pytest.raises(ValueError):
+        state.repeat([2, 0])
+
+    # We fail if the repeat array contains negative values or non-integer values.
+    with pytest.raises(ValueError):
+        state.repeat([2, -1, 3])
+    with pytest.raises(TypeError):
+        state.repeat([2, 0.5, 3])
+
+    # We fail if we would remove all the values.
+    with pytest.raises(ValueError):
+        state.repeat([0, 0, 0])
+
+    # Do a valid repeat and check the results.
+    state.repeat([2, 0, 3])
+    assert state.num_samples == 5
+    assert np.array_equal(state["a"]["v1"], [1.0, 1.0, 3.0, 3.0, 3.0])
+    assert np.array_equal(state["a"]["v2"], [10.0, 10.0, 30.0, 30.0, 30.0])
+    assert np.array_equal(state["b"]["v1"], [-1.0, -1.0, -3.0, -3.0, -3.0])
+
+
+def test_graph_state_repeat_multi_to_single():
+    """Test that repeat correctly 'expands' a multi-sample GraphState to a
+    single-sample GraphState."""
+    state = GraphState(num_samples=3)
+    state.set("a", "v1", [1.0, 2.0, 3.0])
+    state.set("a", "v2", [10.0, 20.0, 30.0])
+    state.set("b", "v1", [-1.0, -2.0, -3.0])
+
+    # Do a valid repeat and check the results.
+    state.repeat([0, 1, 0])
+    assert state.num_samples == 1
+    assert np.isscalar(state["a"]["v1"])
+    assert state["a"]["v1"] == 2.0
+    assert np.isscalar(state["a"]["v2"])
+    assert state["a"]["v2"] == 20.0
+    assert np.isscalar(state["b"]["v1"])
+    assert state["b"]["v1"] == -2.0
+
+
+def test_graph_state_repeat_single_sample():
+    """Test that repeat correctly expands a single-sample GraphState."""
+    state = GraphState(num_samples=1)
+    state.set("a", "v1", 2.5)
+    state.set("b", "v1", -4.0)
+
+    state.repeat([4])
+    assert state.num_samples == 4
+    assert np.array_equal(state["a"]["v1"], [2.5, 2.5, 2.5, 2.5])
+    assert np.array_equal(state["b"]["v1"], [-4.0, -4.0, -4.0, -4.0])
+
+
+def test_graph_state_repeat_single_to_single():
+    """Test that repeat handle a single-sample GraphState with repeat = 1."""
+    state = GraphState(num_samples=1)
+    state.set("a", "v1", 2.5)
+    state.set("b", "v1", -4.0)
+
+    state.repeat([1])
+    assert state.num_samples == 1
+    assert np.isscalar(state["a"]["v1"])
+    assert state["a"]["v1"] == 2.5
+    assert np.isscalar(state["b"]["v1"])
+    assert state["b"]["v1"] == -4.0
+
+
+def test_graph_state_repeat_integer_shortcut():
+    """Test that repeat accepts a scalar integer and applies it to all samples."""
+    state = GraphState(num_samples=3)
+    state.set("a", "v1", [1.0, 2.0, 3.0])
+
+    # We fail with invalid values.
+    with pytest.raises(ValueError):
+        state.repeat(0)
+    with pytest.raises(ValueError):
+        state.repeat(-1)
+    with pytest.raises(TypeError):
+        state.repeat(1.5)
+
+    # Valid repeat value.
+    state.repeat(2)
+    assert state.num_samples == 6
+    assert np.array_equal(state["a"]["v1"], [1.0, 1.0, 2.0, 2.0, 3.0, 3.0])
+
+
 def test_graph_to_from_file(tmp_path):
     """Test that we can create an AstroPy Table from a GraphState."""
     state = GraphState(num_samples=3)

--- a/tests/lightcurvelynx/test_graph_state.py
+++ b/tests/lightcurvelynx/test_graph_state.py
@@ -796,6 +796,14 @@ def test_graph_state_repeat_multi_sample():
     assert np.array_equal(state["a"]["v2"], [10.0, 10.0, 30.0, 30.0, 30.0])
     assert np.array_equal(state["b"]["v1"], [-1.0, -1.0, -3.0, -3.0, -3.0])
 
+    # We can repeat again and it works as expected (note that we need to define the
+    # repeat array with the new number of samples).
+    state.repeat([1, 2, 1, 0, 3])
+    assert state.num_samples == 7
+    assert np.array_equal(state["a"]["v1"], [1.0, 1.0, 1.0, 3.0, 3.0, 3.0, 3.0])
+    assert np.array_equal(state["a"]["v2"], [10.0, 10.0, 10.0, 30.0, 30.0, 30.0, 30.0])
+    assert np.array_equal(state["b"]["v1"], [-1.0, -1.0, -1.0, -3.0, -3.0, -3.0, -3.0])
+
 
 def test_graph_state_repeat_multi_to_single():
     """Test that repeat correctly 'expands' a multi-sample GraphState to a


### PR DESCRIPTION
This is step 1 of at least three in supporting #844. This PR introduces code that will allow the sampler to receive a list of dictionaries for correlated parameters (different observations of the same lensed source), flatten them, and insert them into the `GraphState`. It expands the rows of the `GraphState` such that each previous row is repeated once for each of the subparameters.

This will be used for the lensing effect to create parameters for dRA, dDEC, and dT0. In later PRs, we will introduce code to apply those offsets during and effect (this will require some new functionality in `BasePhysicalModel`).