### PR TITLE
Handle pre-explosion times in RedbackWrapperModel

### DIFF
--- a/src/lightcurvelynx/models/redback_models.py
+++ b/src/lightcurvelynx/models/redback_models.py
@@ -390,12 +390,6 @@ class RedbackWrapperModel(SEDModel, CiteClass):
         # simulated survey, which is the physically correct behaviour.
         post_explosion = shifted_times >= 0.0
         post_times = shifted_times[post_explosion]
-
-        # Determine the output shape: (n_wavelengths, n_times) or (n_times,).
-        if wavelengths.ndim == 0 or np.ndim(wavelengths) == 0:
-            n_wave = 1
-        else:
-            n_wave = len(wavelengths)
         n_time = len(shifted_times)
 
         if post_times.size > 0:
@@ -407,20 +401,21 @@ class RedbackWrapperModel(SEDModel, CiteClass):
                 flam_unit=self._FLAM_UNIT,
                 fnu_unit=uu.nJy,
             )
-        else:
-            # No post-explosion times — return all zeros.
-            if n_wave > 1:
-                model_fnu_post = np.zeros((n_wave, 0))
+            # model_fnu_post is either (n_wave, n_post_times) or (n_post_times,).
+            # Build the full output with zeros for pre-explosion entries.
+            if model_fnu_post.ndim == 2:
+                model_fnu = np.zeros((model_fnu_post.shape[0], n_time))
+                model_fnu[:, post_explosion] = model_fnu_post
             else:
-                model_fnu_post = np.zeros(0)
-
-        # Reconstruct the full output array, inserting zeros for pre-explosion times.
-        if n_wave > 1:
-            model_fnu = np.zeros((n_wave, n_time))
-            model_fnu[:, post_explosion] = model_fnu_post
+                model_fnu = np.zeros(n_time)
+                model_fnu[post_explosion] = model_fnu_post
         else:
-            model_fnu = np.zeros(n_time)
-            model_fnu[post_explosion] = model_fnu_post
+            # All times are pre-explosion — probe shape with a dummy call at t=0.1.
+            dummy_flam = rb_result.get_flux_density(np.array([0.1]), wavelengths)
+            if dummy_flam.ndim == 2:
+                model_fnu = np.zeros((dummy_flam.shape[0], n_time))
+            else:
+                model_fnu = np.zeros(n_time)
 
         # Clear the cached data values if we created them locally.
         if created_cache:

--- a/src/lightcurvelynx/models/redback_models.py
+++ b/src/lightcurvelynx/models/redback_models.py
@@ -410,16 +410,16 @@ class RedbackWrapperModel(SEDModel, CiteClass):
         else:
             # No post-explosion times — return all zeros.
             if n_wave > 1:
-                model_fnu_post = np.zeros((n_wave, 0)) * uu.nJy
+                model_fnu_post = np.zeros((n_wave, 0))
             else:
-                model_fnu_post = np.zeros(0) * uu.nJy
+                model_fnu_post = np.zeros(0)
 
         # Reconstruct the full output array, inserting zeros for pre-explosion times.
         if n_wave > 1:
-            model_fnu = np.zeros((n_wave, n_time)) * uu.nJy
+            model_fnu = np.zeros((n_wave, n_time))
             model_fnu[:, post_explosion] = model_fnu_post
         else:
-            model_fnu = np.zeros(n_time) * uu.nJy
+            model_fnu = np.zeros(n_time)
             model_fnu[post_explosion] = model_fnu_post
 
         # Clear the cached data values if we created them locally.

--- a/src/lightcurvelynx/models/redback_models.py
+++ b/src/lightcurvelynx/models/redback_models.py
@@ -388,6 +388,10 @@ class RedbackWrapperModel(SEDModel, CiteClass):
         # defined for time >= 0 (time since explosion). Pre-explosion observations
         # are assigned zero flux so that they appear as non-detections in the
         # simulated survey, which is the physically correct behaviour.
+        #
+        # get_flux_density returns shape (n_times, n_waves). We evaluate only the
+        # post-explosion times, then reconstruct the full (n_times, n_waves) array
+        # with zeros for pre-explosion rows.
         post_explosion = shifted_times >= 0.0
         post_times = shifted_times[post_explosion]
         n_time = len(shifted_times)
@@ -401,11 +405,10 @@ class RedbackWrapperModel(SEDModel, CiteClass):
                 flam_unit=self._FLAM_UNIT,
                 fnu_unit=uu.nJy,
             )
-            # model_fnu_post is either (n_wave, n_post_times) or (n_post_times,).
-            # Build the full output with zeros for pre-explosion entries.
+            # Reconstruct full (n_time, n_waves) array with zeros for pre-explosion rows.
             if model_fnu_post.ndim == 2:
-                model_fnu = np.zeros((model_fnu_post.shape[0], n_time))
-                model_fnu[:, post_explosion] = model_fnu_post
+                model_fnu = np.zeros((n_time, model_fnu_post.shape[1]))
+                model_fnu[post_explosion] = model_fnu_post
             else:
                 model_fnu = np.zeros(n_time)
                 model_fnu[post_explosion] = model_fnu_post
@@ -413,7 +416,7 @@ class RedbackWrapperModel(SEDModel, CiteClass):
             # All times are pre-explosion — probe shape with a dummy call at t=0.1.
             dummy_flam = rb_result.get_flux_density(np.array([0.1]), wavelengths)
             if dummy_flam.ndim == 2:
-                model_fnu = np.zeros((dummy_flam.shape[0], n_time))
+                model_fnu = np.zeros((n_time, dummy_flam.shape[1]))
             else:
                 model_fnu = np.zeros(n_time)
 

--- a/src/lightcurvelynx/models/redback_models.py
+++ b/src/lightcurvelynx/models/redback_models.py
@@ -272,10 +272,13 @@ class RedbackWrapperModel(SEDModel, CiteClass):
             t0 = 0.0
         shifted_times = times - t0
 
-        # Only evaluate the model within its phase bounds. If we end up with no times,
-        # we use phase=0.1 in order to get the wavelength bounds.
-        if self._min_phase is not None:
-            shifted_times = shifted_times[shifted_times >= self._min_phase]
+        # Only evaluate the model within its phase bounds. Explosion-based redback
+        # models are only defined for time >= 0 (time since explosion), so we always
+        # clip to the effective minimum phase (max of 0 and any user-supplied lower
+        # bound). If we end up with no post-explosion times, use phase=0.1 so we can
+        # still infer the wavelength bounds from a valid model evaluation.
+        min_phase = max(0.0, self._min_phase) if self._min_phase is not None else 0.0
+        shifted_times = shifted_times[shifted_times >= min_phase]
         if self._max_phase is not None:
             shifted_times = shifted_times[shifted_times <= self._max_phase]
         if len(shifted_times) == 0:
@@ -380,16 +383,44 @@ class RedbackWrapperModel(SEDModel, CiteClass):
             t0 = 0.0
         shifted_times = times - t0
 
-        # Query the RedbackTimeSeriesSource at the given times and wavelengths.
-        # Then convert the output to nJy.
-        model_flam = rb_result.get_flux_density(shifted_times, wavelengths)
-        model_fnu = flam_to_fnu(
-            model_flam,
-            wavelengths,
-            wave_unit=uu.AA,
-            flam_unit=self._FLAM_UNIT,
-            fnu_unit=uu.nJy,
-        )
+        # Split times into post-explosion (>= 0) and pre-explosion (< 0).
+        # Explosion-based redback models (kilonovae, supernovae, etc.) are only
+        # defined for time >= 0 (time since explosion). Pre-explosion observations
+        # are assigned zero flux so that they appear as non-detections in the
+        # simulated survey, which is the physically correct behaviour.
+        post_explosion = shifted_times >= 0.0
+        post_times = shifted_times[post_explosion]
+
+        # Determine the output shape: (n_wavelengths, n_times) or (n_times,).
+        if wavelengths.ndim == 0 or np.ndim(wavelengths) == 0:
+            n_wave = 1
+        else:
+            n_wave = len(wavelengths)
+        n_time = len(shifted_times)
+
+        if post_times.size > 0:
+            model_flam_post = rb_result.get_flux_density(post_times, wavelengths)
+            model_fnu_post = flam_to_fnu(
+                model_flam_post,
+                wavelengths,
+                wave_unit=uu.AA,
+                flam_unit=self._FLAM_UNIT,
+                fnu_unit=uu.nJy,
+            )
+        else:
+            # No post-explosion times — return all zeros.
+            if n_wave > 1:
+                model_fnu_post = np.zeros((n_wave, 0)) * uu.nJy
+            else:
+                model_fnu_post = np.zeros(0) * uu.nJy
+
+        # Reconstruct the full output array, inserting zeros for pre-explosion times.
+        if n_wave > 1:
+            model_fnu = np.zeros((n_wave, n_time)) * uu.nJy
+            model_fnu[:, post_explosion] = model_fnu_post
+        else:
+            model_fnu = np.zeros(n_time) * uu.nJy
+            model_fnu[post_explosion] = model_fnu_post
 
         # Clear the cached data values if we created them locally.
         if created_cache:


### PR DESCRIPTION
## Summary

Explosion-based redback models (kilonovae, supernovae, etc.) are only defined for `time >= 0` (days since explosion). Previously, if `obs_time_window_offset` included times before the explosion (e.g. `(-5, 20)`), `RedbackWrapperModel` would pass negative shifted times to the source function, causing crashes or garbage flux values.

This PR fixes `compute_sed` to split observations into pre- and post-explosion, evaluate the model only for post-explosion times, and return zero flux for pre-explosion observations. `_do_bounds_precomputation` is also updated to clip to `time >= 0` when determining wavelength bounds.

With this change, users can safely use negative `obs_time_window_offset` starts to simulate realistic pre-explosion non-detections, which will appear as sub-threshold observations in `results_augment_lightcurves`.

## Changes

- `compute_sed`: split `shifted_times` into pre/post-explosion; evaluate source only on post-explosion times; reconstruct full output with zeros for pre-explosion entries
- `_do_bounds_precomputation`: clip to `min_phase = max(0, _min_phase)` before calling source so bounds inference never hits negative times