### PR TITLE
Extend Noise Models

### DIFF
--- a/src/lightcurvelynx/noise_models/base_noise_models.py
+++ b/src/lightcurvelynx/noise_models/base_noise_models.py
@@ -19,7 +19,12 @@ from lightcurvelynx.noise_models.noise_utils import poisson_bandflux_std
 
 
 class FluxNoiseModel(ABC):
-    """An abstract baseclass noise model for simulating bandflux measurements."""
+    """An abstract baseclass noise model for simulating bandflux measurements.
+
+    Noise is applied by computing `flux_err`, which is the standard deviation of Gaussian noise
+    to apply to the input bandflux measurements. Subclasses must implement the `compute_flux_error`
+    method to compute the noise parameters.
+    """
 
     # A list of column names that must be present in the ObsTable for this noise model to work.
     _required_values = []
@@ -30,6 +35,23 @@ class FluxNoiseModel(ABC):
         return self._required_values
 
     @abstractmethod
+    def compute_flux_error(self, bandflux, **kwargs):
+        """Compute the flux error for the given bandflux and observation parameters.
+
+        Parameters
+        ----------
+        bandflux : array_like of float
+            Source bandflux in nJy.
+        **kwargs
+            Additional parameters for the noise model.
+
+        Returns
+        -------
+        flux_err : array_like
+            The standard deviation of the bandflux measurement error (in nJy)
+        """
+        raise NotImplementedError("Subclasses must implement this method.")
+
     def apply_noise(
         self,
         bandflux,
@@ -67,7 +89,23 @@ class FluxNoiseModel(ABC):
             The bandflux measurement error used for applying noise, in the
             same units as the input bandflux.
         """
-        raise NotImplementedError("Subclasses must implement this method.")
+        # Define the random number generator if not provided.
+        if rng is None:
+            rng = np.random.default_rng()
+
+        # Compute the standard deviation of the noise and make sure it is a numpy array.
+        flux_err = self.compute_flux_error(
+            bandflux,
+            obs_table=obs_table,
+            indices=indices,
+            rng=rng,
+            **kwargs,
+        )
+        flux_err = np.asarray(flux_err)
+
+        # Generate the actual noisy bandflux measurements.
+        noisy_bandflux = rng.normal(loc=bandflux, scale=flux_err)
+        return noisy_bandflux, flux_err
 
     def check_compatibility(self, obs_table, fail_on_incompatible=False):
         """Check if the noise model is compatible with the given ObsTable.
@@ -122,40 +160,22 @@ class ConstantFluxNoiseModel(FluxNoiseModel):
             raise ValueError("Noise level must be non-negative.")
         self.noise_level = noise_level
 
-    def apply_noise(
-        self,
-        bandflux,
-        *,
-        rng=None,
-        **kwargs,
-    ):
-        """Compute the noise parameters for given observations in
-        an ObsTable and apply noise to the input bandflux.
+    def compute_flux_error(self, bandflux, **kwargs):
+        """Compute the flux error for the given bandflux and observation parameters.
 
         Parameters
         ----------
         bandflux : array_like of float
-            Source bandflux in energy units, e.g. nJy.
-        rng : np.random.Generator, optional
-            The random number generator to use for applying noise. If None,
-            a default generator will be used.
+            Source bandflux in nJy.
         **kwargs
             Additional parameters for the noise model.
 
         Returns
         -------
-        flux : array_like
-            The updated flux measurements after applying noise, in the same
-            units as the input bandflux.
         flux_err : array_like
-            The bandflux measurement error used for applying noise, in the
-            same units as the input bandflux.
+            The standard deviation of the bandflux measurement error (in nJy)
         """
-        if rng is None:
-            rng = np.random.default_rng()
-
-        noisy_bandflux = rng.normal(loc=bandflux, scale=self.noise_level)
-        return noisy_bandflux, np.full_like(bandflux, self.noise_level, dtype=float)
+        return np.full_like(bandflux, self.noise_level, dtype=float)
 
 
 class PoissonFluxNoiseModel(FluxNoiseModel):
@@ -181,7 +201,7 @@ class PoissonFluxNoiseModel(FluxNoiseModel):
     def __init__(self):
         pass
 
-    def compute_flux_error(self, bandflux, obs_table, indices):
+    def compute_flux_error(self, bandflux, *, obs_table=None, indices=None, **kwargs):
         """Compute the flux error for the given bandflux and observation parameters.
 
         Parameters
@@ -192,12 +212,21 @@ class PoissonFluxNoiseModel(FluxNoiseModel):
             Table containing the observation parameters needed to compute the noise.
         indices : array_like of int
             Indices of the observations in the ObsTable for which to compute the noise.
+        **kwargs
+            Additional parameters for the noise model.
 
         Returns
         -------
         flux_err : array_like
             The standard deviation of the bandflux measurement error (in nJy)
         """
+        if obs_table is None:  # pragma: no cover
+            raise ValueError("ObsTable must be provided for PoissonFluxNoiseModel.")
+        if indices is None:  # pragma: no cover
+            raise ValueError("Indices must be provided for PoissonFluxNoiseModel.")
+        if len(indices) != len(bandflux):  # pragma: no cover
+            raise ValueError("Length of indices must match length of bandflux.")
+
         # Extract the features needed to compute the noise from the ObsTable.
         total_exposure_time = obs_table.get_value_per_row("exptime", indices=indices)
         exposure_count = obs_table.get_value_per_row("nexposure", indices=indices, default=1)
@@ -221,64 +250,6 @@ class PoissonFluxNoiseModel(FluxNoiseModel):
             zp_err_mag=zp_err_mag,
         )
 
-    def apply_noise(
-        self,
-        bandflux,
-        *,
-        obs_table=None,
-        indices=None,
-        rng=None,
-        **kwargs,
-    ):
-        """Compute the noise parameters for given observations in
-        an ObsTable and apply noise to the input bandflux.
-
-        Parameters
-        ----------
-        bandflux : array_like of float
-            Source bandflux in energy units, e.g. nJy.
-        obs_table : ObsTable, optional
-            Table containing the observation parameters, including all
-            parameters needed to compute the noise.
-        indices : array_like of int, optional
-            Indices of the observations in the ObsTable to which noise should
-            be applied.
-        rng : np.random.Generator, optional
-            The random number generator to use for applying noise. If None,
-            a default generator will be used.
-        **kwargs
-            Additional parameters for the noise model.
-
-        Returns
-        -------
-        flux : array_like
-            The updated flux measurements after applying noise, in the same
-            units as the input bandflux.
-        flux_err : array_like
-            The bandflux measurement error used for applying noise, in the
-            same units as the input bandflux.
-        """
-        if obs_table is None:
-            raise ValueError("ObsTable must be provided for PoissonFluxNoiseModel.")
-        if indices is None:
-            raise ValueError("Indices must be provided for PoissonFluxNoiseModel.")
-        if len(indices) != len(bandflux):
-            raise ValueError("Length of indices must match length of bandflux.")
-
-        flux_err = self.compute_flux_error(
-            bandflux,
-            obs_table=obs_table,
-            indices=indices,
-        )
-
-        # Make sure the array is a numpy array.
-        flux_err = np.asarray(flux_err)
-
-        # Generate the actual noisy bandflux measurements.
-        rng = np.random.default_rng(rng)
-        noisy_bandflux = rng.normal(loc=bandflux, scale=flux_err)
-        return noisy_bandflux, flux_err
-
 
 class GivenNoiseModel(FluxNoiseModel):
     """A noise model that simulates photon noise for bandflux measurements with a
@@ -293,42 +264,26 @@ class GivenNoiseModel(FluxNoiseModel):
     def __init__(self):
         pass
 
-    def apply_noise(
-        self,
-        bandflux,
-        *,
-        obs_table=None,
-        indices=None,
-        rng=None,
-        **kwargs,
-    ):
-        """Compute the noise parameters for given observations in
-        an ObsTable and apply noise to the input bandflux.
+    def compute_flux_error(self, bandflux, *, obs_table=None, indices=None, **kwargs):
+        """Compute the flux error for the given bandflux and observation parameters.
 
         Parameters
         ----------
         bandflux : array_like of float
-            Source bandflux in energy units, e.g. nJy.
-        obs_table : ObsTable, optional
-            Table containing the observation parameters, including all
-            parameters needed to compute the noise.
-        indices : array_like of int, optional
-            Indices of the observations in the ObsTable to which noise should
-            be applied.
-        rng : np.random.Generator, optional
-            The random number generator to use for applying noise. If None,
-            a default generator will be used.
+            Source bandflux in nJy.
+        obs_table : ObsTable
+            Table containing the observation parameters needed to compute the noise.
+            Not used in this noise model, but included for compatibility with the base class.
+        indices : array_like of int
+            Indices of the observations in the ObsTable for which to compute the noise.
+            Not used in this noise model, but included for compatibility with the base class.
         **kwargs
             Additional parameters for the noise model.
 
         Returns
         -------
-        flux : array_like
-            The updated flux measurements after applying noise, in the same
-            units as the input bandflux.
         flux_err : array_like
-            The bandflux measurement error used for applying noise, in the
-            same units as the input bandflux.
+            The standard deviation of the bandflux measurement error (in nJy)
         """
         if obs_table is None:
             raise ValueError("ObsTable must be provided for GivenNoiseModel.")
@@ -339,11 +294,7 @@ class GivenNoiseModel(FluxNoiseModel):
 
         flux_err = obs_table.get_value_per_row("bandflux_error", indices=indices)
         flux_err = np.asarray(flux_err, dtype=float)
-
-        # Generate the actual noisy bandflux measurements.
-        rng = np.random.default_rng(rng)
-        noisy_bandflux = rng.normal(loc=bandflux, scale=flux_err)
-        return noisy_bandflux, flux_err
+        return flux_err
 
 
 class FiveSigmaDepthNoiseModel(FluxNoiseModel):
@@ -363,42 +314,24 @@ class FiveSigmaDepthNoiseModel(FluxNoiseModel):
     def __init__(self):
         pass
 
-    def apply_noise(
-        self,
-        bandflux,
-        *,
-        obs_table=None,
-        indices=None,
-        rng=None,
-        **kwargs,
-    ):
-        """Compute the noise parameters for given observations in
-        an ObsTable and apply noise to the input bandflux.
+    def compute_flux_error(self, bandflux, *, obs_table=None, indices=None, **kwargs):
+        """Compute the flux error for the given bandflux and observation parameters.
 
         Parameters
         ----------
         bandflux : array_like of float
-            Source bandflux in energy units, e.g. nJy.
-        obs_table : ObsTable, optional
-            Table containing the observation parameters, including all
-            parameters needed to compute the noise.
-        indices : array_like of int, optional
-            Indices of the observations in the ObsTable to which noise should
-            be applied.
-        rng : np.random.Generator, optional
-            The random number generator to use for applying noise. If None,
-            a default generator will be used.
+            Source bandflux in nJy.
+        obs_table : ObsTable
+            Table containing the observation parameters needed to compute the noise.
+        indices : array_like of int
+            Indices of the observations in the ObsTable for which to compute the noise.
         **kwargs
             Additional parameters for the noise model.
 
         Returns
         -------
-        flux : array_like
-            The updated flux measurements after applying noise, in the same
-            units as the input bandflux.
         flux_err : array_like
-            The bandflux measurement error used for applying noise, in the
-            same units as the input bandflux.
+            The standard deviation of the bandflux measurement error (in nJy)
         """
         if obs_table is None:
             raise ValueError("ObsTable must be provided for FiveSigmaDepthNoiseModel.")
@@ -411,8 +344,4 @@ class FiveSigmaDepthNoiseModel(FluxNoiseModel):
         # This uses five_sigma_depth in AB magnitudes, so we convert it to bandflux in nJy first.
         five_sigma_depth = obs_table.get_value_per_row("five_sigma_depth", indices=indices)
         flux_err = mag2flux(five_sigma_depth) / 5.0
-
-        # Generate the actual noisy bandflux measurements.
-        rng = np.random.default_rng(rng)
-        noisy_bandflux = rng.normal(loc=bandflux, scale=flux_err)
-        return noisy_bandflux, flux_err
+        return flux_err

--- a/src/lightcurvelynx/noise_models/noise_model_modifiers.py
+++ b/src/lightcurvelynx/noise_models/noise_model_modifiers.py
@@ -32,7 +32,7 @@ class LinearTransformFluxNoiseModel(FluxNoiseModel):
         self.flux_err_offset = flux_err_offset
 
         # Copy the required values from the base noise model to ensure compatibility with ObsTable.
-        self._required_values = base_noise_model.required_values
+        self._required_values = base_noise_model.required_values.copy()
 
     def compute_flux_error(self, bandflux, **kwargs):
         """Compute a base flux error for the given bandflux and observation parameters, and then
@@ -87,7 +87,7 @@ class GivenLinearTransformFluxNoiseModel(FluxNoiseModel):
         self.flux_err_offset_col = flux_err_offset_col
 
         # Copy the required values from the base noise model to ensure compatibility with ObsTable.
-        self._required_values = base_noise_model.required_values
+        self._required_values = base_noise_model.required_values.copy()
 
     def compute_flux_error(self, bandflux, *, obs_table=None, indices=None, **kwargs):
         """Compute a base flux error for the given bandflux and observation parameters, and then

--- a/src/lightcurvelynx/noise_models/noise_model_modifiers.py
+++ b/src/lightcurvelynx/noise_models/noise_model_modifiers.py
@@ -52,3 +52,81 @@ class LinearTransformFluxNoiseModel(FluxNoiseModel):
         """
         flux_err_base = np.asarray(self.base_noise_model.compute_flux_error(bandflux, **kwargs))
         return self.scale_factor * flux_err_base + self.flux_err_offset
+
+
+class GivenLinearTransformFluxNoiseModel(FluxNoiseModel):
+    """A noise model that transforms the flux error computed by a base noise model using a per-observation
+    linear function: flux_err_scaled = scale_factor * flux_err_base + flux_err_offset, where
+    flux_err_base is the flux error computed by the base noise model and scale_factor and flux_err_offset
+    are extracted from the observation table for each observation.
+
+    The scale_factor and flux_err_offset are expected to be provided in the observation table as columns
+    with names specified by the scale_factor_col and flux_err_offset_col parameters, respectively. If
+    these columns are not present in the observation table, default values of 1.0 for scale_factor and 0.0
+    for flux_err_offset will be used.
+
+    Attributes
+    ----------
+    base_noise_model : FluxNoiseModel
+        The base noise model to which the scaling will be applied.
+    scale_factor_col : str, optional
+        The column name in the observation table that provides the
+        factor by which to scale the flux error computed by the base noise model. Default is "scale_factor".
+    flux_err_offset_col : str, optional
+        The column name in the observation table that provides the
+        additive offset to the flux error computed by the base noise model. Default is "flux_err_offset".
+    """
+
+    def __init__(
+        self, base_noise_model, scale_factor_col="scale_factor", flux_err_offset_col="flux_err_offset"
+    ):
+        if not isinstance(base_noise_model, FluxNoiseModel):  # pragma: no cover
+            raise TypeError("base_noise_model must be an instance of FluxNoiseModel.")
+        self.base_noise_model = base_noise_model
+        self.scale_factor_col = scale_factor_col
+        self.flux_err_offset_col = flux_err_offset_col
+
+        # Copy the required values from the base noise model to ensure compatibility with ObsTable.
+        self._required_values = base_noise_model.required_values
+
+    def compute_flux_error(self, bandflux, *, obs_table=None, indices=None, **kwargs):
+        """Compute a base flux error for the given bandflux and observation parameters, and then
+        scale it by the scale_factor and add the flux_err_offset extracted from the observation table for
+        each observation.
+
+        Parameters
+        ----------
+        bandflux : array_like of float
+            Source bandflux in nJy.
+        obs_table : ObsTable
+            Table containing the observation parameters needed to compute the noise.
+        indices : array_like of int
+            Indices of the observations in the ObsTable for which to compute the noise.
+        **kwargs
+            Additional parameters for the noise model.
+
+        Returns
+        -------
+        flux_err : array_like
+            The standard deviation of the bandflux measurement error (in nJy)
+        """
+        if obs_table is None:  # pragma: no cover
+            raise ValueError("ObsTable must be provided for GivenLinearTransformFluxNoiseModel.")
+        if indices is None:  # pragma: no cover
+            raise ValueError("Indices must be provided for GivenLinearTransformFluxNoiseModel.")
+        if len(indices) != len(bandflux):  # pragma: no cover
+            raise ValueError("Length of indices must match length of bandflux.")
+
+        # Start by computing the base flux error using the base noise model.
+        flux_err_base = self.base_noise_model.compute_flux_error(
+            bandflux,
+            obs_table=obs_table,
+            indices=indices,
+            **kwargs,
+        )
+        flux_err_base = np.asarray(flux_err_base)
+
+        # Extract the scale_factor and flux_err_offset from the observation table for each observation.
+        scale_factor = obs_table.get_value_per_row(self.scale_factor_col, indices=indices, default=1.0)
+        flux_err_offset = obs_table.get_value_per_row(self.flux_err_offset_col, indices=indices, default=0.0)
+        return scale_factor * flux_err_base + flux_err_offset

--- a/src/lightcurvelynx/noise_models/noise_model_modifiers.py
+++ b/src/lightcurvelynx/noise_models/noise_model_modifiers.py
@@ -1,0 +1,54 @@
+"""Noise model modifiers are noise models that wrap and transform other noise models. They can be
+used to apply additional transformations to the noise parameters computed by a base noise model, such
+as scaling or adding additional noise components. You can stack multiple noise model modifiers to
+create complex noise models that combine different noise sources and transformations.
+"""
+
+import numpy as np
+
+from lightcurvelynx.noise_models.base_noise_models import FluxNoiseModel
+
+
+class LinearTransformFluxNoiseModel(FluxNoiseModel):
+    """A noise model that transforms the flux error computed by a base noise model using a
+    linear function: flux_err_scaled = scale_factor * flux_err_base + flux_err_offset, where
+    flux_err_base is the flux error computed by the base noise model.
+
+    Attributes
+    ----------
+    base_noise_model : FluxNoiseModel
+        The base noise model to which the scaling will be applied.
+    scale_factor : float, optional
+        The factor by which to scale the flux error computed by the base noise model. Default is 1.0.
+    flux_err_offset : float, optional
+        The additive offset to the flux error computed by the base noise model. Default is 0.0.
+    """
+
+    def __init__(self, base_noise_model, scale_factor=1.0, flux_err_offset=0.0):
+        if not isinstance(base_noise_model, FluxNoiseModel):  # pragma: no cover
+            raise TypeError("base_noise_model must be an instance of FluxNoiseModel.")
+        self.base_noise_model = base_noise_model
+        self.scale_factor = scale_factor
+        self.flux_err_offset = flux_err_offset
+
+        # Copy the required values from the base noise model to ensure compatibility with ObsTable.
+        self._required_values = base_noise_model.required_values
+
+    def compute_flux_error(self, bandflux, **kwargs):
+        """Compute a base flux error for the given bandflux and observation parameters, and then
+        scale it by the scale_factor and add the flux_err_offset.
+
+        Parameters
+        ----------
+        bandflux : array_like of float
+            Source bandflux in nJy.
+        **kwargs
+            Additional parameters for the noise model.
+
+        Returns
+        -------
+        flux_err : array_like
+            The standard deviation of the bandflux measurement error (in nJy)
+        """
+        flux_err_base = np.asarray(self.base_noise_model.compute_flux_error(bandflux, **kwargs))
+        return self.scale_factor * flux_err_base + self.flux_err_offset

--- a/src/lightcurvelynx/noise_models/pzflow_noise_model.py
+++ b/src/lightcurvelynx/noise_models/pzflow_noise_model.py
@@ -251,42 +251,27 @@ class PZFlowNoiseModel(FluxNoiseModel, CiteClass):
 
         return noise_model
 
-    def apply_noise(
-        self,
-        bandflux,
-        *,
-        obs_table=None,
-        indices=None,
-        rng=None,
-        **kwargs,
-    ):
-        """Compute the noise parameters for given observations in
-        an ObsTable and apply noise to the input bandflux.
+    def compute_flux_error(self, bandflux, *, obs_table=None, indices=None, rng=None, **kwargs):
+        """Compute the flux error for the given bandflux and observation parameters.
 
         Parameters
         ----------
         bandflux : array_like of float
-            Source bandflux in energy units, e.g. nJy.
-        obs_table : ObsTable, optional
-            Table containing the observation parameters, including all
-            parameters needed to compute the noise.
-        indices : array_like of int, optional
-            Indices of the observations in the ObsTable to which noise should
-            be applied.
+            Source bandflux in nJy.
+        obs_table : ObsTable
+            Table containing the observation parameters needed to compute the noise.
+        indices : array_like of int
+            Indices of the observations in the ObsTable for which to compute the noise.
         rng : np.random.Generator, optional
-            The random number generator to use for applying noise. If None,
+            The random number generator to use for sampling from the flow. If None,
             a default generator will be used.
         **kwargs
             Additional parameters for the noise model.
 
         Returns
         -------
-        flux : array_like
-            The updated flux measurements after applying noise, in the same
-            units as the input bandflux.
         flux_err : array_like
-            The bandflux measurement error used for applying noise, in the
-            same units as the input bandflux.
+            The standard deviation of the bandflux measurement error (in nJy)
         """
         if obs_table is None:
             raise ValueError("ObsTable must be provided for PZFlowNoiseModel.")
@@ -295,6 +280,9 @@ class PZFlowNoiseModel(FluxNoiseModel, CiteClass):
         num_samples = len(bandflux)
         if len(indices) != num_samples:
             raise ValueError("Length of indices must match length of bandflux.")
+
+        if rng is None:
+            rng = np.random.default_rng()
 
         # Get the input parameters for the flow (if there are any).
         if self._flow.conditional_columns is not None and len(self._flow.conditional_columns) > 0:
@@ -323,7 +311,6 @@ class PZFlowNoiseModel(FluxNoiseModel, CiteClass):
             input_df = None
 
         # Sample from the flow to get the noise parameters.
-        rng = np.random.default_rng(rng)
         pzflow_seed = rng.integers(0, 1e9)
         samples = self._flow.sample(nsamples=1, conditions=input_df, seed=pzflow_seed)
         flux_err = np.clip(samples[self._output_column].values, a_min=0, a_max=None)
@@ -332,10 +319,7 @@ class PZFlowNoiseModel(FluxNoiseModel, CiteClass):
         if self._normalizer_data.get(self._output_column) is not None:
             normalizer = self._normalizer_data[self._output_column]
             flux_err = normalizer.denormalize(flux_err)
-
-        # Apply noise to the input bandflux using the sampled noise parameters.
-        noisy_bandflux = rng.normal(loc=bandflux, scale=flux_err)
-        return noisy_bandflux, flux_err
+        return flux_err
 
     def save_to_file(self, filename):
         """Save the PZFlowNoiseModel to a file.

--- a/src/lightcurvelynx/obstable/roman_obstable.py
+++ b/src/lightcurvelynx/obstable/roman_obstable.py
@@ -95,7 +95,7 @@ class RomanPoissonFluxNoiseModel(PoissonFluxNoiseModel):
     def __init__(self):
         super().__init__()
 
-    def compute_flux_error(self, bandflux, obs_table, indices):
+    def compute_flux_error(self, bandflux, obs_table, indices, **kwargs):
         """Compute the flux error for the given bandflux and observation parameters.
 
         Parameters
@@ -106,6 +106,8 @@ class RomanPoissonFluxNoiseModel(PoissonFluxNoiseModel):
             Table containing the observation parameters needed to compute the noise.
         indices : array_like of int
             Indices of the observations in the ObsTable for which to compute the noise.
+        **kwargs
+            Additional keyword arguments to pass to the noise computation function.
 
         Returns
         -------

--- a/tests/lightcurvelynx/noise_models/test_noise_model_modifiers.py
+++ b/tests/lightcurvelynx/noise_models/test_noise_model_modifiers.py
@@ -1,0 +1,85 @@
+import numpy as np
+from lightcurvelynx.noise_models.base_noise_models import (
+    ConstantFluxNoiseModel,
+    PoissonFluxNoiseModel,
+)
+from lightcurvelynx.noise_models.noise_model_modifiers import LinearTransformFluxNoiseModel
+
+# Local helper class.
+from lookup_only_obstable import LookupOnlyObsTable
+
+
+def test_linear_transform_flux_noise_model_constant():
+    """Test that LinearTransformFluxNoiseModel correctly scales and offsets the flux error
+    computed by a ConstantFluxNoiseModel base noise model."""
+    base_model = ConstantFluxNoiseModel(noise_level=1.0)
+    scale_factor = 2.0
+    flux_err_offset = 0.5
+    model = LinearTransformFluxNoiseModel(
+        base_noise_model=base_model,
+        scale_factor=scale_factor,
+        flux_err_offset=flux_err_offset,
+    )
+
+    bandflux = np.array([10.0, 20.0, 30.0])
+    computed_flux_err = model.compute_flux_error(bandflux)
+    assert np.allclose(
+        computed_flux_err,
+        scale_factor * np.full_like(bandflux, 1.0) + flux_err_offset,
+    )
+
+
+def test_poisson_flux_noise_model():
+    """Test that LinearTransformFluxNoiseModel correctly scales and offsets the flux error
+    computed by a PoissonFluxNoiseModel base noise model."""
+    base_model = PoissonFluxNoiseModel()
+    scale_factor = 1.25
+    flux_err_offset = 0.1
+    model = LinearTransformFluxNoiseModel(
+        base_noise_model=base_model,
+        scale_factor=scale_factor,
+        flux_err_offset=flux_err_offset,
+    )
+
+    # Check that we copied over the required values from the base model.
+    assert set(model.required_values) == {
+        "exptime",
+        "sky_bg_e",
+        "psf_footprint",
+        "zp",
+        "read_noise",
+        "dark_current",
+    }
+
+    bandflux = np.array([100.0, 200.0, 200.0])
+    dummy_data = {
+        "exptime": np.array([30.0, 35.0, 40.0]),
+        "nexposure": np.array([1, 2, 1]),
+        "sky_bg_e": np.array([100.0, 110.0, 120.0]),
+        "psf_footprint": np.array([2.0, 2.5, 3.0]),
+        "zp": np.array([25.0, 26.0, 27.0]),
+        "read_noise": np.array([4.0, 4.5, 5.0]),
+        "dark_current": np.array([0.01, 0.02, 0.03]),
+        "zp_err_mag": np.array([0.001, 0.002, 0.003]),
+    }
+    obs_table = LookupOnlyObsTable(dummy_data)
+
+    # Check that the model is compatible with our ObsTable.
+    assert model.check_compatibility(obs_table, fail_on_incompatible=True)
+
+    # Apply noise with the base model and the transformed model.
+    base_flux, base_flux_err = base_model.apply_noise(
+        bandflux,
+        obs_table=obs_table,
+        indices=np.array([0, 1, 2]),
+        rng=np.random.default_rng(2024),
+    )
+    new_flux, new_flux_err = model.apply_noise(
+        bandflux,
+        obs_table=obs_table,
+        indices=np.array([0, 1, 2]),
+        rng=np.random.default_rng(2024),
+    )
+
+    assert np.allclose(new_flux_err, scale_factor * base_flux_err + flux_err_offset)
+    assert not np.any(base_flux == new_flux)

--- a/tests/lightcurvelynx/noise_models/test_noise_model_modifiers.py
+++ b/tests/lightcurvelynx/noise_models/test_noise_model_modifiers.py
@@ -3,7 +3,10 @@ from lightcurvelynx.noise_models.base_noise_models import (
     ConstantFluxNoiseModel,
     PoissonFluxNoiseModel,
 )
-from lightcurvelynx.noise_models.noise_model_modifiers import LinearTransformFluxNoiseModel
+from lightcurvelynx.noise_models.noise_model_modifiers import (
+    GivenLinearTransformFluxNoiseModel,
+    LinearTransformFluxNoiseModel,
+)
 
 # Local helper class.
 from lookup_only_obstable import LookupOnlyObsTable
@@ -29,7 +32,7 @@ def test_linear_transform_flux_noise_model_constant():
     )
 
 
-def test_poisson_flux_noise_model():
+def test_linear_transform_flux_noise_model_poisson():
     """Test that LinearTransformFluxNoiseModel correctly scales and offsets the flux error
     computed by a PoissonFluxNoiseModel base noise model."""
     base_model = PoissonFluxNoiseModel()
@@ -81,5 +84,75 @@ def test_poisson_flux_noise_model():
         rng=np.random.default_rng(2024),
     )
 
+    assert np.allclose(new_flux_err, scale_factor * base_flux_err + flux_err_offset)
+    assert not np.any(base_flux == new_flux)
+
+
+def test_given_linear_transform_flux_noise_model_poisson():
+    """Test that GivenLinearTransformFluxNoiseModel correctly scales and offsets the flux error
+    computed by a PoissonFluxNoiseModel base noise model."""
+    base_model = PoissonFluxNoiseModel()
+    scale_factor = np.array([1.0, 2.0, 1.5])
+    flux_err_offset = np.array([0.1, 0.5, 0.2])
+    model = GivenLinearTransformFluxNoiseModel(
+        base_noise_model=base_model,
+        scale_factor_col="scale_factor",
+        flux_err_offset_col="flux_err_offset",
+    )
+
+    # Check that we copied over the required values from the base model.
+    assert set(model.required_values) == {
+        "exptime",
+        "sky_bg_e",
+        "psf_footprint",
+        "zp",
+        "read_noise",
+        "dark_current",
+    }
+
+    bandflux = np.array([100.0, 200.0, 200.0])
+    dummy_data = {
+        "exptime": np.array([30.0, 35.0, 40.0]),
+        "nexposure": np.array([1, 2, 1]),
+        "sky_bg_e": np.array([100.0, 110.0, 120.0]),
+        "psf_footprint": np.array([2.0, 2.5, 3.0]),
+        "zp": np.array([25.0, 26.0, 27.0]),
+        "read_noise": np.array([4.0, 4.5, 5.0]),
+        "dark_current": np.array([0.01, 0.02, 0.03]),
+        "zp_err_mag": np.array([0.001, 0.002, 0.003]),
+    }
+    obs_table = LookupOnlyObsTable(dummy_data)
+
+    # Check that the model is compatible with our ObsTable.
+    assert model.check_compatibility(obs_table, fail_on_incompatible=True)
+
+    # Apply noise with the base model and the transformed model. Without the scale_factor and flux_err_offset
+    # columns in the obs_table, the model should use default values of 1.0 and 0.0, respectively.
+    base_flux, base_flux_err = base_model.apply_noise(
+        bandflux,
+        obs_table=obs_table,
+        indices=np.array([0, 1, 2]),
+        rng=np.random.default_rng(2024),
+    )
+    new_flux, new_flux_err = model.apply_noise(
+        bandflux,
+        obs_table=obs_table,
+        indices=np.array([0, 1, 2]),
+        rng=np.random.default_rng(2024),
+    )
+    assert np.allclose(base_flux, new_flux)
+    assert np.allclose(base_flux_err, new_flux_err)
+
+    # We can now add the scale_factor and flux_err_offset columns to the obs_table and test that
+    # the model correctly applies them.
+    dummy_data["scale_factor"] = scale_factor
+    dummy_data["flux_err_offset"] = flux_err_offset
+    obs_table = LookupOnlyObsTable(dummy_data)
+    new_flux, new_flux_err = model.apply_noise(
+        bandflux,
+        obs_table=obs_table,
+        indices=np.array([0, 1, 2]),
+        rng=np.random.default_rng(2024),
+    )
     assert np.allclose(new_flux_err, scale_factor * base_flux_err + flux_err_offset)
     assert not np.any(base_flux == new_flux)


### PR DESCRIPTION
This PR refactors the noise model code to remove duplicate code and improve flexibility:
- `apply_noise` is implemented once in the base class (since all functions used the same implementation). It can still be overridden by subclasses if needed.
- The logic for the noise model has been moved to `compute_flux_error`.
- A new set of noise models are defined that can add transforms to existing noise models via `compute_flux_error`:
    - `LinearTransformFluxNoiseModel` applies a single multiplicative scale and additive offset to the computed flux errors for all rows.
    - `GivenLinearTransformFluxNoiseModel` applies a per-row multiplicative scale and additive offset to the computed flux errors using data computed from the `ObsTable`