### PR TITLE
Add replay functionality to a simulation

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -103,7 +103,7 @@ in multiple observation tables and corresponding passband groups. See the
 Can I Rerun a Simulation with the Same Parameters?
 -------------------------------------------------------------------------------
 
-Yes. There are two approaches do doing this. 
+Yes. There are two approaches to doing this. 
 
 First, if you want to produce exactly the same results, you can provide a random number generator with a fixed seed to the ``simulate_lightcurves()`` function. This will ensure that the same random numbers are used in the simulation for both parameter sampling and noise generation, resulting in identical outputs.
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -100,6 +100,31 @@ in multiple observation tables and corresponding passband groups. See the
 :doc:`multiple surveys demo notebook <notebooks/multiple_surveys>` for an example of how to do this.
 
 
+Can I Rerun a Simulation with the Same Parameters?
+-------------------------------------------------------------------------------
+
+Yes. LightCurveLynx allows you to rerun a simulation with the same parameters by using the ``GraphState`` object. The ``GraphState`` object captures the state of the simulation graph and allows you to rerun the simulation with the same parameters. You can even change the survey information. This is particularly useful if you want to compare the results you get from different surveys on the exact same set of objects.
+
+You can capture the state of the previous simulation from the "params" column in its results table:
+
+.. code-block:: python
+
+    previous_state = GraphState.from_list(results["params"].values)
+
+Then you pass this ``previous_state`` to the ``simulate_lightcurves()`` function to rerun the simulation with the same parameters:
+
+.. code-block:: python
+
+    results2 = simulate_lightcurves(
+        model,
+        previous_state.num_samples,
+        new_survey_info,
+        graph_state=previous_state,
+    )
+
+You can see the :doc:`multiple surveys demo notebook <notebooks/multiple_surveys>` for an example of how to do this.
+
+
 Can I Simulate Spectra?
 --------------------------------------------------------------------------------
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -103,7 +103,11 @@ in multiple observation tables and corresponding passband groups. See the
 Can I Rerun a Simulation with the Same Parameters?
 -------------------------------------------------------------------------------
 
-Yes. LightCurveLynx allows you to rerun a simulation with the same parameters by using the ``GraphState`` object. The ``GraphState`` object captures the state of the simulation graph and allows you to rerun the simulation with the same parameters. You can even change the survey information. This is particularly useful if you want to compare the results you get from different surveys on the exact same set of objects.
+Yes. There are two approaches do doing this. 
+
+First, if you want to produce exactly the same results, you can provide a random number generator with a fixed seed to the ``simulate_lightcurves()`` function. This will ensure that the same random numbers are used in the simulation for both parameter sampling and noise generation, resulting in identical outputs.
+
+Second, LightCurveLynx allows you to rerun a new simulation with the same model parameters by using the ``GraphState`` object. The ``GraphState`` object captures the state of the simulation graph and allows you to rerun the simulation with the same parameters. This approach can be used to rerun a simulation with different survey information (or the same survey information and different noise realizations). This is particularly useful if you want to compare the results you get from different surveys on the exact same set of objects.
 
 You can capture the state of the previous simulation from the "params" column in its results table:
 
@@ -123,6 +127,8 @@ Then you pass this ``previous_state`` to the ``simulate_lightcurves()`` function
     )
 
 You can see the :doc:`multiple surveys demo notebook <notebooks/multiple_surveys>` for an example of how to do this.
+
+It is possible to change the values within the ``GraphState`` object before passing it to the ``simulate_lightcurves()`` function. For example, you might want to change the objects' ``t0`` values to correspond to the new survey's time range. However, care should be taken when changing the values within the ``GraphState`` object. If other parameters depend on the values you change, they will **not** be updated automatically and you can end up with inconsistent results.
 
 
 Can I Simulate Spectra?

--- a/docs/notebooks/multiple_surveys.ipynb
+++ b/docs/notebooks/multiple_surveys.ipynb
@@ -18,6 +18,7 @@
     "import numpy as np\n",
     "\n",
     "from lightcurvelynx.astro_utils.passbands import PassbandGroup\n",
+    "from lightcurvelynx.graph_state import GraphState\n",
     "from lightcurvelynx.models.basic_models import ConstantSEDModel\n",
     "from lightcurvelynx.obstable.opsim import OpSim\n",
     "from lightcurvelynx.simulate import simulate_lightcurves\n",
@@ -234,9 +235,49 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Running Separate Simulations\n",
+    "\n",
+    "In some cases, we may want to try a set of objects on different survey conditions independently. For example, we might want to look at the exact same set of items under ZTF and Rubin independently.\n",
+    "\n",
+    "LightCurveLynx provides the ability to replay a previous simulation by extracting the first simulation's `GraphState` and manually providing it to a simulation. In this case, the simulation uses the given `GraphState` instead of sampling a new one.\n",
+    "\n",
+    "Let's look at re-running the first example (of two LSST-based surveys) with the survey's evaluated independently on the exact same objects."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Run the first simulation.\n",
+    "results1 = simulate_lightcurves(model, 10, survey_info1)\n",
+    "print(\"\\nLight Curve from Survey 1:\\n\", results1[\"lightcurve\"][0])\n",
+    "\n",
+    "# Extract the GraphState (parameter values) from the first simulation.\n",
+    "previous_state = GraphState.from_list(results1[\"params\"].values)\n",
+    "\n",
+    "# Run the second simulation, using the previous state as the initial state.\n",
+    "results2 = simulate_lightcurves(\n",
+    "    model,\n",
+    "    10,\n",
+    "    survey_info2,\n",
+    "    graph_state=previous_state,\n",
+    ")\n",
+    "print(\"\\nLight Curve from Survey 2:\\n\", results2[\"lightcurve\"][0])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## FAQ\n",
     "\n",
     "### Can we use multiple surveys and parallelization?\n",
+    "\n",
+    "Yes.\n",
+    "\n",
+    "### Can we re-simulate objects with parallelization?\n",
     "\n",
     "Yes.\n",
     "\n",

--- a/docs/notebooks/multiple_surveys.ipynb
+++ b/docs/notebooks/multiple_surveys.ipynb
@@ -271,6 +271,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "It is possible to change the values within the ``GraphState`` object before passing it to the ``simulate_lightcurves()`` function. For example, you might want to change the objects' ``t0`` values to correspond to the new survey's time range. However, care should be taken when changing the values within the ``GraphState`` object. If other parameters depend on the values you change, they will **not** be updated automatically and you can end up with inconsistent results."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## FAQ\n",
     "\n",
     "### Can we use multiple surveys and parallelization?\n",

--- a/docs/simulations.rst
+++ b/docs/simulations.rst
@@ -250,6 +250,20 @@ used are determined by each survey. And the bandflux is computed using that surv
 For an example see the :doc:`Simulating from Multiple Surveys notebook <notebooks/multiple_surveys>`.
 
 
+Rerunning a Simulation with the Same Parameters
+-------------------------------------------------------------------------------
+
+The ``simulate_lightcurves()`` function takes a ``graph_state`` argument that allows you to pass in a previously generated ``GraphState`` object. If this argument is provided, the simulation will use the parameters from the provided ``GraphState`` instead of sampling new parameters.
+
+You can capture the state of the previous simulation from the "params" column in its results table:
+
+.. code-block:: python
+
+    previous_state = GraphState.from_list(results["params"].values)
+
+You can see an example of this in the :doc:`multiple surveys demo notebook <notebooks/multiple_surveys>` where we rerun a simulation with the same parameters but different survey information.
+
+
 Running in Parallel
 -------------------------------------------------------------------------------
 

--- a/docs/simulations.rst
+++ b/docs/simulations.rst
@@ -253,7 +253,7 @@ For an example see the :doc:`Simulating from Multiple Surveys notebook <notebook
 Rerunning a Simulation with the Same Parameters
 -------------------------------------------------------------------------------
 
-The ``simulate_lightcurves()`` function takes a ``graph_state`` argument that allows you to pass in a previously generated ``GraphState`` object. If this argument is provided, the simulation will use the parameters from the provided ``GraphState`` instead of sampling new parameters.
+The ``simulate_lightcurves()`` function takes a ``graph_state`` argument that allows you to pass in a previously generated ``GraphState`` object. If this argument is provided, the simulation will use the parameters from the provided ``GraphState`` instead of sampling new parameters. This approach can be used to rerun a simulation with different survey information or the sample survey information and different noise samples.
 
 You can capture the state of the previous simulation from the "params" column in its results table:
 
@@ -262,6 +262,8 @@ You can capture the state of the previous simulation from the "params" column in
     previous_state = GraphState.from_list(results["params"].values)
 
 You can see an example of this in the :doc:`multiple surveys demo notebook <notebooks/multiple_surveys>` where we rerun a simulation with the same parameters but different survey information.
+
+Note that if you want to produce exactly the same results, you can instead provide a random number generator with a fixed seed to the ``simulate_lightcurves()`` function. This will ensure that the same random numbers are used in the simulation for both parameter sampling and noise generation, resulting in identical outputs.
 
 
 Running in Parallel

--- a/src/lightcurvelynx/graph_state.py
+++ b/src/lightcurvelynx/graph_state.py
@@ -620,7 +620,7 @@ class GraphState:
             The number of sample to extract.
         """
         new_state = self.extract_slice(sample_num, sample_num + 1)
-        new_state.sample_idx = sample_num
+        new_state.sample_idx = new_state.sample_offset
         return new_state
 
     def extract_slice(self, start, stop):

--- a/src/lightcurvelynx/graph_state.py
+++ b/src/lightcurvelynx/graph_state.py
@@ -148,8 +148,23 @@ class GraphState:
             for var_name, var_value in node_params.items():
                 if var_name not in other_params:
                     return False
-                if not np.allclose(var_value, other_params[var_name]):
-                    return False
+
+                values1 = np.atleast_1d(var_value)
+                values2 = np.atleast_1d(other_params[var_name])
+                if np.all(values1 == None) and np.all(values2 == None):  # noqa: E711
+                    # Both arrays are all None values, so they are equal.
+                    # This happens a lot for unset values.
+                    continue
+
+                # If the values are numeric, test that they are close.
+                # If this fails (e.g. because the values are objects), then
+                # test for exact equality.
+                try:
+                    if not np.allclose(values1, values2, equal_nan=True):
+                        return False
+                except (TypeError, ValueError):
+                    if not np.array_equal(values1, values2):
+                        return False
 
         # Finally check that the 'fixed' dictionary is the same.
         return self.fixed_vars == other.fixed_vars
@@ -472,7 +487,7 @@ class GraphState:
         if self.num_samples == 1:
             # If this GraphState holds only a single sample, set it from the given value.
             self.states[node_name][var_name] = value
-        elif np.isscalar(value):
+        elif value is None or np.isscalar(value):
             # If the value is a scalar, expand it to the correct number of samples.
             self.states[node_name][var_name] = np.full(self.num_samples, value)
         elif len(value) != self.num_samples:
@@ -604,23 +619,49 @@ class GraphState:
         sample_num : int
             The number of sample to extract.
         """
+        new_state = self.extract_slice(sample_num, sample_num + 1)
+        new_state.sample_idx = sample_num
+        return new_state
+
+    def extract_slice(self, start, stop):
+        """Create a new GraphState with a slice of samples.
+
+        Note
+        ----
+        We use a contiguous slice of samples (instead of an arbitrary set of indices) to preserve
+        the semantics of the sample_offset attribute.
+
+        Parameters
+        ----------
+        start : int
+            The starting index of the slice (inclusive).
+        stop : int
+            The stopping index of the slice (exclusive).
+
+        Returns
+        -------
+        GraphState
+            The sliced GraphState.
+        """
         if self.num_samples <= 0:
             raise ValueError("Cannot sample an empty GraphState")
-        if sample_num < 0 or sample_num >= self.num_samples:
-            raise ValueError(f"Invalid index {sample_num} in GraphState with {self.num_samples} entries.")
+        if start < 0 or stop > self.num_samples or start >= stop:
+            raise ValueError(f"Invalid slice [{start}:{stop}] in GraphState with {self.num_samples} entries.")
+        indices = np.arange(start, stop)
 
-        # Make a copy of the GraphState with exactly one sample.
-        new_state = GraphState(1)
+        # Make a slice of the GraphState with the specified samples.
+        new_state = GraphState(len(indices))
         new_state.num_parameters = self.num_parameters
-        new_state.sample_offset = self.sample_offset
-        new_state.sample_idx = sample_num
+        new_state.sample_offset = start + self.sample_offset
         for node_name in self.states:
             new_state.states[node_name] = {}
             for var_name, value in self.states[node_name].items():
                 if self.num_samples == 1:
                     new_state.states[node_name][var_name] = value
+                elif new_state.num_samples == 1:
+                    new_state.states[node_name][var_name] = value[indices[0]]
                 else:
-                    new_state.states[node_name][var_name] = value[sample_num]
+                    new_state.states[node_name][var_name] = value[indices]
 
         # Copy over the sets of fixed variables. This is a single set of strings
         # per node, so we just need to copy the sets.

--- a/src/lightcurvelynx/simulate.py
+++ b/src/lightcurvelynx/simulate.py
@@ -67,6 +67,9 @@ class SimulationInfo:
         Whether to save the full filter names in the results (including survey prefix).
     progress_bar : bool
         Whether to show a progress bar during the simulation.
+    graph_state : GraphState, optional
+        The predefined graph state to use to replay a previous simulation. If None,
+        a new graph state is sampled.
     kwargs : dict
         Additional keyword arguments to pass to the simulation function.
     """
@@ -87,6 +90,7 @@ class SimulationInfo:
         output_file_path=None,
         save_full_filter_names=False,
         progress_bar=True,
+        graph_state=None,
         **kwargs,
     ):
         self.model = model
@@ -109,6 +113,18 @@ class SimulationInfo:
         if self.num_samples <= 0:
             raise ValueError("Number of samples must be a positive integer.")
 
+        # Copy the graph state if one is provided.
+        if graph_state is not None:
+            if graph_state.num_samples != self.num_samples:
+                raise ValueError(
+                    f"Graph state has {graph_state.num_samples} samples, but simulation is set to "
+                    f"{self.num_samples} samples."
+                )
+            self.graph_state = graph_state.copy()
+        else:
+            self.graph_state = None
+
+        # If an output file path is provided, check that the directory exists.
         if output_file_path is not None:
             self.output_file_path = Path(output_file_path)
             if not self.output_file_path.parent.exists():
@@ -174,6 +190,12 @@ class SimulationInfo:
             else:
                 batch_output_file_path = None
 
+            # If we have a graph state, take a slice for this batch.
+            if self.graph_state is not None:
+                batch_graph_state = self.graph_state.extract_slice(start_idx, end_idx)
+            else:
+                batch_graph_state = None
+
             # Create a subset of the batch. Most information is the same (references to the
             # same objects), except for the number of samples and the RNG.
             batch_info = SimulationInfo(
@@ -190,6 +212,7 @@ class SimulationInfo:
                 output_file_path=batch_output_file_path,
                 save_full_filter_names=self.save_full_filter_names,
                 progress_bar=False,  # Don't show per-batch progress bars.
+                graph_state=batch_graph_state,
                 **self.kwargs,
             )
             batches.append(batch_info)
@@ -302,16 +325,20 @@ def _simulate_lightcurves_batch(simulation_info):
     rng = simulation_info.rng
     num_surveys = len(obstable)
 
-    # Sample the parameter space of this model. We do this once for all surveys, so the
-    # object use the same parameters across all observations.
+    # Sample the parameter space of this model if it is not already provided. We do this once for
+    # all surveys, so the object use the same parameters across all observations.
     if num_samples <= 0:
         raise ValueError("Invalid number of samples.")
-    logger.info(f"Sampling {num_samples} parameter sets from the model.")
-    sample_states = model.sample_parameters(
-        num_samples=num_samples,
-        rng_info=rng,
-        sample_offset=sample_offset,
-    )
+    if simulation_info.graph_state is not None:
+        logger.info("Using provided graph state to sample parameters.")
+        sample_states = simulation_info.graph_state
+    else:
+        logger.info(f"Sampling {num_samples} parameter sets from the model.")
+        sample_states = model.sample_parameters(
+            num_samples=num_samples,
+            rng_info=rng,
+            sample_offset=sample_offset,
+        )
 
     # Create a dictionary for the object level information, including any saved parameters.
     # Some of these are placeholders (e.g. nobs) until they can be filled in during the simulation.
@@ -600,6 +627,7 @@ def simulate_lightcurves(
     batch_size=100_000,
     save_full_filter_names=False,
     progress_bar=True,
+    graph_state=None,
 ):
     """Generate a number of simulations of the given model and information
     from one or more surveys. The result data can either be returned directly
@@ -671,6 +699,9 @@ def simulate_lightcurves(
         Whether to save the full filter names in the results (including survey prefix).
     progress_bar : bool
         Whether to show a progress bar during the simulation.
+    graph_state : GraphState, optional
+        The predefined graph state to use to replay a previous simulation. If None,
+        a new graph state is sampled.
 
     Returns
     -------
@@ -741,6 +772,7 @@ def simulate_lightcurves(
         output_file_path=output_file_path,
         save_full_filter_names=save_full_filter_names,
         progress_bar=progress_bar,
+        graph_state=graph_state,
     )
 
     # If we are given a number of jobs, make sure the batch size is not larger than

--- a/src/lightcurvelynx/simulate.py
+++ b/src/lightcurvelynx/simulate.py
@@ -113,16 +113,13 @@ class SimulationInfo:
         if self.num_samples <= 0:
             raise ValueError("Number of samples must be a positive integer.")
 
-        # Copy the graph state if one is provided.
-        if graph_state is not None:
-            if graph_state.num_samples != self.num_samples:
-                raise ValueError(
-                    f"Graph state has {graph_state.num_samples} samples, but simulation is set to "
-                    f"{self.num_samples} samples."
-                )
-            self.graph_state = graph_state.copy()
-        else:
-            self.graph_state = None
+        # Link the graph state if one is provided.
+        if graph_state is not None and graph_state.num_samples != self.num_samples:
+            raise ValueError(
+                f"Graph state has {graph_state.num_samples} samples, but simulation is set to "
+                f"{self.num_samples} samples."
+            )
+        self.graph_state = graph_state
 
         # If an output file path is provided, check that the directory exists.
         if output_file_path is not None:
@@ -326,7 +323,7 @@ def _simulate_lightcurves_batch(simulation_info):
     num_surveys = len(obstable)
 
     # Sample the parameter space of this model if it is not already provided. We do this once for
-    # all surveys, so the object use the same parameters across all observations.
+    # all surveys, so each object uses the same parameters across all observations.
     if num_samples <= 0:
         raise ValueError("Invalid number of samples.")
     if simulation_info.graph_state is not None:

--- a/tests/lightcurvelynx/test_graph_state.py
+++ b/tests/lightcurvelynx/test_graph_state.py
@@ -118,6 +118,47 @@ def test_create_graph_state_offset():
     assert state.sample_offset == 5
 
 
+def test_graph_state_slice():
+    """Test that we can create a slice of a GraphState."""
+    state = GraphState(20, sample_offset=5)
+    state.set("a", "v1", np.arange(20))
+    state.set("a", "v2", np.arange(20) + 1)
+    state.set("b", "v1", np.arange(20) - 1)
+    assert len(state) == 3
+
+    # Check that we can extract a slice of the GraphState.
+    slice_state = state.extract_slice(5, 10)
+    assert slice_state.num_samples == 5
+    assert slice_state.sample_offset == 10
+    assert np.array_equal(slice_state["a"]["v1"], np.arange(5, 10))
+    assert np.array_equal(slice_state["a"]["v2"], np.arange(6, 11))
+    assert np.array_equal(slice_state["b"]["v1"], np.arange(4, 9))
+
+    # We can slice a slice.
+    slice_state2 = slice_state.extract_slice(1, 3)
+    assert slice_state2.num_samples == 2
+    assert slice_state2.sample_offset == 11
+    assert np.array_equal(slice_state2["a"]["v1"], np.arange(6, 8))
+    assert np.array_equal(slice_state2["a"]["v2"], np.arange(7, 9))
+    assert np.array_equal(slice_state2["b"]["v1"], np.arange(5, 7))
+
+    # We can correctly slice out a single sample and get scalars.
+    slice_state3 = state.extract_slice(5, 6)
+    assert slice_state3.num_samples == 1
+    assert slice_state3.sample_offset == 10
+    assert slice_state3["a"]["v1"] == 5
+    assert slice_state3["a"]["v2"] == 6
+    assert slice_state3["b"]["v1"] == 4
+
+    # We fail with invalid slice indices.
+    with pytest.raises(ValueError):
+        _ = state.extract_slice(-1, 5)
+    with pytest.raises(ValueError):
+        _ = state.extract_slice(5, 25)
+    with pytest.raises(ValueError):
+        _ = state.extract_slice(10, 5)
+
+
 def test_create_single_graph_state_from_flattened_dict():
     """Test that we can create a single GraphState from a flattened dictionary."""
     input = {
@@ -278,7 +319,7 @@ def test_create_multi_sample_graph_state():
     new_state = state.extract_single_sample(3)
     assert len(new_state) == 3
     assert new_state.num_samples == 1
-    assert new_state.sample_offset == 0
+    assert new_state.sample_offset == 3
     assert new_state.sample_idx == 3
     assert new_state["a"]["v1"] == 1.0
     assert new_state["a"]["v2"] == 3.5
@@ -528,6 +569,40 @@ def test_graph_state_equal():
     state5 = GraphState(num_samples=1)
     state6 = GraphState(num_samples=2)
     assert state5 != state6
+
+
+def test_graph_state_equal_scalars():
+    """Test that we use == on GraphStates with scalar values."""
+    state1 = GraphState(num_samples=1)
+    state1.set("a", "v1", 1.0)
+    state1.set("a", "v2", 2.0)
+    state1.set("b", "v1", None)
+
+    state2 = GraphState(num_samples=1)
+    state2.set("a", "v1", 1.0)
+    state2.set("a", "v2", 2.0)
+    state2.set("b", "v1", None)
+    assert state1 == state2
+
+    state2.set("a", "v2", 3.0)
+    assert state1 != state2
+
+
+def test_graph_state_equal_nones():
+    """Test that we use == on GraphStates with None values."""
+    state1 = GraphState(num_samples=3)
+    state1.set("a", "v1", [1.0, 2.0, 3.0])
+    state1.set("a", "v2", [2, 3, None])  # One None
+    state1.set("b", "v1", [None, None, None])  # All None
+
+    state2 = GraphState(num_samples=3)
+    state2.set("a", "v1", [1.0, 2.0, 3.0])
+    state2.set("a", "v2", [2, 3, None])  # One None
+    state2.set("b", "v1", [None, None, None])  # All None
+    assert state1 == state2
+
+    state2.set("b", "v1", [2, 4, None])
+    assert state1 != state2
 
 
 def test_graph_state_fixed():

--- a/tests/lightcurvelynx/test_simulate.py
+++ b/tests/lightcurvelynx/test_simulate.py
@@ -166,16 +166,20 @@ def test_simulation_info():
     assert sim_info.num_samples == 100
     assert sim_info.obs_time_window_offset == (-5.0, 10.0)
     assert sim_info.progress_bar is True
+    assert sim_info.graph_state is None
 
     # Test splitting into batches.
     batches = sim_info.split(num_batches=3)
     assert len(batches) == 3
     assert batches[0].num_samples == 34
     assert batches[0].sample_offset == 0
+    assert batches[0].graph_state is None
     assert batches[1].num_samples == 34
     assert batches[1].sample_offset == 34
+    assert batches[1].graph_state is None
     assert batches[2].num_samples == 32
     assert batches[2].sample_offset == 68
+    assert batches[2].graph_state is None
 
     # We propagate all the keyword parameters.
     assert batches[0].obs_time_window_offset == (-5.0, 10.0)
@@ -278,6 +282,82 @@ def test_simulation_info_random_split():
     random_samples2 = [batch.rng.integers(0, 100000) for batch in batches2]
     assert np.all(random_samples1 == random_samples2)
     assert len(np.unique(random_samples1)) == 5
+
+
+def test_simulation_info_graph_state():
+    """Test that we can create and split SimulationInfo objects with given graph state."""
+    model = ConstantSEDModel(brightness=100.0, t0=0.0, ra=0.0, dec=0.0, redshift=0.0, node_label="source")
+    state = model.sample_parameters(num_samples=100)
+
+    # Create a completely fake passband group and obstable for testing.
+    pb_group = PassbandGroup(
+        [
+            Passband(np.array([[100, 0.5], [200, 0.75], [300, 0.25]]), "my_survey", "r"),
+            Passband(np.array([[250, 0.25], [300, 0.5], [350, 0.75]]), "my_survey", "g"),
+            Passband(np.array([[250, 0.25], [300, 0.5], [350, 0.75]]), "my_survey", "i"),
+        ]
+    )
+
+    values = {
+        "time": np.array([0.0, 1.0, 2.0, 3.0, 4.0]),
+        "ra": np.array([15.0, 30.0, 15.0, 0.0, 60.0]),
+        "dec": np.array([-10.0, -5.0, 0.0, 5.0, 10.0]),
+        "filter": np.array(["r", "g", "r", "i", "g"]),
+    }
+    bandflux_error = {"g": 26.0, "r": 27.0, "i": 28.0}
+    ops_data = FakeObsTable(
+        values,
+        bandflux_error=bandflux_error,
+        fwhm_px=2.0,
+        sky_bg_electrons=100.0,
+    )
+
+    survey_info = SurveyInfo(
+        obstable=ops_data,
+        passbands=pb_group,
+        noise_model=GivenNoiseModel(),  # Uses the bandflux_error from the obs table
+    )
+
+    sim_info = SimulationInfo(
+        model=model,
+        num_samples=100,
+        survey_info=survey_info,
+        obs_time_window_offset=(-5.0, 10.0),  # A keyword argument to test
+        rng=np.random.default_rng(12345),
+        graph_state=state,
+    )
+    assert sim_info.num_samples == 100
+    assert sim_info.obs_time_window_offset == (-5.0, 10.0)
+    assert sim_info.progress_bar is True
+    assert sim_info.graph_state == state
+
+    # Test splitting into batches.
+    batches = sim_info.split(num_batches=3)
+    assert len(batches) == 3
+    assert batches[0].num_samples == 34
+    assert batches[0].sample_offset == 0
+    assert batches[0].graph_state.sample_offset == 0
+    assert batches[0].graph_state.num_samples == 34
+    assert batches[1].num_samples == 34
+    assert batches[1].sample_offset == 34
+    assert batches[1].graph_state.sample_offset == 34
+    assert batches[1].graph_state.num_samples == 34
+    assert batches[2].num_samples == 32
+    assert batches[2].sample_offset == 68
+    assert batches[2].graph_state.sample_offset == 68
+    assert batches[2].graph_state.num_samples == 32
+
+    # Check that we fail if we try to create a SimulationInfo with a graph state that has a
+    # different number of samples than num_samples.
+    with pytest.raises(ValueError):
+        _ = SimulationInfo(
+            model=model,
+            num_samples=50,  # Wrong number
+            survey_info=survey_info,
+            obs_time_window_offset=(-5.0, 10.0),  # A keyword argument to test
+            rng=np.random.default_rng(12345),
+            graph_state=state,
+        )
 
 
 def test_simulate_lightcurves(test_data_dir):
@@ -396,6 +476,65 @@ def test_simulate_lightcurves(test_data_dir):
     assert "Available parameters are:" in str(excinfo.value)
     assert "source2.ra" in str(excinfo.value)
     assert "source2.dec" in str(excinfo.value)
+
+
+def test_replay_simulate_lightcurves(test_data_dir):
+    """Test an end to end run of simulating the light curves using a given state."""
+    # Load the OpSim data.
+    opsim_db = OpSim.from_db(test_data_dir / "opsim_small.db")
+
+    # Load the passband data for the griz filters only.
+    passband_group = PassbandGroup.from_preset(
+        preset="LSST",
+        table_dir=test_data_dir / "passbands",
+        filters=["g", "r", "i", "z"],
+    )
+
+    # Use the default noise model.
+    survey_info = SurveyInfo(obstable=opsim_db, passbands=passband_group)
+
+    # Create a constant SED model with known brightnesses and RA, dec
+    # values that match the opsim.
+    given_brightness = [1000.0, 2000.0, 5000.0, 1000.0, 100.0]
+    source = ConstantSEDModel(
+        brightness=GivenValueList(given_brightness),
+        t0=0.0,
+        ra=GivenValueList(opsim_db["ra"].values[0:5]),
+        dec=GivenValueList(opsim_db["dec"].values[0:5]),
+        redshift=0.0,
+        node_label="source",
+    )
+
+    results = simulate_lightcurves(
+        source,
+        5,
+        survey_info,
+        progress_bar=False,  # Disable progress bar for testing
+    )
+
+    # Test that we can replay the simulation using the saved GraphState.
+    state = GraphState.from_list(results["params"].values)
+    replay_results = simulate_lightcurves(
+        source,
+        5,
+        survey_info,
+        progress_bar=False,  # Disable progress bar for testing
+        graph_state=state,
+    )
+    assert np.allclose(replay_results["ra"].values, results["ra"].values)
+    assert np.allclose(replay_results["dec"].values, results["dec"].values)
+    assert np.allclose(replay_results["z"].values, results["z"].values)
+    assert np.allclose(replay_results["t0"].values, results["t0"].values)
+    assert np.allclose(
+        replay_results["lightcurve.flux_perfect"].values,
+        results["lightcurve.flux_perfect"].values,
+    )
+
+    # The noise realization will be different.
+    assert not np.allclose(
+        replay_results["lightcurve.flux"].values,
+        results["lightcurve.flux"].values,
+    )
 
 
 def test_simulate_lightcurves_uses_single_progress_bar(test_data_dir, monkeypatch):
@@ -745,6 +884,33 @@ def test_simulate_parallel_threads(test_data_dir):
             strict=False,
         ):
             assert full_name == f"LSST_{filter_name}"
+
+    # Extract the graph state, rerun and check that we get the same pre-noise results.
+    state = GraphState.from_list(results["params"].values)
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        results2 = simulate_lightcurves(
+            source,
+            100,
+            survey_info,
+            obstable_save_cols=["observationId", "zp_nJy"],
+            param_cols=["source.brightness"],
+            executor=executor,
+            batch_size=10,
+            save_full_filter_names=True,
+            progress_bar=False,  # Disable progress bar for testing
+            graph_state=state,
+        )
+    assert np.allclose(results["ra"].values, results2["ra"].values)
+    assert np.allclose(results["dec"].values, results2["dec"].values)
+    assert np.allclose(
+        results["lightcurve.flux_perfect"].values,
+        results2["lightcurve.flux_perfect"].values,
+    )
+    # Different noise realizations
+    assert not np.allclose(
+        results["lightcurve.flux"].values,
+        results2["lightcurve.flux"].values,
+    )
 
 
 def test_simulate_parallel_processes(test_data_dir):


### PR DESCRIPTION
All the simulation code to take a `GraphState` that overrides parameter sampling. This is useful if you want to run the exact same set of objects through two different survey designs, want to simulate the same objects with different noise, or want to save objects to replay later.
