### PR TITLE
Update mag_flux.py

### DIFF
--- a/src/lightcurvelynx/astro_utils/mag_flux.py
+++ b/src/lightcurvelynx/astro_utils/mag_flux.py
@@ -24,7 +24,9 @@ def mag2flux(mag: npt.ArrayLike) -> npt.ArrayLike:
     """
     return np.power(10.0, -0.4 * (mag - MAG_AB_ZP_NJY))
 
-MAGERR_FACTOR = 2.5 / np.log(10.0) # Factor to convert flux error to magnitude error
+
+MAGERR_FACTOR = 2.5 / np.log(10.0)  # Factor to convert flux error to magnitude error
+
 
 def flux2mag(flux_njy: npt.ArrayLike, flux_err_njy: npt.ArrayLike = None) -> npt.ArrayLike:
     """Convert bandflux in nJy to AB magnitude
@@ -35,14 +37,14 @@ def flux2mag(flux_njy: npt.ArrayLike, flux_err_njy: npt.ArrayLike = None) -> npt
         The bandflux to convert to magnitude.
     flux_err_njy : ndarray of float, optional
         The bandflux error to convert to magnitude error.
-    
+
     Returns
     -------
     mag : ndarray of float
         The magnitude corresponding to the input bandflux.
     mag_err: ndarray of float
-        The magnitude error corresponding to the input bandflux error. 
-        Only returned if flux_err_njy is provided(not None), 
+        The magnitude error corresponding to the input bandflux error.
+        Only returned if flux_err_njy is provided(not None),
         making the return value a tuple (mag, mag_err).
     """
     mag = MAG_AB_ZP_NJY - 2.5 * np.log10(flux_njy)

--- a/src/lightcurvelynx/astro_utils/mag_flux.py
+++ b/src/lightcurvelynx/astro_utils/mag_flux.py
@@ -24,21 +24,34 @@ def mag2flux(mag: npt.ArrayLike) -> npt.ArrayLike:
     """
     return np.power(10.0, -0.4 * (mag - MAG_AB_ZP_NJY))
 
+MAGERR_FACTOR = 2.5 / np.log(10.0) # Factor to convert flux error to magnitude error
 
-def flux2mag(flux_njy: npt.ArrayLike) -> npt.ArrayLike:
+def flux2mag(flux_njy: npt.ArrayLike, flux_err_njy: npt.ArrayLike = None) -> npt.ArrayLike:
     """Convert bandflux in nJy to AB magnitude
 
     Parameters
     ----------
     flux_njy : ndarray of float
         The bandflux to convert to magnitude.
-
+    flux_err_njy : ndarray of float, optional
+        The bandflux error to convert to magnitude error.
+    
     Returns
     -------
     mag : ndarray of float
         The magnitude corresponding to the input bandflux.
+    mag_err: ndarray of float
+        The magnitude error corresponding to the input bandflux error. 
+        Only returned if flux_err_njy is provided(not None), 
+        making the return value a tuple (mag, mag_err).
     """
-    return MAG_AB_ZP_NJY - 2.5 * np.log10(flux_njy)
+    mag = MAG_AB_ZP_NJY - 2.5 * np.log10(flux_njy)
+
+    if flux_err_njy is None:
+        return mag
+
+    mag_err = MAGERR_FACTOR * flux_err_njy / flux_njy
+    return mag, mag_err
 
 
 class Mag2FluxNode(FunctionNode):

--- a/tests/lightcurvelynx/astro_utils/test_mag_flux.py
+++ b/tests/lightcurvelynx/astro_utils/test_mag_flux.py
@@ -12,10 +12,42 @@ from lightcurvelynx.math_nodes.np_random import NumpyRandomFunc
 
 
 def test_flux2mag():
-    """Test that mag2flux is correct."""
-    flux = np.array([3631e9, 1e9, 3631])
-    desired_mag = np.array([0, 8.9, 22.5])
-    np.testing.assert_allclose(flux2mag(flux), desired_mag, atol=1e-3)
+    """Test conversion from nJy flux/error to AB magnitude/error."""
+    flux = np.array([3631e9, 1e9, 3631.0])
+    desired_mag = np.array([0.0, 8.9, 22.5])
+
+    # No flux error: return magnitudes only, not a tuple.
+    mag_only = flux2mag(flux, flux_err_njy=None)
+
+    assert not isinstance(mag_only, tuple)
+    np.testing.assert_allclose(mag_only, desired_mag, atol=1e-3)
+
+    # Use 10%, 20%, and 1% fractional flux uncertainties, respectively.
+    flux_err = np.array(
+        [
+            0.10 * 3631e9,
+            0.20 * 1e9,
+            0.01 * 3631.0,
+        ]
+    )
+
+    # mag_err = (2.5 / ln(10)) * (flux_err / flux)
+    desired_mag_err = np.array(
+        [
+            0.1085736205,  # 1.085736205 * 0.10
+            0.2171472410,  # 1.085736205 * 0.20
+            0.0108573620,  # 1.085736205 * 0.01
+        ]
+    )
+
+    result = flux2mag(flux, flux_err)
+
+    assert isinstance(result, tuple)
+    assert len(result) == 2
+
+    mag, mag_err = result
+    np.testing.assert_allclose(mag, desired_mag, atol=1e-3)
+    np.testing.assert_allclose(mag_err, desired_mag_err, atol=1e-3)
 
 
 def test_mag2flux():


### PR DESCRIPTION

## Change Description  
Updated flux2mag function, added an optional argument flux_err_njy for flux error conversion. When provided, the function returns a tuple (mag, magerr).
<!--- 
Closes #???
-->

## Solution Description
Used `MAGERR_FACTOR = 2.5 / np.log(10.0)` as the factor to convert flux error to magnitude error

## Code Quality
- [x] I have read the Contribution Guide and agree to the Code of Conduct
- [x] My code follows the code style of this project
- [x] My code builds (or compiles) cleanly without any errors or warnings
- [x] My code contains relevant comments and necessary documentation
