### PR TITLE
Initial editorial tweaks for publication in JOSS

### DIFF
--- a/joss_paper/paper.bib
+++ b/joss_paper/paper.bib
@@ -27,7 +27,7 @@ url = {https://doi.org/10.5281/zenodo.15019859}
 
 @article{Bellm2019,
 author = {Bellm, Eric C. and Kulkarni, Shrinivas R. and Graham, Matthew J. and Dekany, Richard and Smith, Roger M. and Riddle, Reed and Masci, Frank J. and Patterson, Bryan and Rebbapragada, Umaa and Walters, Richard and Ward, Charlotte and Ye, Quan-Zhi and Zolkower, Jeffry and others},
-title = {The Zwicky Transient Facility: System Overview, Performance, and First Results},
+title = {The {Zwicky Transient Facility}: System Overview, Performance, and First Results},
 journal = {Publications of the Astronomical Society of the Pacific},
 volume = {131},
 number = {995},
@@ -52,9 +52,28 @@ month=feb,
 pages={A219}
 }
 
+@article{crenshaw2024,
+       author = {{Crenshaw}, John Franklin and {Kalmbach}, J. Bryce and {Gagliano}, Alexander and {Yan}, Ziang and {Connolly}, Andrew J. and {Malz}, Alex I. and {Schmidt}, Samuel J. and {The LSST Dark Energy Science Collaboration}},
+        title = {Probabilistic Forward Modeling of Galaxy Catalogs with Normalizing Flows},
+      journal = {The Astronomical Journal},
+     keywords = {Neural networks, Galaxy photometry, Surveys, Computational methods, 1933, 611, 1671, 1965, Astrophysics - Instrumentation and Methods for Astrophysics, Astrophysics - Cosmology and Nongalactic Astrophysics},
+         year = 2024,
+        month = aug,
+       volume = {168},
+       number = {2},
+          eid = {80},
+        pages = {80},
+          doi = {10.3847/1538-3881/ad54bf},
+archivePrefix = {arXiv},
+       eprint = {2405.04740},
+ primaryClass = {astro-ph.IM},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2024AJ....168...80C},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
 @software{crenshaw2025,
-author = {John Franklin Crenshaw and 颜子昂,Zi'ang Yan and vladislav doster},
-title = {jfcrenshaw/pzflow: v3.3.0},
+author = {John Franklin Crenshaw and Ziang Yan and Vladislav Doster},
+title = {{jfcrenshaw/pzflow}: v3.3.0},
 month = dec,
 year = 2025,
 publisher = {Zenodo},
@@ -126,12 +145,12 @@ volume = {134},
 number = {1033},
 pages = {035003},
 author = {Law, Nicholas M. and Corbett, Hank and Galliher, Nathan W. and Gonzalez, Ramses and Vasquez, Alan and Walters, Glenn and Machia, Lawrence and Ratzloff, Jeff and Ackley, Kendall and Bizon, Chris and Clemens, Christopher and Cox, Steven and Eikenberry, Steven and Howard, Ward S. and Glazier, Amy and Mann, Andrew W. and Quimby, Robert and Reichart, Daniel and Trilling, David},
-title = {Low-cost Access to the Deep, High-cadence Sky: the Argus Optical Array},
+title = {Low-cost Access to the Deep, High-cadence Sky: the {Argus Optical Array}},
 journal = {Publications of the Astronomical Society of the Pacific}
 }
 
 @misc{lu2025,
-title={The BAGLE Python Package for Bayesian Analysis of Gravitational Lensing Events},
+title={The BAGLE {Python} Package for {Bayesian} Analysis of Gravitational Lensing Events},
 author={J. R. Lu and M. Medford and C. Y. Lam and T. D. Bhadra and M. J. Huston and N. S. Abrams and E. Broadberry and J. Chen and S. K. Terry and N. Arredondo and A. Scharf},
 year={2025},
 doi={10.48550/arXiv.2512.03364},
@@ -142,7 +161,7 @@ url={https://arxiv.org/abs/2512.03364}
 }
 
 @misc{rigault2026,
-title={skysurvey: a pure python package to simulate the transient sky}, 
+title={{skysurvey}: a pure {Python} package to simulate the transient sky},
 author={M. Rigault and M. Ginolin and L. Dellazzeri and B. Popovic and J. O. Hjortlund and A. Gilles-Lordet and S. Conseil and M. Coughlin and F. Ruppin and M. Smith and A. Townsend and A. Trigui and C. Barjou-Delayre and R. Kebadian and J. Nordin},
 year={2026},
 eprint={2605.25840},
@@ -153,7 +172,7 @@ url={https://arxiv.org/abs/2605.25840},
 
 @article{sarin2024,
 author = {Sarin, Nikhil and Hübner, Moritz and Omand, Conor M B and Setzer, Christian N and Schulze, Steve and Adhikari, Naresh and Sagués-Carracedo, Ana and Galaudage, Shanika and Wallace, Wendy F and Lamb, Gavin P and Lin, En-Tzu},
-title = {redback: a Bayesian inference software package for electromagnetic transients},
+title = {{redback}: a {Bayesian} inference software package for electromagnetic transients},
 journal = {Monthly Notices of the Royal Astronomical Society},
 volume = {531},
 number = {1},
@@ -170,7 +189,7 @@ eprint = {https://academic.oup.com/mnras/article-pdf/531/1/1203/57801464/stae123
 author = {Virtanen, Pauli and Gommers, Ralf and Oliphant, Travis E. and Haberland, Matt and Reddy, Tyler and Cournapeau, David and Burovski, Evgeni and Peterson, Pearu and Weckesser, Warren and Bright, Jonathan and {van der Walt}, St{\'e}fan J. and Brett, Matthew and Wilson, Joshua and Millman, K. Jarrod and Mayorov, Nikolay and Nelson, Andrew R. J. and Jones, Eric and Kern, Robert and Larson, Eric and Carey, C J and Polat, {\.I}lhan and Feng, Yu and Moore, Eric W. and {VanderPlas}, Jake and Laxalde, Denis and Perktold, Josef and Cimrman, Robert and Henriksen, Ian and Quintero, E. A. and
  Harris, Charles R. and Archibald, Anne M. and Ribeiro, Ant{\^o}nio H. and Pedregosa, Fabian and
  {van Mulbregt}, Paul and {SciPy 1.0 Contributors}},
-title = {{{SciPy} 1.0: Fundamental Algorithms for Scientific Computing in Python}},
+title = {{SciPy} 1.0: Fundamental Algorithms for Scientific Computing in {Python}},
 journal = {Nature Methods},
 year = {2020},
 volume = {17},
@@ -210,7 +229,7 @@ Year = 2013
 
 @ARTICLE{astropy2018,
 author = {{Astropy Collaboration} and {Price-Whelan}, A.~M. and {Sip{\H{o}}cz}, B.~M. and {G{\"u}nther}, H.~M. and {Lim}, P.~L. and {Crawford}, S.~M. and {Conseil}, S. and {Shupe}, D.~L. and {Craig}, M.~W. and {Dencheva}, N. and {Ginsburg}, A. and {VanderPlas}, J.~T. and {Bradley}, L.~D. and {P{\'e}rez-Su{\'a}rez}, D. and  {de Val-Borro}, M. and {Aldcroft}, T.~L. and {Cruz}, K.~L. and {Robitaille}, T.~P. and {Tollerud}, E.~J. and {Ardelean}, C. and {Babej}, T. and {Bach}, Y.~P. and {Bachetti}, M. and {Bakanov}, A.~V. and {Bamford}, S.~P. and {Barentsen}, G. and {Barmby}, P. and {Baumbach}, A. and {Berry}, K.~L. and {Biscani}, F. and {Boquien}, M. and {Bostroem}, K.~A. and {Bouma}, L.~G. and {Brammer}, G.~B. and {Bray}, E.~M. and {Breytenbach}, H. and {Buddelmeijer}, H. and  {Burke}, D.~J. and {Calderone}, G. and {Cano Rodr{\'\i}guez}, J.~L. and {Cara}, M. and {Cardoso}, J.~V.~M. and {Cheedella}, S. and {Copin}, Y. and {Corrales}, L. and {Crichton}, D. and {D'Avella}, D. and {Deil}, C. and {Depagne}, {\'E}. and {Dietrich}, J.~P. and {Donath}, A. and {Droettboom}, M. and {Earl}, N. and {Erben}, T. and {Fabbro}, S. and {Ferreira}, L.~A. and {Finethy}, T. and {Fox}, R.~T. and {Garrison}, L.~H. and {Gibbons}, S.~L.~J. and {Goldstein}, D.~A. and {Gommers}, R. and {Greco}, J.~P. and {Greenfield}, P. and {Groener}, A.~M. and {Grollier}, F. and {Hagen}, A. and {Hirst}, P. and {Homeier}, D. and {Horton}, A.~J. and {Hosseinzadeh}, G. and {Hu}, L. and {Hunkeler}, J.~S. and {Ivezi{\'c}}, {\v{Z}}. and {Jain}, A. and {Jenness}, T. and {Kanarek}, G. and {Kendrew}, S. and {Kern}, N.~S. and {Kerzendorf}, W.~E. and {Khvalko}, A. and {King}, J. and {Kirkby}, D. and {Kulkarni}, A.~M. and {Kumar}, A. and {Lee}, A. and {Lenz}, D. and {Littlefair}, S.~P. and {Ma}, Z. and {Macleod}, D.~M. and {Mastropietro}, M. and {McCully}, C. and {Montagnac}, S. and {Morris}, B.~M. and {Mueller}, M. and {Mumford}, S.~J. and {Muna}, D. and {Murphy}, N.~A. and {Nelson}, S. and {Nguyen}, G.~H. and {Ninan}, J.~P. and {N{\"o}the}, M. and {Ogaz}, S. and {Oh}, S. and {Parejko}, J.~K. and {Parley}, N. and {Pascual}, S. and {Patil}, R. and {Patil}, A.~A. and {Plunkett}, A.~L. and {Prochaska}, J.~X. and {Rastogi}, T. and {Reddy Janga}, V. and {Sabater}, J. and {Sakurikar}, P. and {Seifert}, M. and {Sherbert}, L.~E. and {Sherwood-Taylor}, H. and {Shih}, A.~Y. and {Sick}, J. and {Silbiger}, M.~T. and {Singanamalla}, S. and {Singer}, L.~P. and {Sladen}, P.~H. and {Sooley}, K.~A. and {Sornarajah}, S. and {Streicher}, O. and {Teuben}, P. and {Thomas}, S.~W. and {Tremblay}, G.~R. and {Turner}, J.~E.~H. and {Terr{\'o}n}, V. and {van Kerkwijk}, M.~H. and {de la Vega}, A. and {Watkins}, L.~L. and {Weaver}, B.~A. and {Whitmore}, J.~B. and {Woillez}, J. and {Zabalza}, V. and {Astropy Contributors}},
-title = "{The Astropy Project: Building an Open-science Project and Status of the v2.0 Core Package}",
+title = {The {Astropy} Project: Building an Open-science Project and Status of the v2.0 Core Package},
 journal = {The Astronomical Journal},
 keywords = {methods: data analysis, methods: miscellaneous, methods: statistical, reference systems, Astrophysics - Instrumentation and Methods for Astrophysics},
 year = 2018,
@@ -231,8 +250,8 @@ aas-doi = {10.3847/1538-3881/aabc4f},
 
 @ARTICLE{astropy2022,
 author = {{Astropy Collaboration} and {Price-Whelan}, Adrian M. and {Lim}, Pey Lian and {Earl}, Nicholas and {Starkman}, Nathaniel and {Bradley}, Larry and {Shupe}, David L. and {Patil}, Aarya A. and {Corrales}, Lia and {Brasseur}, C.~E. and {N{"o}the}, Maximilian and {Donath}, Axel and {Tollerud}, Erik and {Morris}, Brett M. and {Ginsburg}, Adam and {Vaher}, Eero and {Weaver}, Benjamin A. and {Tocknell}, James and {Jamieson}, William and {van Kerkwijk}, Marten H. and {Robitaille}, Thomas P. and {Merry}, Bruce and {Bachetti}, Matteo and {G{"u}nther}, H. Moritz and {Aldcroft}, Thomas L. and {Alvarado-Montes}, Jaime A. and {Archibald}, Anne M. and {B{'o}di}, Attila and {Bapat}, Shreyas and {Barentsen}, Geert and {Baz{'a}n}, Juanjo and {Biswas}, Manish and {Boquien}, M{'e}d{'e}ric and {Burke}, D.~J. and {Cara}, Daria and {Cara}, Mihai and {Conroy}, Kyle E. and {Conseil}, Simon and {Craig}, Matthew W. and {Cross}, Robert M. and {Cruz}, Kelle L. and {D'Eugenio}, Francesco and {Dencheva}, Nadia and {Devillepoix}, Hadrien A.~R. and {Dietrich}, J{"o}rg P. and {Eigenbrot}, Arthur Davis and {Erben}, Thomas and {Ferreira}, Leonardo and {Foreman-Mackey}, Daniel and {Fox}, Ryan and {Freij}, Nabil and {Garg}, Suyog and {Geda}, Robel and {Glattly}, Lauren and {Gondhalekar}, Yash and {Gordon}, Karl D. and {Grant}, David and {Greenfield}, Perry and {Groener}, Austen M. and {Guest}, Steve and {Gurovich}, Sebastian and {Handberg}, Rasmus and {Hart}, Akeem and {Hatfield-Dodds}, Zac and {Homeier}, Derek and {Hosseinzadeh}, Griffin and {Jenness}, Tim and {Jones}, Craig K. and {Joseph}, Prajwel and {Kalmbach}, J. Bryce and {Karamehmetoglu}, Emir and {Ka{l}uszy{'n}ski}, Miko{l}aj and {Kelley}, Michael S.~P. and {Kern}, Nicholas and {Kerzendorf}, Wolfgang E. and {Koch}, Eric W. and {Kulumani}, Shankar and {Lee}, Antony and {Ly}, Chun and {Ma}, Zhiyuan and {MacBride}, Conor and {Maljaars}, Jakob M. and {Muna}, Demitri and {Murphy}, N.~A. and {Norman}, Henrik and {O'Steen}, Richard and {Oman}, Kyle A. and {Pacifici}, Camilla and {Pascual}, Sergio and {Pascual-Granado}, J. and {Patil}, Rohit R. and {Perren}, Gabriel I. and {Pickering}, Timothy E. and {Rastogi}, Tanuj and {Roulston}, Benjamin R. and {Ryan}, Daniel F. and {Rykoff}, Eli S. and {Sabater}, Jose and {Sakurikar}, Parikshit and {Salgado}, Jes{'u}s and {Sanghi}, Aniket and {Saunders}, Nicholas and {Savchenko}, Volodymyr and {Schwardt}, Ludwig and {Seifert-Eckert}, Michael and {Shih}, Albert Y. and {Jain}, Anany Shrey and {Shukla}, Gyanendra and {Sick}, Jonathan and {Simpson}, Chris and {Singanamalla}, Sudheesh and {Singer}, Leo P. and {Singhal}, Jaladh and {Sinha}, Manodeep and {Sip{H{o}}cz}, Brigitta M. and {Spitler}, Lee R. and {Stansby}, David and {Streicher}, Ole and {{{S}}umak}, Jani and {Swinbank}, John D. and {Taranu}, Dan S. and {Tewary}, Nikita and {Tremblay}, Grant R. and {Val-Borro}, Miguel de and {Van Kooten}, Samuel J. and {Vasovi{'c}}, Zlatan and {Verma}, Shresth and {de Miranda Cardoso}, Jos{'e} Vin{'i}cius and {Williams}, Peter K.~G. and {Wilson}, Tom J. and {Winkel}, Benjamin and {Wood-Vasey}, W.~M. and {Xue}, Rui and {Yoachim}, Peter and {Zhang}, Chen and {Zonca}, Andrea and {Astropy Project Contributors}},
-title = "{The Astropy Project: Sustaining and Growing a Community-oriented Open-source Project and the Latest Major Release (v5.0) of the Core Package}",
-journal = {Astrophysical Journal},
+title = {The {Astropy} Project: Sustaining and Growing a Community-oriented Open-source Project and the Latest Major Release (v5.0) of the Core Package},
+journal = {The Astrophysical Journal},
 keywords = {Astronomy software, Open source software, Astronomy data analysis, 1855, 1866, 1858, Astrophysics - Instrumentation and Methods for Astrophysics},
 year = 2022,
 month = aug,

--- a/joss_paper/paper.md
+++ b/joss_paper/paper.md
@@ -1,5 +1,5 @@
 ---
-title: 'LightCurveLynx: Fast and Nimble Time Domain Simulation for Astronomical Surveys'
+title: 'LightCurveLynx: Fast and Nimble Time-Domain Simulation for Astronomical Surveys'
 tags:
   - Python
   - astronomy
@@ -82,7 +82,7 @@ The astronomy community has invested significant resources into developing power
 `LightCurveLynx` is a package for forward simulation of time-varying astronomical phenomena that brings together this extensive ecosystem of software into a consistent framework. The user can access models from different packages, a range of effects, and a variety of surveys and instrument types. In addition, the modular API makes `LightCurveLynx` highly extensible. Users can easily introduce new variability models or wrap other Python packages, expanding the system’s capabilities to incorporate the community’s latest developments.
 
 
-# State of the Field
+# State of the field
 
 As noted in the previous section, the astronomy community has developed a range of powerful tools for forward simulation of transient and variable sources. Individual packages often focus on specific types of astronomical phenomena such as supernovae or microlensing. Further each package may support a subset of the existing physical effects or survey strategy. `LightCurveLynx` does not aim to duplicate those efforts, but rather to augment them by providing a common framework for users to combine the existing packages.
 
@@ -91,7 +91,7 @@ As noted in the previous section, the astronomy community has developed a range 
 
 `LightCurveLynx` is designed to enable users to accurately and efficiently run simulations using a range of models and simulation packages. As such, it uses several core principles: (1) provide an extensible and flexible object-oriented API, (2) provide an interface to consistently sample from complex distributions, (3) allow users to save simulation state and replay all/part of the simulation for analysis and debugging, and (4) build in vectorization and parallelization for efficient runs. This modular structure (and the general program flow) are shown in \autoref{fig:flow}.
 
-![The basic simulation flow for `LightCurveLynx`\label{fig:flow}](figure.png)
+![The basic simulation flow for `LightCurveLynx`.\label{fig:flow}](figure.png)
 
 The simulation starts by sampling the model’s parameters from given statistical distributions. These parameters are combined with the information about where the survey is pointing to generate observed fluxes at either the spectral or band level. (We use “flux” as a synonym of “spectral flux density per unit frequency", while by “bandflux” we mean spectral flux density measured in the given photometric passband). `LightCurveLynx` uses the survey information, along with each object's position, to pre-filter evaluations to just those times when the object will be observed, saving significant computation over evaluating models at all times.  The simulation then applies line of sight effects, such as dust extinction, to the fluxes. If the fluxes were generated at the spectral level, they are integrated with the survey’s filter to produce band fluxes. Finally, instrument and detector noise are sampled and added based on the survey’s characteristics.
 
@@ -99,13 +99,13 @@ Models of physical phenomena are implemented as subclasses in a simple class hie
 
 Another advantage of this class hierarchy is that new features can be added in the parent classes and automatically applied to all models. One example of this is `LightCurveLynx`’s extrapolation functionality. Some common models, such as splines fit from data, only produce valid predictions over a finite range of times and wavelengths. By supporting bound checking and extrapolation in the parent classes, `LightCurveLynx` adds the ability to use an extrapolation function with any model.
 
-The parameter distributions are specified using Pythonic syntax as a directed acyclic graph of parameter relations that can draw distributions from packages such as NumPy [@harris2020array], SciPy [@SciPy2020], or PZFlow [@crenshaw2025]. All parameter (and bookkeeping) information is handled through the `ParameterizedNode` base class and saved as a `GraphState` object, which allows the user to analyze or replay the simulations. Sampling is vectorized wherever possible and can be parallelized for efficiency. Where possible `LightCurveLynx` uses established scientific packages, such as Astropy [@astropy2013] [@astropy2018] [@astropy2022] and SciPy, for computation.
+The parameter distributions are specified using Pythonic syntax as a directed acyclic graph of parameter relations that can draw distributions from packages such as NumPy [@harris2020array], SciPy [@SciPy2020], or PZFlow [@crenshaw2024; @crenshaw2025]. All parameter (and bookkeeping) information is handled through the `ParameterizedNode` base class and saved as a `GraphState` object, which allows the user to analyze or replay the simulations. Sampling is vectorized wherever possible and can be parallelized for efficiency. Where possible `LightCurveLynx` uses established scientific packages, such as Astropy [@astropy2013; @astropy2018; @astropy2022] and SciPy, for computation.
 
 Line of sight effects are wrapped subclasses of the `EffectModel` class and can be added to any `BasePhysicalModel` object. This separates the implementation of the model from the effects and allows a single effect type (e.g. dust extinction) to be consistently applied to any physical model. This approach ensures consistency and reduces code duplication.
 
-Survey specific information is encapsulated in subclasses of the `ObsTable`, allowing users to simulate their models under different survey conditions. `LightCurveLynx` currently supports data from the Vera C. Rubin’s LSST [@Ivezic2019] in simulated and DP1/DP2 formats, data from the Zwicky Transient Facility surveys [@Bellm2019], simulations of the Nancy Grace Roman telescope [@Spergel2015], and simulations of the Argus Array [@Law2022].
+Survey specific information is encapsulated in subclasses of the `ObsTable`, allowing users to simulate their models under different survey conditions. `LightCurveLynx` currently supports data from the Vera C. Rubin’s LSST [@Ivezic2019] in simulated and DP1/DP2 formats, data from the Zwicky Transient Facility (ZTF) surveys [@Bellm2019], simulations of the Nancy Grace Roman telescope [@Spergel2015], and simulations of the Argus Array [@Law2022].
 
-Parallelization is natively supported using Python's `ProcessPoolExecutor` as well as multi-machine parallelization such as [Dask](https://www.dask.org/) or [Ray](https://docs.ray.io/en/latest/index.html).
+Parallelization is natively supported using Python's `ProcessPoolExecutor` as well as multi-machine parallelization such as [Dask](https://www.dask.org/) or [Ray](https://docs.ray.io/).
 
 
 # Research impact statement
@@ -115,7 +115,7 @@ The software was verified by simulating populations of Type Ia supernovae under 
 
 # Installation and usage
 
-`LightCurveLynx` can be installed with `pip` or through `conda-forge`. See the instructions on our [Read the Docs page](https://lightcurvelynx.readthedocs.io/en/latest/). The project's [tutorial notebooks documentation page](https://lightcurvelynx.readthedocs.io/en/latest/notebooks.html) provides a variety of usage examples and technical deep dives.
+`LightCurveLynx` can be installed with `pip` or through `conda-forge`. See the instructions on our [Read the Docs page](https://lightcurvelynx.readthedocs.io/). The project's [tutorial notebooks documentation page](https://lightcurvelynx.readthedocs.io/en/latest/notebooks.html) provides a variety of usage examples and technical deep dives.
 
 
 # AI usage disclosure


### PR DESCRIPTION
This is an initial set of editorial tweaks to the JOSS paper following the [successful review](https://github.com/openjournals/joss-reviews/issues/10629). Most of these are to the citation style and bits of capitalisation but I'll flag some more significant suggestions.

* For PZFlow, I've gone ahead and added the AJ citation that the creators also request [in their README.md](https://github.com/jfcrenshaw/pzflow?tab=readme-ov-file#citation). In the Zenodo citation, I've also changed the author "颜子昂, Zi'ang Yan" to "Ziang Yan" (as in the AJ paper) because our publication pipeline doesn't support the non-Latin characters. This is definitely a shortcoming in our pipeline and I'll raise it with our development team, but I expect it will take quite a long time to resolve.
* I've hyphenated the title ("Time-Domain Simulation"). Presuming that's acceptable (I believe it's correct), I'll update the other metadata in the review issue appropriately.
* If I'm not mistaken, the citation to "Dai et al. 2026" is the associated AAS Journals paper. Since all the metadata is known (including DOI), you should be able to update the relevant BibTeX entry from the arXiv version to the published version, and the citations will be correctly tracked in Crossref. The DOI must anyway be added to the metadata before we publish in JOSS.

If you're happy with the changes and merge them (or selectively apply some yourself), I'll launch another test run of our publication pipeline to double-check I haven't missed anything else.