### PR TITLE
Speed up the flam_to_fnu computation

### DIFF
--- a/src/lightcurvelynx/astro_utils/unit_utils.py
+++ b/src/lightcurvelynx/astro_utils/unit_utils.py
@@ -1,26 +1,55 @@
+from functools import lru_cache
+
 import numpy as np
 from astropy import constants as const
 
 
-def bulk_convert_matrix(mat, in_units, out_units):
-    """Bulk convert a numpy matrix from one set of units to another.
+# Cache the conversion factors to avoid repeated calculations. We expect this
+# to be more efficient because the models use the same units for each evaluation.
+@lru_cache(maxsize=32)
+def get_flam_to_fnu_multiplier(flam_unit, wave_unit, fnu_unit):
+    """Get the multiplier for flam to fnu conversion.
 
     Parameters
     ----------
-    mat : numpy.ndarray
-        The numpy matrix of values to convert.
-    in_units : astropy.units
-        The current (input) units of the matrix.
-    out_units : astropy.units
-        The desired (output) units of the matrix.
+    flam_unit : astropy.units.Unit
+        The unit for the input flux_flam values.
+    wave_unit : astropy.units.Unit
+        The unit for the wavelength values.
+    fnu_unit : astropy.units.Unit
+        The unit for the output flux_fnu values.
 
     Returns
     -------
-    output : numpy.ndarray
-        The converted numpy matrix of values.
+    multiplier : float
+        The multiplier for the conversion from flam to fnu.
     """
-    multipler = (1.0 * in_units).to_value(out_units)
-    return multipler * mat
+    input_units = (flam_unit * wave_unit * wave_unit) / const.c.unit
+    multiplier = (1.0 * input_units).to_value(fnu_unit)
+    return multiplier
+
+
+@lru_cache(maxsize=32)
+def get_fnu_to_flam_multiplier(fnu_unit, wave_unit, flam_unit):
+    """Get the multiplier for fnu to flam conversion.
+
+    Parameters
+    ----------
+    fnu_unit : astropy.units.Unit
+        The unit for the output flux_fnu values.
+    wave_unit : astropy.units.Unit
+        The unit for the wavelength values.
+    flam_unit : astropy.units.Unit
+        The unit for the input flux_flam values.
+
+    Returns
+    -------
+    multiplier : float
+        The multiplier for the conversion from fnu to flam.
+    """
+    input_units = (fnu_unit * const.c.unit) / (wave_unit * wave_unit)
+    multiplier = (1.0 * input_units).to_value(flam_unit)
+    return multiplier
 
 
 def flam_to_fnu(flux_flam, wavelengths, *, wave_unit, flam_unit, fnu_unit):
@@ -64,9 +93,9 @@ def flam_to_fnu(flux_flam, wavelengths, *, wave_unit, flam_unit, fnu_unit):
         ) from err
 
     # convert flux in flam_unit (e.g. ergs/s/cm^2/A) to fnu_unit (e.g. nJy or ergs/s/cm^2/Hz)
-    input_units = (flam_unit * wave_unit * wave_unit) / const.c.unit
+    multiplier = get_flam_to_fnu_multiplier(flam_unit, wave_unit, fnu_unit)
     flux_fnu = flux_flam * (wavelengths**2) / const.c.value
-    return bulk_convert_matrix(flux_fnu, input_units, fnu_unit)
+    return multiplier * flux_fnu
 
 
 def fnu_to_flam(flux_fnu, wavelengths, *, wave_unit, flam_unit, fnu_unit):
@@ -111,6 +140,6 @@ def fnu_to_flam(flux_fnu, wavelengths, *, wave_unit, flam_unit, fnu_unit):
         ) from err
 
     # convert flux in fnu_unit (e.g. nJy or ergs/s/cm^2/Hz) to flam_unit (e.g. ergs/s/cm^2/A)
-    input_units = (fnu_unit * const.c.unit) / (wave_unit * wave_unit)
+    multiplier = get_fnu_to_flam_multiplier(fnu_unit, wave_unit, flam_unit)
     flux_flam = flux_fnu * const.c.value / wavelengths**2
-    return bulk_convert_matrix(flux_flam, input_units, flam_unit)
+    return multiplier * flux_flam

--- a/src/lightcurvelynx/astro_utils/unit_utils.py
+++ b/src/lightcurvelynx/astro_utils/unit_utils.py
@@ -36,11 +36,11 @@ def get_fnu_to_flam_multiplier(fnu_unit, wave_unit, flam_unit):
     Parameters
     ----------
     fnu_unit : astropy.units.Unit
-        The unit for the output flux_fnu values.
+        The unit for the input flux_fnu values.
     wave_unit : astropy.units.Unit
         The unit for the wavelength values.
     flam_unit : astropy.units.Unit
-        The unit for the input flux_flam values.
+        The unit for the output flux_flam values.
 
     Returns
     -------

--- a/tests/lightcurvelynx/astro_utils/test_unit_utils.py
+++ b/tests/lightcurvelynx/astro_utils/test_unit_utils.py
@@ -20,6 +20,20 @@ def test_flam_to_fnu():
     )
     assert np.allclose(fnu, [1.0, 1.0e15 / c])
 
+    # Include some tests using values from an older implementation to ensure that nothing has changed.
+    flam = [697.713, 697.713, 697.713, 1013.715, 1013.715, 1013.715, 489.0754, 489.0754, 489.0754]
+    wave = [5000, 5010, 5020, 5000, 5010, 5020, 5000, 5010, 5020]
+    fnu = flam_to_fnu(
+        flam,
+        wave,
+        wave_unit=u.AA,
+        flam_unit=u.erg / u.second / u.cm**2 / u.AA,
+        fnu_unit=u.nJy,
+    )
+
+    expected = [5.82e23, 5.84e23, 5.86e23, 8.45e23, 8.49e23, 8.52e23, 4.08e23, 4.09e23, 4.11e23]
+    assert np.allclose(fnu, expected, rtol=1e-2)
+
 
 def test_flam_to_fnu_matrix():
     """Test flam to fnu conversion when dealing with a matrix of observations."""
@@ -49,6 +63,32 @@ def test_flam_to_fnu_matrix():
     expected = np.array([[1.0, 1.0e15 / c], [1.0e7 / c, 2.0e13 / c], [1.0, 1.0e6]])
     assert np.allclose(fnu, expected)
 
+    # Include some tests using values from an older implementation to ensure that nothing has changed.
+    flam = [
+        [148.55, 148.55, 148.55, 148.55],
+        [414.47, 414.47, 414.47, 414.47],
+        [491.29, 491.29, 491.29, 491.29],
+    ]
+    wave = [
+        [6000, 6050, 7000, 7025],
+        [6000, 6050, 7000, 7025],
+        [6000, 6050, 7000, 7025],
+    ]
+    fnu = flam_to_fnu(
+        flam,
+        wave,
+        wave_unit=u.AA,
+        flam_unit=u.erg / u.second / u.cm**2 / u.AA,
+        fnu_unit=u.nJy,
+    )
+
+    expected = [
+        [1.78e23, 1.81e23, 2.43e23, 2.45e23],
+        [4.98e23, 5.06e23, 6.77e23, 6.82e23],
+        [5.90e23, 6.00e23, 8.03e23, 8.09e23],
+    ]
+    assert np.allclose(fnu, expected, rtol=1e-2)
+
     # Fail if the dimensions are not compatible.
     with pytest.raises(ValueError):
         _ = flam_to_fnu(
@@ -67,6 +107,50 @@ def test_flam_to_fnu_matrix():
             flam_unit=u.erg / u.second / u.cm**2 / u.AA,
             fnu_unit=u.erg / u.second / u.cm**2 / u.Hz,
         )
+
+
+def test_fnu_to_flam():
+    """Test fnu to flam conversion using values from an older implementation to ensure
+    that nothing has changed.
+    """
+    fnu = [5.82e23, 5.84e23, 5.86e23, 8.45e23, 8.49e23, 8.52e23, 4.08e23, 4.09e23, 4.11e23]
+    wave = [5000, 5010, 5020, 5000, 5010, 5020, 5000, 5010, 5020]
+    flam = fnu_to_flam(
+        fnu,
+        wave,
+        wave_unit=u.AA,
+        flam_unit=u.erg / u.second / u.cm**2 / u.AA,
+        fnu_unit=u.nJy,
+    )
+
+    expected = [697.713, 697.713, 697.713, 1013.715, 1013.715, 1013.715, 489.0754, 489.0754, 489.0754]
+    assert np.allclose(flam, expected, rtol=1e-2)
+
+    # Test as a matrix.
+    fnu = [
+        [1.78e23, 1.81e23, 2.43e23, 2.45e23],
+        [4.98e23, 5.06e23, 6.77e23, 6.82e23],
+        [5.90e23, 6.00e23, 8.03e23, 8.09e23],
+    ]
+    wave = [
+        [6000, 6050, 7000, 7025],
+        [6000, 6050, 7000, 7025],
+        [6000, 6050, 7000, 7025],
+    ]
+    flam = fnu_to_flam(
+        fnu,
+        wave,
+        wave_unit=u.AA,
+        flam_unit=u.erg / u.second / u.cm**2 / u.AA,
+        fnu_unit=u.nJy,
+    )
+
+    expected = [
+        [148.55, 148.55, 148.55, 148.55],
+        [414.47, 414.47, 414.47, 414.47],
+        [491.29, 491.29, 491.29, 491.29],
+    ]
+    assert np.allclose(flam, expected, rtol=1e-2)
 
 
 def test_flam_to_fnu_to_flam():

--- a/tests/lightcurvelynx/astro_utils/test_unit_utils.py
+++ b/tests/lightcurvelynx/astro_utils/test_unit_utils.py
@@ -152,6 +152,26 @@ def test_fnu_to_flam():
     ]
     assert np.allclose(flam, expected, rtol=1e-2)
 
+    # The code works with a single vector of wavelengths.
+    flam2 = fnu_to_flam(
+        fnu,
+        [6000, 6050, 7000, 7025],  # Wavelengths are a single vector, not a matrix.
+        wave_unit=u.AA,
+        flam_unit=u.erg / u.second / u.cm**2 / u.AA,
+        fnu_unit=u.nJy,
+    )
+    assert np.allclose(flam2, expected, rtol=1e-2)
+
+    # We fail with incompatible dimensions.
+    with pytest.raises(ValueError):
+        _ = fnu_to_flam(
+            fnu,
+            [[6000, 6050, 7000, 7025], [6000, 6050, 7000, 7025]],
+            wave_unit=u.AA,
+            flam_unit=u.erg / u.second / u.cm**2 / u.AA,
+            fnu_unit=u.nJy,
+        )
+
 
 def test_flam_to_fnu_to_flam():
     """Test that flam_to_fnu(fnu_to_flam) is the identity."""


### PR DESCRIPTION
Profiling shows that computing the unit multiplier for `flam_to_fnu` and `fnu_to_flam` take a significant amount of time. So use an lru_cache to reduce the amount of work performed. This produces a 20% speedup on the benchmark notebook.