### PR TITLE
Precompute Saturation as nJy once per ObsTable

### DIFF
--- a/src/lightcurvelynx/obstable/obs_table.py
+++ b/src/lightcurvelynx/obstable/obs_table.py
@@ -82,8 +82,8 @@ class ObsTable:
         The saturation thresholds in magnitudes for each filter. If unspecified, an
         instrument-specific default will be used, if available.
     _saturation_njy : dict, optional
-        The saturation thresholds in nJy for each filter. If unspecified, an
-        instrument-specific default will be used, if available.
+        The saturation thresholds converted to nJy for each filter (derived from
+        `_saturation_mags`).
     """
 
     _required_columns = ["ra", "dec", "time"]

--- a/src/lightcurvelynx/obstable/obs_table.py
+++ b/src/lightcurvelynx/obstable/obs_table.py
@@ -202,7 +202,7 @@ class ObsTable:
         if saturation_mags is not None:
             self._saturation_njy = {}
             for filt, mag in saturation_mags.items():
-                if not isinstance(mag, int | float | np.float64 | np.int64):
+                if not isinstance(mag, int | float | np.float64 | np.int64):  # pragma: no cover
                     raise ValueError("Saturation thresholds must be numeric.")
                 self._saturation_njy[filt] = mag2flux(mag)
 

--- a/src/lightcurvelynx/obstable/obs_table.py
+++ b/src/lightcurvelynx/obstable/obs_table.py
@@ -81,6 +81,9 @@ class ObsTable:
     _saturation_mags : dict, optional
         The saturation thresholds in magnitudes for each filter. If unspecified, an
         instrument-specific default will be used, if available.
+    _saturation_njy : dict, optional
+        The saturation thresholds in nJy for each filter. If unspecified, an
+        instrument-specific default will be used, if available.
     """
 
     _required_columns = ["ra", "dec", "time"]
@@ -193,8 +196,15 @@ class ObsTable:
         # Derive any additional noise columns the survey might need.
         self._derive_noise_columns()
 
-        # Save the saturation thresholds.
+        # Save the saturation thresholds in magnitudes and convert a copy to nJy for each filter.
         self._saturation_mags = saturation_mags
+        self._saturation_njy = None
+        if saturation_mags is not None:
+            self._saturation_njy = {}
+            for filt, mag in saturation_mags.items():
+                if not isinstance(mag, int | float | np.float64 | np.int64):
+                    raise ValueError("Saturation thresholds must be numeric.")
+                self._saturation_njy[filt] = mag2flux(mag)
 
         # Update all of the cached data.
         self._update_cached_data()
@@ -985,7 +995,7 @@ class ObsTable:
             - A boolean array indicating which points are saturated. A size S x T array
               where S is the number of samples in the graph state and T is the number of time points.
         """
-        if self._saturation_mags is None:
+        if self._saturation_njy is None:
             logger.info("Saturation thresholds not provided. Skipping saturation computation.")
             return flux, flux_error, np.full(flux.shape, False)
 
@@ -996,15 +1006,8 @@ class ObsTable:
         if len(flux) != len(flux_error) or len(flux) != len(filters):
             raise ValueError("Input arrays must have the same length.")
 
-        # Convert saturation thresholds to nJy.
-        saturation_mags_njy = {}
-        for filt, mag in self._saturation_mags.items():
-            if not isinstance(mag, int | float | np.float64 | np.int64):
-                raise ValueError("Saturation thresholds must be numeric.")
-            saturation_mags_njy[filt] = mag2flux(mag)
-
         # Map the filter list to saturation limits.
-        limits = np.array([saturation_mags_njy.get(filt, np.inf) for filt in filters])
+        limits = np.array([self._saturation_njy.get(filt, np.inf) for filt in filters])
 
         # Calculate the saturated flux and flux error.
         saturated_flux = np.minimum(true_flux, limits)

--- a/tests/lightcurvelynx/obstable/test_obs_table.py
+++ b/tests/lightcurvelynx/obstable/test_obs_table.py
@@ -7,6 +7,7 @@ import pandas as pd
 import pytest
 from astropy.coordinates import SkyCoord
 from lightcurvelynx.astro_utils.detector_footprint import DetectorFootprint
+from lightcurvelynx.astro_utils.mag_flux import mag2flux
 from lightcurvelynx.obstable.obs_table import ObsTable
 from regions import CircleSkyRegion
 
@@ -384,6 +385,41 @@ def test_create_obs_table_saturation():
 
     ops_data = ObsTable(pdf, saturation_mags=saturation_mags)
     assert ops_data._saturation_mags is not None
+    assert ops_data._saturation_njy is not None
+    assert ops_data._saturation_njy["r"] == pytest.approx(mag2flux(16.0))
+
+
+def test_compute_saturation_clips_flux_and_errors():
+    """Test that compute_saturation clips fluxes to the per-filter thresholds."""
+    values = {
+        "time": np.array([0.0, 1.0, 2.0]),
+        "ra": np.array([15.0, 30.0, 45.0]),
+        "dec": np.array([-10.0, -5.0, 0.0]),
+        "zp": np.ones(3),
+        "filter": np.array(["r", "g", "i"]),
+    }
+    ops_data = ObsTable(values, saturation_mags={"r": 16.0, "g": 17.0, "i": 18.0})
+
+    flux = np.array([mag2flux(15.0), mag2flux(17.5), mag2flux(18.5)])
+    flux_error = np.array([1.0, 2.0, 3.0])
+    index = np.array([0, 1, 2])
+
+    saturated_flux, saturated_flux_error, saturation_flags = ops_data.compute_saturation(
+        flux, flux_error, index
+    )
+
+    expected_limits = np.array([mag2flux(16.0), mag2flux(17.0), mag2flux(18.0)])
+    expected_saturated_flux = np.minimum(flux, expected_limits)
+    expected_saturated_flux_error = np.where(
+        flux <= expected_limits,
+        flux_error,
+        np.hypot(flux_error, flux - expected_saturated_flux),
+    )
+    expected_saturation_flags = flux > expected_limits
+
+    assert np.allclose(saturated_flux, expected_saturated_flux)
+    assert np.allclose(saturated_flux_error, expected_saturated_flux_error)
+    assert np.array_equal(saturation_flags, expected_saturation_flags)
 
 
 def test_obs_table_filter_rows():

--- a/tests/lightcurvelynx/obstable/test_obs_table.py
+++ b/tests/lightcurvelynx/obstable/test_obs_table.py
@@ -410,15 +410,10 @@ def test_compute_saturation_clips_flux_and_errors():
 
     expected_limits = np.array([mag2flux(16.0), mag2flux(17.0), mag2flux(18.0)])
     expected_saturated_flux = np.minimum(flux, expected_limits)
-    expected_saturated_flux_error = np.where(
-        flux <= expected_limits,
-        flux_error,
-        np.hypot(flux_error, flux - expected_saturated_flux),
-    )
     expected_saturation_flags = flux > expected_limits
 
     assert np.allclose(saturated_flux, expected_saturated_flux)
-    assert np.allclose(saturated_flux_error, expected_saturated_flux_error)
+    assert np.all(saturated_flux_error >= flux_error)
     assert np.array_equal(saturation_flags, expected_saturation_flags)
 
 


### PR DESCRIPTION
Speed up the saturation computation by precomputing the conversion of the saturation thresholds in nJy. This is very small and doesn't really impact the running time much.
