### PR TITLE
State expansion node

### DIFF
--- a/src/lightcurvelynx/math_nodes/state_expansion_node.py
+++ b/src/lightcurvelynx/math_nodes/state_expansion_node.py
@@ -9,6 +9,8 @@ Note
 This class is experimental and may be removed in the future.
 """
 
+from collections.abc import Mapping
+
 import numpy as np
 
 from lightcurvelynx.base_models import FunctionNode
@@ -35,10 +37,10 @@ class StateExpansionNode(FunctionNode):
     param_names : list of str, optional
         A list of parameters to unpack from the param_values argument.
         Default: None
-    param_values : parameter
-        A list of dictionaries where each dictionary contains the same keys (new column names)
-        and the values for each parameter. The number of dictionaries must be the same as the
-        number of samples in the graph state.
+    param_values : parameter, optional
+        A parameter that produces a list of dictionaries where each dictionary contains the same
+        keys (new column names) and the values for each parameter. The number of dictionaries
+        produced must be the same as the number of samples in the graph state.
         Default: None
     repeats: int or list of int, optional
         The number of repeats for each sample. If an int is provided, it is applied to
@@ -111,6 +113,10 @@ class StateExpansionNode(FunctionNode):
         # If new parameters to add are not None, we compute the repeats array from the length
         # of the subparameters for each sample.
         if len(self.new_param_names) > 0:
+            if graph_state.num_samples == 1 and isinstance(param_values, Mapping):
+                # If num_samples is 1, we expect a single dictionary instead of a list of dictionaries
+                # (because of the way the sampling process works). We wrap it in a list to make it consistent.
+                param_values = [param_values]
             if len(param_values) != graph_state.num_samples:
                 raise ValueError(
                     f"The number of subparameter dictionaries ({len(param_values)}) must match the "
@@ -151,16 +157,18 @@ class StateExpansionNode(FunctionNode):
 
         # Use the repeats list to expand the graph state. Save the information about the
         # original indices and the sub-indices for each sample before and after expansion.
-        org_inds = np.arange(graph_state.num_samples).repeat(repeats)
-        sub_inds = np.concatenate([np.arange(r) for r in repeats])
+        sample_offset = graph_state.sample_offset
+        if sample_offset is None:
+            sample_offset = 0
+        original_indices = np.arange(sample_offset, sample_offset + graph_state.num_samples)
+        org_inds = np.repeat(original_indices, repeats)
+        sub_inds = np.concatenate([np.arange(repeat) for repeat in repeats])
         graph_state.repeat(repeats)
-        results = [org_inds, sub_inds]
 
-        # Add columns for any subparameters we need to concatenate.
-        for col, values in concat_values.items():
-            graph_state.set(self.node_string, col, values)
-            results.append(values)
-
-        # Save and return the old indices and the subindices as the result.
+        # Return the original indices, sub-indices, and any new parameter values as a result.
+        # These will get automatically added to the graph state by _save_results.
+        results = [org_inds, sub_inds, *concat_values.values()]
+        if graph_state.num_samples == 1:
+            results = [value[0] for value in results]
         self._save_results(results, graph_state)
         return results

--- a/src/lightcurvelynx/math_nodes/state_expansion_node.py
+++ b/src/lightcurvelynx/math_nodes/state_expansion_node.py
@@ -113,7 +113,7 @@ class StateExpansionNode(FunctionNode):
         # If new parameters to add are not None, we compute the repeats array from the length
         # of the subparameters for each sample.
         if len(self.new_param_names) > 0:
-            if graph_state.num_samples == 1 and isinstance(param_values, Mapping):
+            if isinstance(param_values, Mapping):
                 # If num_samples is 1, we expect a single dictionary instead of a list of dictionaries
                 # (because of the way the sampling process works). We wrap it in a list to make it consistent.
                 param_values = [param_values]
@@ -122,11 +122,12 @@ class StateExpansionNode(FunctionNode):
                     f"The number of subparameter dictionaries ({len(param_values)}) must match the "
                     f"number of samples in the graph state ({graph_state.num_samples})."
                 )
-            repeats = [0] * graph_state.num_samples
 
-            # We get the first dictionary to compute the column names.
+            # We get the first dictionary in the list to compute the column names, compute the number
+            # of repeats for that row, and initialize the concatenation dictionary.
             column_names_set = set(self.new_param_names)
             concat_values = {col: [] for col in self.new_param_names}
+            repeats = [0] * graph_state.num_samples
             for idx, subparam_dict in enumerate(param_values):
                 # Make sure each dictionary has the required column names (keys).
                 if not column_names_set.issubset(subparam_dict.keys()):
@@ -136,7 +137,7 @@ class StateExpansionNode(FunctionNode):
                         f"{', '.join(column_names_set)}. Missing keys: {', '.join(missing_cols)}."
                     )
 
-                # Use the first column to compute the number of repeats for this sample.
+                # Use the first column in the dictionary to compute the number of repeats for this sample.
                 repeats[idx] = len(subparam_dict[self.new_param_names[0]])
 
                 # For each entry in the dictionary, check that the length matches the number of repeats

--- a/tests/lightcurvelynx/math_nodes/test_state_expansion_node.py
+++ b/tests/lightcurvelynx/math_nodes/test_state_expansion_node.py
@@ -52,6 +52,13 @@ def test_state_expansion_node():
     assert new_state["exp"]["sub_inds"].tolist() == [0, 1, 2, 0, 1, 2, 0, 1, 2]
     assert new_state["exp"]["repeats"].tolist() == [3, 3, 3, 3, 3, 3, 3, 3, 3]
 
+    # We can use num_samples=1 and still get the correct expansion.
+    single_state = exp_node.sample_parameters(num_samples=1)
+    assert single_state.num_samples == 3
+    assert single_state["exp"]["org_inds"].tolist() == [0, 0, 0]
+    assert single_state["exp"]["sub_inds"].tolist() == [0, 1, 2]
+    assert single_state["exp"]["repeats"].tolist() == [3, 3, 3]
+
     # We can chain the nodes.
     exp_node2 = StateExpansionNode(repeats=2, node_label="exp2")
     add_node = _AddModel(
@@ -84,6 +91,18 @@ def test_state_expansion_node():
         _ = StateExpansionNode(node_label="bad_exp")
 
 
+def test_state_expansion_node_offset():
+    """Test that we can create and query a StateExpansionNode with an sample offset."""
+    exp_node = StateExpansionNode(repeats=3, node_label="exp")
+    state = exp_node.sample_parameters(num_samples=2, sample_offset=5)
+
+    # We ask for 2 samples, but force 3 repeats of each.
+    assert state.num_samples == 6
+    assert state["exp"]["org_inds"].tolist() == [5, 5, 5, 6, 6, 6]
+    assert state["exp"]["sub_inds"].tolist() == [0, 1, 2, 0, 1, 2]
+    assert state["exp"]["repeats"].tolist() == [3, 3, 3, 3, 3, 3]
+
+
 def test_state_expansion_node_subparameters():
     """Test that we can create and query a StateExpansionNode from subparameters."""
     sub_param_list = [
@@ -109,6 +128,15 @@ def test_state_expansion_node_subparameters():
     assert state["exp"]["a"].tolist() == [1, 2, 5, 6, 7, 9, 10]
     assert state["exp"]["b"].tolist() == [3, 4, 7, 8, 9, 13, 14]
     assert "c" not in state["exp"]
+
+    # Check that we correctly flatten when num_samples is 1.
+    sub_param_node.reset()  # Reset the list of subparameters.
+    state = exp_node.sample_parameters(num_samples=1)
+    assert state.num_samples == 2
+    assert state["exp"]["org_inds"].tolist() == [0, 0]
+    assert state["exp"]["sub_inds"].tolist() == [0, 1]
+    assert state["exp"]["a"].tolist() == [1, 2]
+    assert state["exp"]["b"].tolist() == [3, 4]
 
     # We fail if we give bad combinations of parameters to the node.
     with pytest.raises(ValueError):

--- a/tests/lightcurvelynx/math_nodes/test_state_expansion_node.py
+++ b/tests/lightcurvelynx/math_nodes/test_state_expansion_node.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pytest
 from lightcurvelynx.base_models import FunctionNode, ParameterizedNode
 from lightcurvelynx.math_nodes.given_sampler import GivenValueList
@@ -89,18 +90,6 @@ def test_state_expansion_node():
     # We fail if we try to create a node without any repetition information.
     with pytest.raises(ValueError):
         _ = StateExpansionNode(node_label="bad_exp")
-
-
-def test_state_expansion_node_offset():
-    """Test that we can create and query a StateExpansionNode with an sample offset."""
-    exp_node = StateExpansionNode(repeats=3, node_label="exp")
-    state = exp_node.sample_parameters(num_samples=2, sample_offset=5)
-
-    # We ask for 2 samples, but force 3 repeats of each.
-    assert state.num_samples == 6
-    assert state["exp"]["org_inds"].tolist() == [5, 5, 5, 6, 6, 6]
-    assert state["exp"]["sub_inds"].tolist() == [0, 1, 2, 0, 1, 2]
-    assert state["exp"]["repeats"].tolist() == [3, 3, 3, 3, 3, 3]
 
 
 def test_state_expansion_node_subparameters():
@@ -227,3 +216,50 @@ def test_state_expansion_node_subparameters_chaining():
     assert state["add_uneven"]["value1"].tolist() == [0, 0, 10, 10, 10, 30]
     assert state["add_uneven"]["value2"].tolist() == [0, 1, 10, 11, 12, 30]
     assert state["add_uneven"]["value_sum"].tolist() == [0, 1, 20, 21, 22, 60]
+
+
+def test_state_expansion_node_uses_sample_offset():
+    """Test that provenance indices include the graph state's sample offset."""
+    node = StateExpansionNode(repeats=2, node_label="exp")
+
+    state = node.sample_parameters(num_samples=2, sample_offset=5)
+
+    assert state.sample_offset == 5
+    assert state["exp.org_inds"].tolist() == [5, 5, 6, 6]
+    assert state["exp.sub_inds"].tolist() == [0, 1, 0, 1]
+
+
+def test_state_expansion_node_accepts_single_mapping_from_sampler():
+    """Test that a single mapping returned by a sampler is expanded."""
+    node = StateExpansionNode(
+        param_names=["a", "b"],
+        param_values=GivenValueList([{"a": [1, 2], "b": [3, 4]}]),
+        node_label="exp",
+    )
+
+    state = node.sample_parameters(num_samples=1)
+
+    assert state.num_samples == 2
+    assert state["exp.org_inds"].tolist() == [0, 0]
+    assert state["exp.sub_inds"].tolist() == [0, 1]
+    assert state["exp.a"].tolist() == [1, 2]
+    assert state["exp.b"].tolist() == [3, 4]
+
+
+def test_state_expansion_node_single_to_single_stores_scalars():
+    """Test that a one-row expansion stores scalar output values."""
+    node = StateExpansionNode(
+        param_names=["a"],
+        param_values=[{"a": [7]}],
+        node_label="exp",
+    )
+
+    state = node.sample_parameters(num_samples=1, sample_offset=8)
+
+    assert state.num_samples == 1
+    assert np.isscalar(state["exp.org_inds"])
+    assert np.isscalar(state["exp.sub_inds"])
+    assert np.isscalar(state["exp.a"])
+    assert state["exp.org_inds"] == 8
+    assert state["exp.sub_inds"] == 0
+    assert state["exp.a"] == 7


### PR DESCRIPTION
This fix is from @jacob-hjortlund 's lensing branch and related to #844

Add some fixes to the `StateExpansionNode`:
- Correct the case where `num_samples == 1` and `param_values` will thus be passed in as a dictionary (instead of a list).
- Handle `sample_offset` for the computed original indices.
