### PR TITLE
Spectrograph takes min/max

### DIFF
--- a/docs/notebooks/multiple_surveys.ipynb
+++ b/docs/notebooks/multiple_surveys.ipynb
@@ -197,7 +197,7 @@
     "    \"dec\": [10.0, 10.0, -10.0, -10.0],\n",
     "}\n",
     "obstable3 = SpectrographObsTable(obsdata3)\n",
-    "spectograph = Spectrograph(np.arange(4000, 8000, 100))\n",
+    "spectograph = Spectrograph(waves_min=np.arange(4000, 8000, 100), waves_max=np.arange(4100, 8100, 100))\n",
     "\n",
     "survey_info3 = SurveyInfo(obstable=obstable3, passbands=spectograph, survey_name=\"spectrograph\")"
    ]
@@ -312,7 +312,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "lightcurvelynx (3.13.8)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },

--- a/docs/notebooks/spectrograph_demo.ipynb
+++ b/docs/notebooks/spectrograph_demo.ipynb
@@ -24,8 +24,9 @@
     "\n",
     "from lightcurvelynx.astro_utils.spectrograph import Spectrograph\n",
     "\n",
-    "bin_centers = np.arange(4000, 8000, 100)\n",
-    "my_spectrograph = Spectrograph(bin_centers)"
+    "wave_min = np.arange(4000, 8000, 100)\n",
+    "wave_max = np.arange(4100, 8100, 100)\n",
+    "my_spectrograph = Spectrograph(wave_min, wave_max)"
    ]
   },
   {
@@ -216,7 +217,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "lightcurvelynx (3.13.8)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },

--- a/src/lightcurvelynx/astro_utils/spectrograph.py
+++ b/src/lightcurvelynx/astro_utils/spectrograph.py
@@ -12,53 +12,68 @@ class Spectrograph:
 
     Attributes
     ----------
+    waves_min : np.ndarray
+        The start of each wavelength bin in Angstroms.
+    waves_max : np.ndarray
+        The end of each wavelength bin in Angstroms.
     waves : np.ndarray
-        The wavelengths at the center of each bin in Angstroms.
+        The center of each wavelength bin in Angstroms.
+    bin_widths : np.ndarray
+        The width of each wavelength bin in Angstroms.
     instrument : str
         The instrument name for the spectrograph. Default is "Spectrograph".
     scale : np.ndarray
         The multiplicative factor to apply to each bin's flux to capture sensor
         sensitivity, etc. If None, we use 1.0 for all bins.
-    wave_min : float
-        The minimum wavelength of the spectra in Angstroms.
-    wave_max : float
-        The maximum wavelength of the spectra in Angstroms.
     """
 
     def __init__(
         self,
-        waves: np.array,
+        waves_min,
+        waves_max,
         *,
-        scale: np.ndarray | None = None,
+        scale=None,
         instrument: str | None = None,
     ):
-        if np.any(np.diff(waves) <= 0):
-            raise ValueError("waves must be in strictly increasing order.")
-        self.waves = waves
-        self.instrument = instrument if instrument is not None else "Spectrograph"
-
-        self.wave_min = self.waves[0] - 0.5 * self.bin_width(0)
-        self.wave_max = self.waves[-1] + 0.5 * self.bin_width(len(self.waves) - 1)
+        if len(waves_min) != len(waves_max):
+            raise ValueError("waves_min and waves_max must have the same length.")
+        if np.any(np.diff(waves_min) <= 0):
+            raise ValueError("waves_min must be in strictly increasing order.")
+        if np.any(np.diff(waves_max) <= 0):
+            raise ValueError("waves_max must be in strictly increasing order.")
+        if np.any(waves_max <= waves_min):
+            raise ValueError(
+                "Each element of waves_max must be greater than the corresponding element of waves_min."
+            )
+        self.waves_min = np.asarray(waves_min)
+        self.waves_max = np.asarray(waves_max)
+        self.waves = (self.waves_min + self.waves_max) / 2
+        self.bin_widths = self.waves_max - self.waves_min
 
         # Scale is the multiplicative factor to apply to each bin's flux. If None, we use 1.0 for all bins.
         if scale is None:
-            scale = np.ones(len(self.waves))
-        elif len(scale) != len(self.waves):
+            scale = np.ones(len(self.waves_min))
+        elif len(scale) != len(self.waves_min):
             raise ValueError("Scale array must have the same length as the number of bins in the spectra.")
-        self.scale = scale
+        self.scale = np.asarray(scale)
+
+        # Save the other spectrograph properties if provided.
+        self.instrument = instrument if instrument is not None else "Spectrograph"
 
     def __str__(self) -> str:
         """Return a string representation of the spectra filter."""
-        return f"{self.instrument} (spectra) [{self.wave_min}A - {self.wave_max}A]"
+        return f"{self.instrument} (spectra) [{self.waves_min[0]}A - {self.waves_max[-1]}A]"
 
     def __len__(self) -> int:
         return len(self.waves)
 
     def __eq__(self, other) -> bool:
         """Determine if two passbands have equal values for the processed tables."""
-        if len(self.waves) != len(other.waves):
+        if len(self.waves_min) != len(other.waves_min):
             return False
-        if not np.allclose(self.waves, other.waves):
+        if not np.allclose(self.waves_min, other.waves_min):
+            return False
+        if not np.allclose(self.waves_max, other.waves_max):
             return False
         if not np.allclose(self.scale, other.scale):
             return False
@@ -91,7 +106,44 @@ class Spectrograph:
 
         # We use the wavelength at the center of each bin.
         bin_centers = np.arange(wave_start + bin_width / 2, wave_end, bin_width)
-        return cls(bin_centers, **kwargs)
+        waves_min = bin_centers - bin_width / 2
+        waves_max = bin_centers + bin_width / 2
+        return cls(waves_min, waves_max, **kwargs)
+
+    @classmethod
+    def from_midpoints(cls, wave_midpoints, bin_width, **kwargs):
+        """Create a Spectrograph from the midpoints and widths of the bins.
+
+        Parameters
+        ----------
+        wave_midpoints : array-like
+            The midpoints of each wavelength bin in Angstroms.
+        bin_width : float or array-like
+            The width of each wavelength bin in Angstroms.
+        **kwargs
+            Additional keyword arguments to pass to the Spectrograph constructor.
+
+        Returns
+        -------
+        Spectrograph
+            A Spectrograph object with bins defined by the midpoints and widths.
+        """
+        wave_midpoints = np.asarray(wave_midpoints, dtype=float)
+        if bin_width is None:
+            raise ValueError("bin_width must be provided.")
+        if np.isscalar(bin_width):
+            bin_widths = np.full(wave_midpoints.shape, float(bin_width), dtype=float)
+        else:
+            bin_widths = np.asarray(bin_width, dtype=float)
+
+        if np.any(bin_widths <= 0):
+            raise ValueError("All bin widths must be positive.")
+        if len(wave_midpoints) != len(bin_widths):
+            raise ValueError("wave_midpoints and bin_widths must have the same length.")
+
+        waves_min = wave_midpoints - bin_widths / 2
+        waves_max = wave_midpoints + bin_widths / 2
+        return cls(waves_min, waves_max, **kwargs)
 
     def bin_width(self, index):
         """Get the width of the bin at the given index.
@@ -106,19 +158,9 @@ class Spectrograph:
         float
             The width of the bin in Angstroms.
         """
-        if index < 0 or index >= len(self.waves):
-            raise IndexError(f"Index {index} out of bounds for {len(self.waves)} bin widths.")
-        elif index == 0:
-            # The center of the bin is at waves[0], so we assume the lower bound is symmetric
-            # about that point: 2.0 * (center_1 - center_0) / 2.0
-            return self.waves[1] - self.waves[0]
-        elif index == len(self.waves) - 1:
-            # The center of the bin is at waves[-1], so we assume the upper bound is symmetric
-            # about that point 2.0 * (center_N-1 - center_N-2) / 2.0
-            return self.waves[-1] - self.waves[-2]
-        else:
-            # Half the distance to the neighboring bins on either side.
-            return (self.waves[index + 1] - self.waves[index - 1]) / 2
+        if index < 0 or index >= len(self.waves_min):
+            raise IndexError(f"Index {index} out of bounds for {len(self.waves_min)} bin widths.")
+        return self.bin_widths[index]
 
     def wave_bounds(self):
         """Get the minimum and maximum wavelength for this spectra.
@@ -130,7 +172,7 @@ class Spectrograph:
         max_wave : float
             The maximum wavelength.
         """
-        return self.wave_min, self.wave_max
+        return self.waves_min[0], self.waves_max[-1]
 
     def evaluate(
         self,

--- a/tests/lightcurvelynx/astro_utils/test_spectrograph.py
+++ b/tests/lightcurvelynx/astro_utils/test_spectrograph.py
@@ -38,24 +38,25 @@ def test_create_spectrograph_from_regular_grid():
 
 def test_create_spectrograph_from_irregular_grid():
     """Test that we can create and query a Spectrograph object."""
-    waves = np.array([3500.0, 4000.0, 5000.0, 7000.0, 7500.0, 8000.0])
-    spgraph = Spectrograph(waves, instrument="custom_spectrograph")
+    waves_min = np.array([3500.0, 4000.0, 5000.0, 7000.0, 7500.0, 8000.0])
+    waves_max = np.array([4000.0, 5000.0, 7000.0, 7500.0, 8000.0, 8500.0])
+    spgraph = Spectrograph(waves_min, waves_max, instrument="custom_spectrograph")
     assert spgraph.instrument == "custom_spectrograph"
     assert len(spgraph) == 6
-    assert np.array_equal(spgraph.waves, waves)
+    assert np.array_equal(spgraph.waves, (waves_min + waves_max) / 2)
 
     l_val, h_val = spgraph.wave_bounds()
-    assert l_val == 3250.0
-    assert h_val == 8250.0
+    assert l_val == 3500.0
+    assert h_val == 8500.0
 
     assert spgraph.bin_width(0) == pytest.approx(500.0)
-    assert spgraph.bin_width(1) == pytest.approx(750.0)
-    assert spgraph.bin_width(2) == pytest.approx(1500.0)
-    assert spgraph.bin_width(3) == pytest.approx(1250.0)
+    assert spgraph.bin_width(1) == pytest.approx(1000.0)
+    assert spgraph.bin_width(2) == pytest.approx(2000.0)
+    assert spgraph.bin_width(3) == pytest.approx(500.0)
     assert spgraph.bin_width(4) == pytest.approx(500.0)
     assert spgraph.bin_width(5) == pytest.approx(500.0)
 
-    assert str(spgraph) == "custom_spectrograph (spectra) [3250.0A - 8250.0A]"
+    assert str(spgraph) == "custom_spectrograph (spectra) [3500.0A - 8500.0A]"
     # Two dimensional fluxes to spec_fluxes
     values = np.random.random((10, len(spgraph)))
     spec_fluxes = spgraph.evaluate(values)
@@ -67,9 +68,18 @@ def test_create_spectrograph_from_irregular_grid():
     assert np.allclose(spec_fluxes_3d, values_3d)
 
     # Test that we fail to create a Spectrograph object with invalid parameters.
-    bad_waves = np.array([4000.0, 3500.0, 5000.0])
     with pytest.raises(ValueError):
-        _ = Spectrograph(bad_waves)
+        # waves_min and waves_max have different lengths
+        _ = Spectrograph([1000.0, 2000.0], [2000.0, 3000.0, 4000.0])
+    with pytest.raises(ValueError):
+        # waves_min is not in strictly increasing order
+        _ = Spectrograph([1000.0, 3000.0, 2999.0], [2000.0, 3000.0, 4000.0])
+    with pytest.raises(ValueError):
+        # waves_max is not in strictly increasing order
+        _ = Spectrograph([1000.0, 2000.0, 3000.0], [2000.0, 1000.0, 4000.0])
+    with pytest.raises(ValueError):
+        # waves_max is not greater than waves_min
+        _ = Spectrograph([1000.0, 2000.0, 3000.0], [2000.0, 1500.0, 4000.0])
 
 
 def test_spectrograph_equals():
@@ -137,15 +147,14 @@ def test_create_spectrograph_with_scale():
     assert np.allclose(results, expected)
 
     # Test equality with scales.
-    waves = np.copy(spgraph.waves)
-    spgraph2 = Spectrograph(waves, scale=scale)
+    spgraph2 = Spectrograph(spgraph.waves_min, spgraph.waves_max, scale=scale)
     assert spgraph == spgraph2
 
     different_scale = np.array([0.5, 1.0, 1.0, 1.0, 0.9])
-    spgraph3 = Spectrograph(waves, scale=different_scale)
+    spgraph3 = Spectrograph(spgraph.waves_min, spgraph.waves_max, scale=different_scale)
     assert spgraph != spgraph3
 
     # Test with a mismatched scale length.
     bad_scale = np.array([1.0, 0.8])
     with pytest.raises(ValueError):
-        _ = Spectrograph(waves, scale=bad_scale)
+        _ = Spectrograph(spgraph.waves_min, spgraph.waves_max, scale=bad_scale)


### PR DESCRIPTION
Change the `Spectrograph` API to use min and max bin boundaries. This fixes a problem where the bin widths were not being correctly computed. It also makes it more compatible with SNANA style files.