### PR TITLE
Issue891

### DIFF
--- a/docs/notebooks/citations.ipynb
+++ b/docs/notebooks/citations.ipynb
@@ -28,6 +28,8 @@
     "    t0=0.0,\n",
     "    blackhole_mass=1e9 * M_SUN_G,\n",
     "    edd_ratio=0.9,\n",
+    "    redshift=0.01,\n",
+    "    distance=100.0,\n",
     "    node_label=\"AGN\",\n",
     ")\n",
     "\n",
@@ -108,7 +110,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "lightcurvelynx",
+   "display_name": "lightcurvelynx (3.13.8)",
    "language": "python",
    "name": "python3"
   },
@@ -122,7 +124,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.4"
+   "version": "3.13.8"
   }
  },
  "nbformat": 4,

--- a/docs/notebooks/citations.ipynb
+++ b/docs/notebooks/citations.ipynb
@@ -20,7 +20,7 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
-    "\n",
+    "from astropy.cosmology import FlatLambdaCDM\n",
     "from lightcurvelynx.consts import M_SUN_G\n",
     "from lightcurvelynx.models.agn import AGN\n",
     "\n",
@@ -29,7 +29,7 @@
     "    blackhole_mass=1e9 * M_SUN_G,\n",
     "    edd_ratio=0.9,\n",
     "    redshift=0.01,\n",
-    "    distance=100.0,\n",
+    "    cosmology=FlatLambdaCDM(H0=70, Om0=0.3),  # Needed to compute distance from redshift\n",
     "    node_label=\"AGN\",\n",
     ")\n",
     "\n",

--- a/docs/notebooks/host_source_models.ipynb
+++ b/docs/notebooks/host_source_models.ipynb
@@ -74,7 +74,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note that `AdditiveMultiObjectModel` simply adds up the rest0frame flux density produced by each model. If you want to account for the specifics of extended sources (variation of flux density with position), that should be computed by the individual models."
+    "Note that `AdditiveMultiObjectModel` simply adds up the rest-frame flux density produced by each model. It does not use PSF or do anything complex with blending. If you want to account for the specifics of extended sources (e.g., variation of flux density with position), that should be computed by the individual models."
    ]
   },
   {

--- a/docs/notebooks/host_source_models.ipynb
+++ b/docs/notebooks/host_source_models.ipynb
@@ -8,7 +8,7 @@
     "\n",
     "For some extragalatic studies, the user might be interested in simulating the *combination* of fluxes coming from multiple objects. The simplest case of this is an object and its host galaxy. However, other combinations, such as two blended objects, use the same mechanism.\n",
     "\n",
-    "LightCurveLynx provides a general purpose class `AdditiveMultiObjectModel` that produces the combined flux densities from multiple models. This class can be used to simulate host/object combinations, unresolved sources, etc.\n",
+    "LightCurveLynx provides a general purpose class `AdditiveMultiObjectModel` that produces the combined flux densities from multiple models by adding their rest frame flux densities. This class can be used to simulate host/object combinations, unresolved sources, etc.\n",
     "\n",
     "\n",
     "## The AdditiveMultiObjectModel Node\n",
@@ -68,6 +68,13 @@
     "plt.xlabel(\"Time\")\n",
     "plt.ylabel(\"Flux\")\n",
     "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that `AdditiveMultiObjectModel` simply adds up the rest0frame flux density produced by each model. If you want to account for the specifics of extended sources (variation of flux density with position), that should be computed by the individual models."
    ]
   },
   {
@@ -199,7 +206,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "lightcurvelynx",
+   "display_name": "lightcurvelynx (3.13.8)",
    "language": "python",
    "name": "python3"
   },

--- a/docs/notebooks/host_source_models.ipynb
+++ b/docs/notebooks/host_source_models.ipynb
@@ -74,7 +74,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note that `AdditiveMultiObjectModel` simply adds up the rest-frame flux density produced by each model. It does not use PSF or do anything complex with blending. If you want to account for the specifics of extended sources (e.g., variation of flux density with position), that should be computed by the individual models."
+    "Note that `AdditiveMultiObjectModel` simply adds up the rest-frame flux density produced by each model. It does not use PSF or do anything complex with blending."
    ]
   },
   {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "numpy>=2.0",
     "pandas",
     "pooch",
-    "pyarrow",
+    "pyarrow>19.0.1",
     "PyYAML>=6.0",
     "regions",
     "scipy",


### PR DESCRIPTION
Address 2.5 of the 3 points in issue #891:
- Fixes the error in the citations notebook by including the missing parameters.
- Pins pyarrow>19.0.1
- Clarifies how `AdditiveMultiObjectModel` adds the flux densities.

We still need a description of how PSF is actually used in the noise models somewhere.