### PR TITLE
Turn off summary generation when writing to HATS

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ dev = [
     "fsspec[http]",  # Read OpSim file from the web with utils/make_opsim_shorten.py
     "jupyter", # Clears output from Jupyter notebooks
     "jax",
-    "lsdb>=0.8",
+    "lsdb>=0.10.2",
     "modeldag",
     "networkx",  # Used for graph visualization
     "pre-commit", # Used to run checks before finalizing a git commit
@@ -68,7 +68,7 @@ all = [
     "dust_extinction",
     "extinction>=0.4.7",  # Needed by sncosmo
     "jax",
-    "lsdb",  # Used to read and write LSDB catalogs
+    "lsdb>=0.10.2",  # Used to read and write LSDB catalogs
     "networkx",  # Used for graph visualization
     "pzflow>=4.0",
     "synphot",  # used for SED modeling tests

--- a/src/lightcurvelynx/utils/io_utils.py
+++ b/src/lightcurvelynx/utils/io_utils.py
@@ -169,6 +169,7 @@ def write_results_as_hats(base_catalog_path, results, *, catalog_name=None, over
         catalog_name=catalog_name,
         as_collection=False,
         overwrite=overwrite,
+        create_summary=False,
     )
 
 


### PR DESCRIPTION
Turn off summary generation when writing to HATS. Requires pinning LSDB >= 0.10.2 so we can pick up the correct function argument.
