### PR TITLE
Small cleanups

### DIFF
--- a/src/lightcurvelynx/math_nodes/basic_math_node.py
+++ b/src/lightcurvelynx/math_nodes/basic_math_node.py
@@ -235,8 +235,9 @@ class BasicMathNode(FunctionNode):
             elif isinstance(node, ast.Call):
                 # Check that this is just a math function name, with no library prefix.
                 if not isinstance(node.func, ast.Name):
+                    func_str = ast.unparse(node.func)
                     raise ValueError(
-                        f"Unsupported function call {ast.dump(node.func)}. Only basic math "
+                        f"Unsupported function call '{func_str}'. Only basic math "
                         "operations are allowed. The backend should be set via the 'backend' "
                         "argument, not by using a library prefix."
                     )

--- a/src/lightcurvelynx/math_nodes/basic_math_node.py
+++ b/src/lightcurvelynx/math_nodes/basic_math_node.py
@@ -225,7 +225,7 @@ class BasicMathNode(FunctionNode):
             Any additional keyword arguments, including the variable
             assignments.
         """
-        tree = ast.parse(expression)
+        tree = ast.parse(expression, mode="eval")
 
         # Walk the tree and confirm that it only contains the basic math.
         for node in ast.walk(tree):
@@ -233,6 +233,13 @@ class BasicMathNode(FunctionNode):
                 # Nothing to do, this is a valid operation for the ast.
                 continue
             elif isinstance(node, ast.Call):
+                # Check that this is just a math function name, with no library prefix.
+                if not isinstance(node.func, ast.Name):
+                    raise ValueError(
+                        f"Unsupported function call {ast.dump(node.func)}. Only basic math "
+                        "operations are allowed. The backend should be set via the 'backend' "
+                        "argument, not by using a library prefix."
+                    )
                 # Check that function calls are only using items on the allow list.
                 if node.func.id not in self._math_map:
                     raise ValueError(f"Unsupported function {node.func.id}")

--- a/src/lightcurvelynx/math_nodes/given_sampler.py
+++ b/src/lightcurvelynx/math_nodes/given_sampler.py
@@ -336,10 +336,6 @@ class TableSampler(FunctionNode):
         """Return the number of items in the table."""
         return self._num_values
 
-    def reset(self):
-        """Reset the next index to use. Only used for in-order sampling."""
-        self.next_ind = 0
-
     def compute(self, graph_state, rng_info=None, **kwargs):
         """Return the given values.
 

--- a/src/lightcurvelynx/math_nodes/np_random.py
+++ b/src/lightcurvelynx/math_nodes/np_random.py
@@ -136,6 +136,7 @@ class NumpyRandomFunc(FunctionNode):
                 if isinstance(arg_value, list):
                     # Convert lists to arrays so we can broadcast them.
                     arg_value = np.asarray(arg_value)
+                    args[key] = arg_value
                 if isinstance(arg_value, np.ndarray) and arg_value.shape != target_size:
                     # Add new axes for the sample_size dimensions, then broadcast
                     expanded_shape = arg_value.shape + (1,) * len(self.sample_size)

--- a/src/lightcurvelynx/math_nodes/np_random.py
+++ b/src/lightcurvelynx/math_nodes/np_random.py
@@ -133,6 +133,9 @@ class NumpyRandomFunc(FunctionNode):
             target_size = (graph_state.num_samples, *self.sample_size)
             for key in args:
                 arg_value = args[key]
+                if isinstance(arg_value, list):
+                    # Convert lists to arrays so we can broadcast them.
+                    arg_value = np.asarray(arg_value)
                 if isinstance(arg_value, np.ndarray) and arg_value.shape != target_size:
                     # Add new axes for the sample_size dimensions, then broadcast
                     expanded_shape = arg_value.shape + (1,) * len(self.sample_size)

--- a/tests/lightcurvelynx/math_nodes/test_basic_math_node.py
+++ b/tests/lightcurvelynx/math_nodes/test_basic_math_node.py
@@ -73,9 +73,13 @@ def test_basic_math_node_multi_dim():
 
 def test_basic_math_node_fail():
     """Test that we perform the needed checks for a math node."""
-    # Imports not allowed
-    with pytest.raises(ValueError):
+    # Imports not allowed. They will fail with a SyntaxError in eval mode.
+    with pytest.raises(SyntaxError):
         _ = BasicMathNode("import os")
+
+    # Prefixes shouldn't be included.
+    with pytest.raises(ValueError):
+        _ = BasicMathNode("np.sin(1.0)")
 
     # Ifs not allowed (won't work with JAX)
     with pytest.raises(ValueError):

--- a/tests/lightcurvelynx/math_nodes/test_np_random.py
+++ b/tests/lightcurvelynx/math_nodes/test_np_random.py
@@ -36,6 +36,15 @@ def test_numpy_random_uniform():
     assert np.all(values >= 10.0)
     assert np.abs(np.mean(values) - 15.0) < 0.5
 
+    # We can specify the range with lists of values.
+    np_node4 = NumpyRandomFunc("uniform", low=[0.0, 10.0], high=[1.0, 20.0], seed=100, size=2)
+    values = np.array([np_node4.generate() for _ in range(1000)])
+    assert values.shape == (1000, 1, 2)
+    assert np.all(values[:, 0, 0] <= 1.0)
+    assert np.all(values[:, 0, 0] >= 0.0)
+    assert np.all(values[:, 0, 1] <= 20.0)
+    assert np.all(values[:, 0, 1] >= 10.0)
+
     # We fail with invalid sizes.
     with pytest.raises(ValueError):
         NumpyRandomFunc("uniform", size=(10, -1))


### PR DESCRIPTION
A few small cleanups for code health:

- Use mode="eval" for the basic math node parser, which has stricter logic.
- Better failure message if someone uses a library prefix (e.g. "np.") for the basic math node
- Remove `TableSampler.reset()` since this node is stateless and the function modifies a variable that isn't being used (the function should not exist).
- Allow lists of parameters to a `NumpyRandomFunc` for multi-dimensional samples.
