### PR TITLE
Clean up ObsTable constructors

### DIFF
--- a/src/lightcurvelynx/obstable/argus_obstable.py
+++ b/src/lightcurvelynx/obstable/argus_obstable.py
@@ -42,8 +42,7 @@ class ArgusHealpixObsTable(ObsTable):
         Each value in the dictionary can be a string or a list of strings.
     saturation_mags : dict, optional
         A dictionary mapping filter names to their saturation thresholds in magnitudes. The filters
-        provided must match those in the table. If not provided, Argus-specific defaults will be
-        used.
+        provided must match those in the table. If not provided, no saturation will be applied.
     **kwargs : dict
         Additional keyword arguments to pass to the constructor. This includes overrides
         for survey parameters such as:

--- a/src/lightcurvelynx/obstable/argus_obstable.py
+++ b/src/lightcurvelynx/obstable/argus_obstable.py
@@ -84,7 +84,6 @@ class ArgusHealpixObsTable(ObsTable):
         table,
         *,
         colmap=None,
-        apply_saturation=True,
         saturation_mags=None,
         nside=None,
         **kwargs,
@@ -124,7 +123,6 @@ class ArgusHealpixObsTable(ObsTable):
         super().__init__(
             table=table,
             colmap=colmap,
-            apply_saturation=apply_saturation,
             saturation_mags=saturation_mags,
             **kwargs,
         )

--- a/src/lightcurvelynx/obstable/fake_obs_table.py
+++ b/src/lightcurvelynx/obstable/fake_obs_table.py
@@ -23,10 +23,6 @@ class FakeObsTable(ObsTable):
     colmap : dict, optional
         A mapping of standard column names to a list of possible names in the input table.
         Each value in the dictionary can be a string or a list of strings.
-    zp_per_band : dict, optional
-        A dictionary mapping filter names to their instrumental zero points (flux in nJy
-        corresponding to 1 electron per exposure). The filters provided must match those
-        in the table. This is required if the table does not have a zero point column.
     bandflux_error : float or dict, optional
         If provided, use this constant flux error (in nJy) for all observations (overriding
         the normal noise compuation). A value of 0.0 will produce a noise-free simulation.
@@ -39,9 +35,7 @@ class FakeObsTable(ObsTable):
         provided must match those in the table. If not provided, saturation effects will not be applied.
     **kwargs : dict
         Additional keyword arguments to pass to the ObsTable constructor. This includes overrides
-        for survey parameters such as:
-
-        - survey_name: The name of the survey (default="FAKE_SURVEY").
+        for survey parameters, such as "survey_name" or "read_noise".
     """
 
     # Default survey values.
@@ -62,6 +56,8 @@ class FakeObsTable(ObsTable):
         *,
         colmap=None,
         bandflux_error=None,
+        radius=None,
+        saturation_mags=None,
         **kwargs,
     ):
         # Pass along all the survey parameters to the parent class.
@@ -69,5 +65,7 @@ class FakeObsTable(ObsTable):
             table,
             colmap=colmap,
             bandflux_error=bandflux_error,
+            radius=radius,
+            saturation_mags=saturation_mags,
             **kwargs,
         )

--- a/tests/lightcurvelynx/obstable/test_obs_table.py
+++ b/tests/lightcurvelynx/obstable/test_obs_table.py
@@ -944,7 +944,6 @@ def test_obstable_make_resampled_table():
         pixel_scale=0.112,
         radius=1.03,
         survey_other=1.2,
-        apply_saturation=True,
         saturation_mags=saturation_mags,
     )
 
@@ -1003,7 +1002,6 @@ def test_obstable_make_resampled_table_overwrite():
         values,
         detector_footprint=detector_footprint,
         saturation_mags=saturation_mags,
-        apply_saturation=True,
     )
 
     # Create a resampled ObsTable with some new values.


### PR DESCRIPTION
After some of the ObsTable redesigns, there were some unused arguments that are being passed around or included in the doc strings. This cleans up the interfaces.
