### PR TITLE
Address some tutorial notebook issues

### DIFF
--- a/docs/notebooks/introduction.ipynb
+++ b/docs/notebooks/introduction.ipynb
@@ -40,12 +40,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Display logging info messages to the console to help track progress.\n",
+    "# Display logging warning messages to the console to help track progress.\n",
     "# This is optional but useful for long-running simulations.\n",
     "\n",
     "import logging\n",
     "\n",
-    "logging.basicConfig(level=logging.INFO)"
+    "logging.basicConfig(level=logging.WARNING)"
    ]
   },
   {
@@ -336,8 +336,8 @@
     "    amplitude=200.0,\n",
     "    frequency=NumpyRandomFunc(\"uniform\", low=0.01, high=0.1),\n",
     "    t0=60796.0,\n",
-    "    ra=NumpyRandomFunc(\"normal\", loc=200.5, scale=0.01),\n",
-    "    dec=NumpyRandomFunc(\"normal\", loc=-50.0, scale=0.01),\n",
+    "    ra=NumpyRandomFunc(\"normal\", loc=9.25, scale=0.05),\n",
+    "    dec=NumpyRandomFunc(\"normal\", loc=-44.0, scale=0.05),\n",
     "    node_label=\"sin_wave_model\",\n",
     ")\n",
     "\n",
@@ -529,7 +529,9 @@
    "source": [
     "## Saving Data\n",
     "\n",
-    "We can save the results of a simulation using nested-pandas `to_parquet` function. This will save the entire result set in a single file."
+    "We can save the results of a simulation using nested-pandas `to_parquet` function. This will save the entire result set in a single file.\n",
+    "\n",
+    "For this example, we save the results to a temporary directory."
    ]
   },
   {
@@ -539,11 +541,11 @@
    "outputs": [],
    "source": [
     "from pathlib import Path\n",
+    "import tempfile\n",
     "\n",
-    "scratch_dir = Path(\"./scratch\")\n",
-    "scratch_dir.mkdir(exist_ok=True)\n",
-    "\n",
-    "lightcurves.to_parquet(scratch_dir / \"simulated_lightcurves.parquet\")"
+    "with tempfile.TemporaryDirectory() as tmpdir:\n",
+    "    tmp_path = Path(tmpdir) / \"simulated_lightcurves.parquet\"\n",
+    "    lightcurves.to_parquet(tmp_path)"
    ]
   },
   {
@@ -563,7 +565,8 @@
    "source": [
     "from lightcurvelynx.utils.io_utils import write_results_as_hats\n",
     "\n",
-    "write_results_as_hats(scratch_dir / \"lsdb_dir\", lightcurves, overwrite=True)"
+    "with tempfile.TemporaryDirectory() as tmpdir:\n",
+    "    write_results_as_hats(Path(tmpdir) / \"lsdb_dir\", lightcurves, overwrite=True)"
    ]
   },
   {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "PyYAML>=6.0",
     "regions",
     "scipy",
+    "sncosmo",    
     "tqdm",
 ]
 
@@ -56,7 +57,6 @@ dev = [
     "pytest-cov", # Used to report total code coverage
     "pzflow>=4.0",
     "ruff", # Used for static linting of files
-    "sncosmo",
     "synphot", # Used for SED modeling tests
     "VBMicrolensing",  # used for microlensing tests
 ]
@@ -71,7 +71,6 @@ all = [
     "lsdb",  # Used to read and write LSDB catalogs
     "networkx",  # Used for graph visualization
     "pzflow>=4.0",
-    "sncosmo",
     "synphot",  # used for SED modeling tests
     "VBMicrolensing",  # used for microlensing tests
 ]


### PR DESCRIPTION
Address the first few problems from #885 
- Change the logging level in the intro notebook to WARNING to remove noisy messages
- Uses RA and dec that match data set (which we changed recently) so we do not get Nones in the data
- Use temporary directories for output so this runs on the readthedocs servers
- Add sncosmo to the default installs so it can be used by all notebooks
