### PR TITLE
Create the ability to offset an object's core parameters

### DIFF
--- a/src/lightcurvelynx/base_models.py
+++ b/src/lightcurvelynx/base_models.py
@@ -546,7 +546,6 @@ class ParameterizedNode:
         self,
         name,
         value=None,
-        *,
         allow_gradient=None,
         description=None,
         add_at_front=False,

--- a/src/lightcurvelynx/base_models.py
+++ b/src/lightcurvelynx/base_models.py
@@ -119,6 +119,22 @@ class _ParameterSource:
         elif self.source_type == self.COMPUTE_OUTPUT:
             print("    Source: Result of computation within this node")
 
+    def set_from_parameter_source(self, source_info):
+        """Set the parameter from another _ParameterSource. This effectively
+        copies the source information from one parameter to another.
+
+        Parameters
+        ----------
+        source_info : _ParameterSource
+            The source information to copy.
+        """
+        # We do not set parameter name, node name, or description since those will be unique
+        # to the receiving parameter.
+        self.source_type = source_info.source_type
+        self.allow_gradient = source_info.allow_gradient
+        self.dependency = source_info.dependency
+        self.value = source_info.value
+
     def set_as_constant(self, value, allow_gradient=True):
         """Set the parameter as a constant value.
 
@@ -474,7 +490,10 @@ class ParameterizedNode:
             # The value wasn't set, but the name is in kwargs.
             value = kwargs[name]
 
-        if callable(value):
+        if isinstance(value, _ParameterSource):
+            # If the value is already a _ParameterSource, we just copy the parts that should change.
+            self.setters[name].set_from_parameter_source(value)
+        elif callable(value):
             if isinstance(value, _AttributeIndicatorNode):
                 # Case 1a: This is an attribute of a ParameterizedNode.
                 # We set the parameter's value in this node as the extraction of the
@@ -523,7 +542,16 @@ class ParameterizedNode:
         """
         self.setters[name].allow_gradient = allow_gradient
 
-    def add_parameter(self, name, value=None, allow_gradient=None, description=None, **kwargs):
+    def add_parameter(
+        self,
+        name,
+        value=None,
+        *,
+        allow_gradient=None,
+        description=None,
+        add_at_front=False,
+        **kwargs,
+    ):
         """Add a single *new* parameter to the ParameterizedNode.
 
         Note
@@ -547,6 +575,10 @@ class ParameterizedNode:
             Default: None
         description : str, optional
             A brief description of the parameter.
+        add_at_front : bool, optional
+            Add the parameter at the front the setters dictionary instead of the end. Since the order
+            of insertion must match the dependency order, this should be used with care.
+            Default: False.
         **kwargs : dict, optional
            All other keyword arguments, possibly including the parameter setters.
 
@@ -567,12 +599,16 @@ class ParameterizedNode:
         # Add an entry for the setter function and fill in the remaining information using
         # set_parameter(). We add an initial (dummy) value here to indicate that this parameter
         # exists and was added via add_parameter().
-        self.setters[name] = _ParameterSource(
+        dummy_parameter_source = _ParameterSource(
             parameter_name=name,
             source_type=_ParameterSource.UNDEFINED,
             node_name=str(self),
             description=description,
         )
+        if add_at_front:
+            self.setters = {name: dummy_parameter_source, **self.setters}
+        else:
+            self.setters[name] = dummy_parameter_source
         self.set_parameter(name, value, **kwargs)
 
         # Check if we should override allow_gradient.

--- a/src/lightcurvelynx/base_models.py
+++ b/src/lightcurvelynx/base_models.py
@@ -542,15 +542,7 @@ class ParameterizedNode:
         """
         self.setters[name].allow_gradient = allow_gradient
 
-    def add_parameter(
-        self,
-        name,
-        value=None,
-        allow_gradient=None,
-        description=None,
-        add_at_front=False,
-        **kwargs,
-    ):
+    def add_parameter(self, name, value=None, allow_gradient=None, description=None, **kwargs):
         """Add a single *new* parameter to the ParameterizedNode.
 
         Note
@@ -574,10 +566,6 @@ class ParameterizedNode:
             Default: None
         description : str, optional
             A brief description of the parameter.
-        add_at_front : bool, optional
-            Add the parameter at the front the setters dictionary instead of the end. Since the order
-            of insertion must match the dependency order, this should be used with care.
-            Default: False.
         **kwargs : dict, optional
            All other keyword arguments, possibly including the parameter setters.
 
@@ -598,16 +586,12 @@ class ParameterizedNode:
         # Add an entry for the setter function and fill in the remaining information using
         # set_parameter(). We add an initial (dummy) value here to indicate that this parameter
         # exists and was added via add_parameter().
-        dummy_parameter_source = _ParameterSource(
+        self.setters[name] = _ParameterSource(
             parameter_name=name,
             source_type=_ParameterSource.UNDEFINED,
             node_name=str(self),
             description=description,
         )
-        if add_at_front:
-            self.setters = {name: dummy_parameter_source, **self.setters}
-        else:
-            self.setters[name] = dummy_parameter_source
         self.set_parameter(name, value, **kwargs)
 
         # Check if we should override allow_gradient.

--- a/src/lightcurvelynx/models/physical_model.py
+++ b/src/lightcurvelynx/models/physical_model.py
@@ -219,10 +219,18 @@ class BasePhysicalModel(ParameterizedNode, ABC):
             raise ValueError(f"An offset has already been applied to parameter {param_name}.")
         self.add_parameter(
             base_name,
-            self.setters[param_name],  # We do a copy of the original setter
+            self.setters[param_name],  # Copy the original setter
             description=f"Base version of parameter {param_name} before applying offset.",
-            add_at_front=True,  # Make sure base value is computed before the offset version.
         )
+
+        # Place base_<param> immediately before <param> to preserve intra-node dependency order.
+        base_setter = self.setters.pop(base_name)
+        reordered = {}
+        for key, val in self.setters.items():
+            if key == param_name:
+                reordered[base_name] = base_setter
+            reordered[key] = val
+        self.setters = reordered
 
         # Compute the offset using a BasicMathNode.
         offset_modifier = "*" if multiplicative else "+"

--- a/src/lightcurvelynx/models/physical_model.py
+++ b/src/lightcurvelynx/models/physical_model.py
@@ -18,6 +18,7 @@ import numpy as np
 from lightcurvelynx.astro_utils.passbands import Passband, PassbandGroup
 from lightcurvelynx.astro_utils.redshift import RedshiftDistFunc, obs_to_rest_times_waves, rest_to_obs_flux
 from lightcurvelynx.base_models import ParameterizedNode
+from lightcurvelynx.graph_state import GraphState
 from lightcurvelynx.math_nodes.basic_math_node import BasicMathNode
 from lightcurvelynx.utils.extrapolate import FluxExtrapolationModel
 
@@ -198,6 +199,12 @@ class BasePhysicalModel(ParameterizedNode, ABC):
         used to adjust the value of a parameter when applying an effect. Only one offset function can
         be applied to each parameter.
 
+        Note
+        ----
+        Offsets cannot be applied to parameters that are used to derive later parameters (e.g. redshift
+        when it is used to derive distance) since this would change the ordering of computations in the
+        graph and break dependencies.
+
         Parameters
         ----------
         param_name : str
@@ -210,8 +217,20 @@ class BasePhysicalModel(ParameterizedNode, ABC):
             times the offset) or additive (i.e. the new parameter is the original value plus the offset).
             Default: False (additive).
         """
+        # Check that the parameter exists in the model.
         if param_name not in self.setters:
             raise ValueError(f"Parameter {param_name} not found in model.")
+
+        # Check that nothing in this node (transitively) depends on this parameter. We will need
+        # to change its ordering in the setters, which may break dependencies.
+        dependency_graph = self.build_dependency_graph()
+        full_param_name = GraphState.extended_param_name(str(self), param_name)
+        dependent_params = dependency_graph.outgoing[full_param_name]
+        if len(dependent_params) > 0:
+            raise ValueError(
+                f"Cannot apply an offset to parameter {param_name} since other parameters "
+                f"depend on it: {', '.join(dependent_params)}. "
+            )
 
         # We create a base version of the parameter for reference.
         base_name = f"base_{param_name}"
@@ -223,19 +242,21 @@ class BasePhysicalModel(ParameterizedNode, ABC):
             description=f"Base version of parameter {param_name} before applying offset.",
         )
 
-        # Resort the setters to ensure the base parameter comes immediately before the original parameter.
-        # This is important for the correct evaluation order.
+        # Add the new base parameter in the location (sorted ordering) of the original parameter
+        # and the updated parameter at the end. This allows the offset to depend on any other
+        # computed parameters.
         base_setter = self.setters.pop(base_name)  # Remove the new setter from the dictionary.
         new_setters = {}
         for key, val in self.setters.items():
             if key == param_name:
-                # Once we see the original parameter, we add the base parameter BEFORE
-                # the original parameter.
+                # When we see the original parameter, we add the base parameter instead.
                 new_setters[base_name] = base_setter
-            new_setters[key] = val
+            else:
+                new_setters[key] = val
+        new_setters[param_name] = self.setters[param_name]
         self.setters = new_setters
 
-        # Compute the offset using a BasicMathNode.
+        # Compute the offset using a BasicMathNode and overwrite the setter.
         offset_modifier = "*" if multiplicative else "+"
         offset_node = BasicMathNode(
             f"base_value {offset_modifier} offset",

--- a/src/lightcurvelynx/models/physical_model.py
+++ b/src/lightcurvelynx/models/physical_model.py
@@ -18,6 +18,7 @@ import numpy as np
 from lightcurvelynx.astro_utils.passbands import Passband, PassbandGroup
 from lightcurvelynx.astro_utils.redshift import RedshiftDistFunc, obs_to_rest_times_waves, rest_to_obs_flux
 from lightcurvelynx.base_models import ParameterizedNode
+from lightcurvelynx.math_nodes.basic_math_node import BasicMathNode
 from lightcurvelynx.utils.extrapolate import FluxExtrapolationModel
 
 
@@ -191,6 +192,46 @@ class BasePhysicalModel(ParameterizedNode, ABC):
             The effect to add.
         """
         raise NotImplementedError()  # pragma: no cover
+
+    def add_parameter_offset(self, param_name, offset, *, multiplicative=False):
+        """Add an offset computation step to one of the core parameters (RA, Dec, t0, etc.). This is
+        used to adjust the value of a parameter when applying an effect. Only one offset function can
+        be applied to each parameter.
+
+        Parameters
+        ----------
+        param_name : str
+            The name of the parameter to adjust.
+        offset : parameter
+            The additive or multiplicative offset to apply to the parameter. This can be a function
+            of other parameters.
+        multiplicative : bool
+            Whether the offset should be multiplicative (i.e. the new parameter is the original value
+            times the offset) or additive (i.e. the new parameter is the original value plus the offset).
+            Default: False (additive).
+        """
+        if param_name not in self.setters:
+            raise ValueError(f"Parameter {param_name} not found in model.")
+
+        # We create a base version of the parameter for reference.
+        base_name = f"base_{param_name}"
+        if base_name in self.setters:
+            raise ValueError(f"An offset has already been applied to parameter {param_name}.")
+        self.add_parameter(
+            base_name,
+            self.setters[param_name],  # We do a copy of the original setter
+            description=f"Base version of parameter {param_name} before applying offset.",
+            add_at_front=True,  # Make sure base value is computed before the offset version.
+        )
+
+        # Compute the offset using a BasicMathNode.
+        offset_modifier = "*" if multiplicative else "+"
+        offset_node = BasicMathNode(
+            f"base_value {offset_modifier} offset",
+            base_value=getattr(self, base_name),  # Attribute reference for chaining.
+            offset=offset,
+        )
+        self.set_parameter(param_name, offset_node)
 
     def evaluate_bandfluxes(self, passband_or_group, times, filters, state, rng_info=None) -> np.ndarray:
         """Get the band fluxes for a given Passband or PassbandGroup.

--- a/src/lightcurvelynx/models/physical_model.py
+++ b/src/lightcurvelynx/models/physical_model.py
@@ -229,7 +229,7 @@ class BasePhysicalModel(ParameterizedNode, ABC):
         if len(dependent_params) > 0:
             raise ValueError(
                 f"Cannot apply an offset to parameter {param_name} since other parameters "
-                f"depend on it: {', '.join(dependent_params)}. "
+                f"depend on it: {', '.join(dependent_params)}."
             )
 
         # We create a base version of the parameter for reference.
@@ -242,9 +242,9 @@ class BasePhysicalModel(ParameterizedNode, ABC):
             description=f"Base version of parameter {param_name} before applying offset.",
         )
 
-        # Add the new base parameter in the location (sorted ordering) of the original parameter
-        # and the updated parameter at the end. This allows the offset to depend on any other
-        # computed parameters.
+        # Reinsert the parameters in the setters dictionary so that the new base parameter is
+        # in the same location as the original parameter, the original parameter is now at the end,
+        # and everything else stays in the same place (in term of order of keys).
         base_setter = self.setters.pop(base_name)  # Remove the new setter from the dictionary.
         new_setters = {}
         for key, val in self.setters.items():

--- a/src/lightcurvelynx/models/physical_model.py
+++ b/src/lightcurvelynx/models/physical_model.py
@@ -223,14 +223,17 @@ class BasePhysicalModel(ParameterizedNode, ABC):
             description=f"Base version of parameter {param_name} before applying offset.",
         )
 
-        # Place base_<param> immediately before <param> to preserve intra-node dependency order.
-        base_setter = self.setters.pop(base_name)
-        reordered = {}
+        # Resort the setters to ensure the base parameter comes immediately before the original parameter.
+        # This is important for the correct evaluation order.
+        base_setter = self.setters.pop(base_name)  # Remove the new setter from the dictionary.
+        new_setters = {}
         for key, val in self.setters.items():
             if key == param_name:
-                reordered[base_name] = base_setter
-            reordered[key] = val
-        self.setters = reordered
+                # Once we see the original parameter, we add the base parameter BEFORE
+                # the original parameter.
+                new_setters[base_name] = base_setter
+            new_setters[key] = val
+        self.setters = new_setters
 
         # Compute the offset using a BasicMathNode.
         offset_modifier = "*" if multiplicative else "+"

--- a/tests/lightcurvelynx/effects/test_hypothetical_effects.py
+++ b/tests/lightcurvelynx/effects/test_hypothetical_effects.py
@@ -3,10 +3,12 @@ in production, but help stress test the underlying machinery and make sure that 
 are working as expected in a variety of scenarios.
 """
 
+import numpy as np
+from lightcurvelynx.effects.basic_effects import ScaleFluxEffect
 from lightcurvelynx.effects.effect_model import EffectModel
 from lightcurvelynx.math_nodes.given_sampler import GivenValueList
 from lightcurvelynx.math_nodes.state_expansion_node import StateExpansionNode
-from lightcurvelynx.models.basic_models import ConstantSEDModel
+from lightcurvelynx.models.basic_models import ConstantSEDModel, StepModel
 
 
 class _DuplicatingObservationEffect(EffectModel):
@@ -123,3 +125,48 @@ def test_duplicate_object_effects():
     assert state2["basic_model"]["ra"].tolist() == [0.0, 0.0, 90.0, 90.0, 90.0]
     assert state2["basic_model"]["dec"].tolist() == [0.0, 0.0, 10.0, 10.0, 10.0]
     assert state2["basic_model"]["brightness"].tolist() == [10.0, 10.0, 30.0, 30.0, 30.0]
+
+
+def test_fake_lensing_effect():
+    """Test that we can use a combination of the StateExpansionNode and the
+    add_parameter_offset method to create a fake lensing effect.
+    """
+    basic_model = StepModel(
+        brightness=GivenValueList([10.0, 20.0, 30.0]),
+        ra=GivenValueList([0.0, 45.0, 90.0]),
+        dec=GivenValueList([0.0, -10.0, 10.0]),
+        t0=GivenValueList([100.0, 110.0, 120.0]),
+        t1=GivenValueList([200.0, 210.0, 220.0]),
+        node_label="basic_model",
+    )
+
+    # Create a lensing effect that will create duplicates of the observations
+    # with different parameters. We use a dictionary of lists to specify the number
+    # and values of the parameters for each duplicate.
+    lensing_data = StateExpansionNode(
+        param_names=["magnification", "time_delay"],
+        param_values=GivenValueList(
+            [
+                {"magnification": [2.0, 1.0], "time_delay": [10.0, 20.0]},
+                {"magnification": [0.5, 0.8, 0.1], "time_delay": [5.0, 8.0, 100.0]},
+                {"magnification": [1.0], "time_delay": [20.0]},
+            ],
+        ),
+    )
+    basic_model.add_parameter_offset("t0", lensing_data.time_delay)
+    basic_model.add_parameter_offset("t1", lensing_data.time_delay)
+    basic_model.add_effect(ScaleFluxEffect(flux_scale=lensing_data.magnification))
+
+    state = basic_model.sample_parameters(num_samples=3)
+    assert state.num_samples == 6
+    assert state["basic_model"]["ra"].tolist() == [0.0, 0.0, 45.0, 45.0, 45.0, 90.0]
+    assert state["basic_model"]["dec"].tolist() == [0.0, 0.0, -10.0, -10.0, -10.0, 10.0]
+    assert state["basic_model"]["brightness"].tolist() == [10.0, 10.0, 20.0, 20.0, 20.0, 30.0]
+    assert state["basic_model"]["t0"].tolist() == [110.0, 120.0, 115.0, 118.0, 210.0, 140.0]
+    assert state["basic_model"]["t1"].tolist() == [210.0, 220.0, 215.0, 218.0, 310.0, 240.0]
+
+    times = np.array([200.0])
+    wavelengths = np.array([5000.0])
+    flux_density = basic_model.evaluate_sed(times, wavelengths, state)
+    assert flux_density.shape == (6, 1, 1)
+    assert flux_density[:, 0, 0].tolist() == [20.0, 10.0, 10.0, 16.0, 0.0, 30.0]

--- a/tests/lightcurvelynx/models/test_physical_models.py
+++ b/tests/lightcurvelynx/models/test_physical_models.py
@@ -163,11 +163,18 @@ def test_sed_model_offset():
         multiplicative=True,
     )
 
+    # Check that the base parameters come immediately before the offset parameters.
+    param_list = model.list_params()
+    assert param_list.index("base_ra") == param_list.index("ra") - 1
+    assert param_list.index("base_t0") == param_list.index("t0") - 1
+
+    # Check that when we sample, the base parameters are the original values and the
+    # offset parameters are the original values plus (or times) the offset.
     state = model.sample_parameters(num_samples=3)
     assert np.array_equal(state["model"]["base_ra"], [1.0, 1.0, 1.0])
     assert np.array_equal(state["model"]["base_t0"], [1.0, 1.0, 1.0])
-    assert "base_dec" not in state["model"]
-    assert "base_redshift" not in state["model"]
+    assert "base_dec" not in state["model"]  # No offset.
+    assert "base_redshift" not in state["model"]  # No offset.
 
     assert np.array_equal(state["model"]["ra"], [1.1, 1.2, 1.3])
     assert np.array_equal(state["model"]["dec"], [2.0, 2.0, 2.0])

--- a/tests/lightcurvelynx/models/test_physical_models.py
+++ b/tests/lightcurvelynx/models/test_physical_models.py
@@ -145,3 +145,31 @@ def test_sed_model_evaluate_bandflux(passbands_dir):
     assert bandfluxes2.shape == (n_samples, n_passbands)
     for idx, brightness in enumerate(brightness_list):
         np.testing.assert_allclose(bandfluxes2[idx, :], brightness, rtol=1e-10)
+
+
+def test_sed_model_offset():
+    """Test that we can create a SEDModel and apply offsets."""
+    # Everything is specified to start with, but we add an additive offset to RA
+    # and a multiplicative offset to t0.
+    model = SEDModel(ra=1.0, dec=2.0, redshift=0.0, t0=1.0, node_label="model")
+    model.add_parameter_offset(
+        "ra",
+        offset=GivenValueList([0.1, 0.2, 0.3]),
+        multiplicative=False,
+    )
+    model.add_parameter_offset(
+        "t0",
+        offset=GivenValueList([1.0, 0.5, 2.0]),
+        multiplicative=True,
+    )
+
+    state = model.sample_parameters(num_samples=3)
+    assert np.array_equal(state["model"]["base_ra"], [1.0, 1.0, 1.0])
+    assert np.array_equal(state["model"]["base_t0"], [1.0, 1.0, 1.0])
+    assert "base_dec" not in state["model"]
+    assert "base_redshift" not in state["model"]
+
+    assert np.array_equal(state["model"]["ra"], [1.1, 1.2, 1.3])
+    assert np.array_equal(state["model"]["dec"], [2.0, 2.0, 2.0])
+    assert np.array_equal(state["model"]["redshift"], [0.0, 0.0, 0.0])
+    assert np.array_equal(state["model"]["t0"], [1.0, 0.5, 2.0])

--- a/tests/lightcurvelynx/models/test_physical_models.py
+++ b/tests/lightcurvelynx/models/test_physical_models.py
@@ -214,7 +214,7 @@ def test_sed_model_offset_fail():
     assert "base_ra" in model.list_params()
     assert "base_redshift" in model.list_params()
 
-    # But we fail if we try to add a parameter off set for t0.
+    # But we fail if we try to add a parameter offset for t0.
     with pytest.raises(ValueError):
         model.add_parameter_offset(
             "t0",

--- a/tests/lightcurvelynx/models/test_physical_models.py
+++ b/tests/lightcurvelynx/models/test_physical_models.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 from astropy.cosmology import Planck18
 from lightcurvelynx.astro_utils.passbands import PassbandGroup
+from lightcurvelynx.math_nodes.basic_math_node import BasicMathNode
 from lightcurvelynx.math_nodes.given_sampler import GivenValueList
 from lightcurvelynx.models.basic_models import ConstantSEDModel
 from lightcurvelynx.models.physical_model import SEDModel
@@ -163,10 +164,10 @@ def test_sed_model_offset():
         multiplicative=True,
     )
 
-    # Check that the base parameters come immediately before the offset parameters.
+    # Check that the base parameters come before the offset parameters.
     param_list = model.list_params()
-    assert param_list.index("base_ra") == param_list.index("ra") - 1
-    assert param_list.index("base_t0") == param_list.index("t0") - 1
+    assert param_list.index("base_ra") < param_list.index("ra")
+    assert param_list.index("base_t0") < param_list.index("t0")
 
     # Check that when we sample, the base parameters are the original values and the
     # offset parameters are the original values plus (or times) the offset.
@@ -180,3 +181,52 @@ def test_sed_model_offset():
     assert np.array_equal(state["model"]["dec"], [2.0, 2.0, 2.0])
     assert np.array_equal(state["model"]["redshift"], [0.0, 0.0, 0.0])
     assert np.array_equal(state["model"]["t0"], [1.0, 0.5, 2.0])
+
+
+def test_sed_model_offset_fail():
+    """Test that we fail to create a parameter offset if there are dependencies."""
+    # Everything is specified to start with, but we add an additive offset to RA
+    # and a multiplicative offset to t0.
+    t0_list = GivenValueList([1.0, 2.0, 10.0])
+    model = SEDModel(ra=1.0, dec=2.0, redshift=0.01, t0=t0_list, node_label="model")
+    model.add_parameter(
+        "t0_minus_50",
+        BasicMathNode("t0 - 50", t0=model.t0),
+        description="The start of interesting time for the event: t0 minus 50",
+    )
+
+    # We correctly condition t0_minus_50 on t0.
+    state = model.sample_parameters(num_samples=3)
+    assert np.array_equal(state["model"]["t0"], [1.0, 2.0, 10.0])
+    assert np.array_equal(state["model"]["t0_minus_50"], [-49.0, -48.0, -40.0])
+
+    # We can add a parameter offset to ra or redshift since nothing depends on them.
+    model.add_parameter_offset(
+        "ra",
+        offset=GivenValueList([0.1, 0.2, 0.3]),
+        multiplicative=False,
+    )
+    model.add_parameter_offset(
+        "redshift",
+        offset=GivenValueList([0.01, 0.02, 0.03]),
+        multiplicative=False,
+    )
+    assert "base_ra" in model.list_params()
+    assert "base_redshift" in model.list_params()
+
+    # But we fail if we try to add a parameter off set for t0.
+    with pytest.raises(ValueError):
+        model.add_parameter_offset(
+            "t0",
+            offset=GivenValueList([1.0, 0.5, 2.0]),
+            multiplicative=True,
+        )
+
+    # We also fail if we try to change redshift in a model where distance depends on it.
+    model2 = SEDModel(ra=1.0, dec=2.0, redshift=0.01, cosmology=Planck18, node_label="model2")
+    with pytest.raises(ValueError):
+        model2.add_parameter_offset(
+            "redshift",
+            offset=GivenValueList([0.01, 0.02, 0.03]),
+            multiplicative=False,
+        )

--- a/tests/lightcurvelynx/test_base_models.py
+++ b/tests/lightcurvelynx/test_base_models.py
@@ -239,20 +239,6 @@ def test_parameterized_node(capsys):
         _ = model1.sample_parameters(num_samples=0)
 
 
-def test_parameterized_node_add_at_front():
-    """Test that we can add a parameter at the front of the setters dictionary."""
-    model = _PairModel(value1=0.5, value2=0.5)
-    assert list(model.setters.keys()) == ["value1", "value2", "value_sum"]
-
-    # By default adding a parameter adds it at the end of the setters dictionary.
-    model.add_parameter("new_param_1", 1.0)
-    assert list(model.setters.keys()) == ["value1", "value2", "value_sum", "new_param_1"]
-
-    # But we can also add the parameter at the front of the setters dictionary.
-    model.add_parameter("new_param_2", 2.0, add_at_front=True)
-    assert list(model.setters.keys()) == ["new_param_2", "value1", "value2", "value_sum", "new_param_1"]
-
-
 def test_parameterized_node_label_collision():
     """Test that throw an error when two nodes use the same label."""
     node_a = SingleVariableNode("A", 10.0, node_label="A")

--- a/tests/lightcurvelynx/test_base_models.py
+++ b/tests/lightcurvelynx/test_base_models.py
@@ -31,8 +31,9 @@ def _test_func(value1, value2):
     return value1 + value2
 
 
-class PairModel(ParameterizedNode):
-    """A test class for the ParameterizedNode.
+class _PairModel(ParameterizedNode):
+    """A test class for the ParameterizedNode that takes two values
+    and computes their sum as a parameter.
 
     Parameters
     ----------
@@ -40,8 +41,6 @@ class PairModel(ParameterizedNode):
         The first value.
     value2 : `float`
         The second value.
-    value_sum : `float`
-        The sum of the two values.
     **kwargs : `dict`, optional
         Any additional keyword arguments.
     """
@@ -84,6 +83,7 @@ def test_parameter_source(capsys):
     with pytest.raises(ValueError):
         source.set_as_constant(_test_func)
 
+    # We can set a node from another node's parameter.
     node = SingleVariableNode("A", 20.0, node_label="single")
     source.set_as_parameter(node, "A")
     assert source.source_type == _ParameterSource.MODEL_PARAMETER
@@ -94,21 +94,42 @@ def test_parameter_source(capsys):
     captured = capsys.readouterr()
     assert "Source: MODEL_PARAMETER A of node single" in captured.out
 
+    # Test that we can set a second source as a 'copy' of the first one.
+    source2 = _ParameterSource("test2", node_name="node2", description="A test parameter")
+    source2.set_from_parameter_source(source)
+    assert source2.parameter_name == "test2"
+    assert source2.node_name == "node2"
+    assert source2.source_type == _ParameterSource.MODEL_PARAMETER
+    assert source2.dependency is node
+    assert source2.value == "A"
+    assert source2.description == "A test parameter"
+
+    # We can set a node as a function output.
     func = FunctionNode(_test_func, value1=0.1, value2=0.4)
     source.set_as_function(func)
     assert source.source_type == _ParameterSource.FUNCTION_NODE
+    assert source.value == "function_node_result"
     assert source.dependency is func
 
     source.help()
     captured = capsys.readouterr()
     assert "Source: Result of FUNCTION_NODE" in captured.out
 
+    # We can copy this source function as well.
+    source2.set_from_parameter_source(source)
+    assert source2.parameter_name == "test2"
+    assert source2.node_name == "node2"
+    assert source2.source_type == _ParameterSource.FUNCTION_NODE
+    assert source2.dependency is func
+    assert source2.value == "function_node_result"
+    assert source2.description == "A test parameter"
+
 
 def test_parameterized_node(capsys):
-    """Test that we can sample and create a PairModel object."""
+    """Test that we can sample and create a _PairModel object."""
     # Simple addition
-    model1 = PairModel(value1=0.5, value2=0.5)
-    assert str(model1) == "PairModel"
+    model1 = _PairModel(value1=0.5, value2=0.5)
+    assert str(model1) == "_PairModel"
 
     # Check that we can access the parameter indicators.
     assert model1.value1 is not None
@@ -161,10 +182,10 @@ def test_parameterized_node(capsys):
     # If we set a position (and there is no node_label), the position shows up in the name.
     model1.node_pos = 100
     model1._update_node_string()
-    assert str(model1) == "PairModel_100"
+    assert str(model1) == "_PairModel_100"
 
     # Use value1=model.value and value2=1.0
-    model2 = PairModel(value1=model1.value1, value2=1.0, node_label="test")
+    model2 = _PairModel(value1=model1.value1, value2=1.0, node_label="test")
     assert str(model2) == "test"
 
     state = model2.sample_parameters()
@@ -174,14 +195,14 @@ def test_parameterized_node(capsys):
 
     # Compute value1 from model2's result and value2 from the sampler function.
     # The sampler function is auto-wrapped in a FunctionNode.
-    model3 = PairModel(value1=model2.value_sum, value2=_sampler_fun)
+    model3 = _PairModel(value1=model2.value_sum, value2=_sampler_fun)
     state = model3.sample_parameters()
     rand_val = model3.get_param(state, "value2")
     assert model3.get_param(state, "value_sum") == pytest.approx(1.5 + rand_val)
 
     # Compute value1 from model3's result (which is itself the result for model2 +
     # a random value) and value2 = -1.0.
-    model4 = PairModel(value1=model3.value_sum, value2=-1.0)
+    model4 = _PairModel(value1=model3.value_sum, value2=-1.0)
     state = model4.sample_parameters()
     rand_val = model3.get_param(state, "value2")
     assert model4.get_param(state, "value_sum") == pytest.approx(0.5 + rand_val)
@@ -218,12 +239,26 @@ def test_parameterized_node(capsys):
         _ = model1.sample_parameters(num_samples=0)
 
 
+def test_parameterized_node_add_at_front():
+    """Test that we can add a parameter at the front of the setters dictionary."""
+    model = _PairModel(value1=0.5, value2=0.5)
+    assert list(model.setters.keys()) == ["value1", "value2", "value_sum"]
+
+    # By default adding a parameter adds it at the end of the setters dictionary.
+    model.add_parameter("new_param_1", 1.0)
+    assert list(model.setters.keys()) == ["value1", "value2", "value_sum", "new_param_1"]
+
+    # But we can also add the parameter at the front of the setters dictionary.
+    model.add_parameter("new_param_2", 2.0, add_at_front=True)
+    assert list(model.setters.keys()) == ["new_param_2", "value1", "value2", "value_sum", "new_param_1"]
+
+
 def test_parameterized_node_label_collision():
     """Test that throw an error when two nodes use the same label."""
     node_a = SingleVariableNode("A", 10.0, node_label="A")
     node_b = SingleVariableNode("B", 20.0, node_label="B")
-    pair1 = PairModel(value1=node_a.A, value2=node_b.B, node_label="pair1")
-    pair2 = PairModel(value1=pair1.value_sum, value2=node_b.B, node_label="pair2")
+    pair1 = _PairModel(value1=node_a.A, value2=node_b.B, node_label="pair1")
+    pair2 = _PairModel(value1=pair1.value_sum, value2=node_b.B, node_label="pair2")
 
     # No collision even though node_b is referenced twice.
     state = pair2.sample_parameters()
@@ -233,14 +268,14 @@ def test_parameterized_node_label_collision():
     # We run into a problem if we reuse a label. Label "A" collides multiple
     # levels above.
     node_c = SingleVariableNode("C", 5.0, node_label="C")
-    pair3 = PairModel(value1=pair2.value_sum, value2=node_c.C, node_label="A")
+    pair3 = _PairModel(value1=pair2.value_sum, value2=node_c.C, node_label="A")
     with pytest.raises(ValueError):
         _ = pair3.sample_parameters()
 
 
 def test_parameterized_node_modify():
     """Test that we can modify the parameters in a node."""
-    model = PairModel(value1=0.5, value2=0.5)
+    model = _PairModel(value1=0.5, value2=0.5)
 
     # We cannot add a parameter a second time.
     with pytest.raises(KeyError):
@@ -270,7 +305,7 @@ def test_parameterized_node_self_parameter():
 
 def test_parameterized_build_dependency_graph():
     """Test that we can build a dependency graph of a simple ParameterizedNode."""
-    model1 = PairModel(value1=0.15, value2=0.5, node_label="A")
+    model1 = _PairModel(value1=0.15, value2=0.5, node_label="A")
     dep_graph = model1.build_dependency_graph()
     assert "A" in dep_graph.all_nodes
 
@@ -322,9 +357,9 @@ def test_parameterized_node_from_node():
     """Test that we can no longer set the values of a parameterized node directly
     from the values of another parameterized node as this is a confusing pattern.
     """
-    model1 = PairModel(value1=0.5, value2=1.5, node_label="A")
+    model1 = _PairModel(value1=0.5, value2=1.5, node_label="A")
     with pytest.raises(ValueError):
-        _ = PairModel(value1=model1, value2=model1, node_label="B")
+        _ = _PairModel(value1=model1, value2=model1, node_label="B")
 
 
 def test_parameterized_node_overwrite_fun():
@@ -350,8 +385,8 @@ def test_parameterized_node_overwrite_fun():
 
 def test_parameterized_node_build_pytree():
     """Test that we can extract the PyTree of a graph."""
-    model1 = PairModel(value1=0.5, value2=1.5, node_label="A")
-    model2 = PairModel(value1=model1.value1, value2=3.0, node_label="B")
+    model1 = _PairModel(value1=0.5, value2=1.5, node_label="A")
+    model2 = _PairModel(value1=model1.value1, value2=3.0, node_label="B")
     graph_state = model2.sample_parameters()
 
     pytree = model2.build_pytree(graph_state)
@@ -408,7 +443,7 @@ def test_no_resample_functions():
     """Test that if we use the same node as dependencies in two other nodes, we do not resample it."""
     rand_val = FunctionNode(_sampler_fun)
     node_a = SingleVariableNode("A", rand_val)
-    node_b = PairModel(value1=node_a.A, value2=rand_val)
+    node_b = _PairModel(value1=node_a.A, value2=rand_val)
     state = node_b.sample_parameters()
 
     # All the values should be the same (no resampling of A.)
@@ -457,12 +492,12 @@ def test_function_node_obj():
     """
     # The model depends on the function.
     func = FunctionNode(_test_func, value1=5.0, value2=6.0)
-    model = PairModel(value1=10.0, value2=func)
+    model = _PairModel(value1=10.0, value2=func)
     state = model.sample_parameters()
     assert model.get_param(state, "value_sum") == 21.0
 
     # Function depends on the model's value2 parameter.
-    model = PairModel(value1=-10.0, value2=17.5)
+    model = _PairModel(value1=-10.0, value2=17.5)
     func = FunctionNode(_test_func, value1=5.0, value2=model.value2, outputs=["res"])
     state = func.sample_parameters()
 
@@ -504,7 +539,7 @@ def test_function_node_multi():
     assert dep_graph.outgoing["test.value2"] == set(["test.sum_res", "test.diff_res"])
 
     # Build a model that takes the two outputs of the FunctionNode as inputs.
-    model = PairModel(value1=my_func.sum_res, value2=my_func.diff_res, node_label="A")
+    model = _PairModel(value1=my_func.sum_res, value2=my_func.diff_res, node_label="A")
     state = model.sample_parameters()
 
     assert model.get_param(state, "value1") == 11.0


### PR DESCRIPTION
This is step 2a of at least three in #844 (also see #875). This PR introduces code that will allows an offset to be applied for parameters such as ra, dec, t0. The code creates a "base" version using the original setter and then uses that (along with the offset) to update the parameter.

The code requires that the modified parameter is not required for the computation of any other parameter in the node, because modifying parameters changes their ordering and can break dependencies. We might be able to relax this restriction in the future if needed.