### PR TITLE
Fix GraphState equal

### DIFF
--- a/src/lightcurvelynx/graph_state.py
+++ b/src/lightcurvelynx/graph_state.py
@@ -153,10 +153,10 @@ class GraphState:
                 values2 = np.atleast_1d(other_params[var_name])
                 if np.all(values1 == None) and np.all(values2 == None):  # noqa: E711
                     # Both arrays are all None values, so they are equal.
-                    # This happens a lot of unset values.
+                    # This happens a lot for unset values.
                     continue
 
-                # If the values are numberic, test that they are close.
+                # If the values are numeric, test that they are close.
                 # If this fails (e.g. because the values are objects), then
                 # test for exact equality.
                 try:

--- a/src/lightcurvelynx/graph_state.py
+++ b/src/lightcurvelynx/graph_state.py
@@ -148,8 +148,23 @@ class GraphState:
             for var_name, var_value in node_params.items():
                 if var_name not in other_params:
                     return False
-                if not np.allclose(var_value, other_params[var_name]):
-                    return False
+
+                values1 = np.atleast_1d(var_value)
+                values2 = np.atleast_1d(other_params[var_name])
+                if np.all(values1 == None) and np.all(values2 == None):  # noqa: E711
+                    # Both arrays are all None values, so they are equal.
+                    # This happens a lot of unset values.
+                    continue
+
+                # If the values are numberic, test that they are close.
+                # If this fails (e.g. because the values are objects), then
+                # test for exact equality.
+                try:
+                    if not np.allclose(values1, values2, equal_nan=True):
+                        return False
+                except (TypeError, ValueError):
+                    if not np.array_equal(values1, values2):
+                        return False
 
         # Finally check that the 'fixed' dictionary is the same.
         return self.fixed_vars == other.fixed_vars
@@ -472,7 +487,7 @@ class GraphState:
         if self.num_samples == 1:
             # If this GraphState holds only a single sample, set it from the given value.
             self.states[node_name][var_name] = value
-        elif np.isscalar(value):
+        elif value is None or np.isscalar(value):
             # If the value is a scalar, expand it to the correct number of samples.
             self.states[node_name][var_name] = np.full(self.num_samples, value)
         elif len(value) != self.num_samples:

--- a/tests/lightcurvelynx/test_graph_state.py
+++ b/tests/lightcurvelynx/test_graph_state.py
@@ -530,6 +530,40 @@ def test_graph_state_equal():
     assert state5 != state6
 
 
+def test_graph_state_equal_scalars():
+    """Test that we use == on GraphStates with scalar values."""
+    state1 = GraphState(num_samples=1)
+    state1.set("a", "v1", 1.0)
+    state1.set("a", "v2", 2.0)
+    state1.set("b", "v1", None)
+
+    state2 = GraphState(num_samples=1)
+    state2.set("a", "v1", 1.0)
+    state2.set("a", "v2", 2.0)
+    state2.set("b", "v1", None)
+    assert state1 == state2
+
+    state2.set("a", "v2", 3.0)
+    assert state1 != state2
+
+
+def test_graph_state_equal_nones():
+    """Test that we use == on GraphStates with None values."""
+    state1 = GraphState(num_samples=3)
+    state1.set("a", "v1", [1.0, 2.0, 3.0])
+    state1.set("a", "v2", [2, 3, None])  # One None
+    state1.set("b", "v1", [None, None, None])  # All None
+
+    state2 = GraphState(num_samples=3)
+    state2.set("a", "v1", [1.0, 2.0, 3.0])
+    state2.set("a", "v2", [2, 3, None])  # One None
+    state2.set("b", "v1", [None, None, None])  # All None
+    assert state1 == state2
+
+    state2.set("b", "v1", [2, 4, None])
+    assert state1 != state2
+
+
 def test_graph_state_fixed():
     """Test that we respected the 'fixed' flag for GraphState."""
     state = GraphState()


### PR DESCRIPTION
The `GraphState` equals check currently fails if the values are `None` which happens often for unset parameter values. Fix the code so that this is handled correctly (all Nones are equal, etc.).
