### PR TITLE
Small optimization to extrapolation

### DIFF
--- a/src/lightcurvelynx/models/physical_model.py
+++ b/src/lightcurvelynx/models/physical_model.py
@@ -727,7 +727,7 @@ class SEDModel(BasePhysicalModel):
             new_computed_flux[:, in_bounds_mask] = computed_flux[:, start_idx:end_idx]
             computed_flux = new_computed_flux
 
-        # Do a similiar process for time extrapolation.
+        # Do a similar process for time extrapolation.
         if before_time_queries is not None or after_time_queries is not None:
             new_computed_flux = np.empty((len(times), len(wavelengths)))
             in_bounds_mask = np.full(len(times), True)

--- a/src/lightcurvelynx/models/physical_model.py
+++ b/src/lightcurvelynx/models/physical_model.py
@@ -558,9 +558,9 @@ class SEDModel(BasePhysicalModel):
                 # the list of wavelengths to extrapolate.
                 valid_mask = query_waves >= min_valid_wave
                 before_wave_queries = query_waves[~valid_mask]
-                n_select_wave_before = self._wave_extrap_before.nfit
+                n_added_wave_before = self._wave_extrap_before.nfit
                 query_waves = np.concatenate(
-                    (min_valid_wave + 10.0 * np.arange(n_select_wave_before), query_waves[valid_mask])
+                    (min_valid_wave + 10.0 * np.arange(n_added_wave_before), query_waves[valid_mask])
                 )
 
         # We check if we can do extrapolation for after the last valid wavelength and, if so, modify
@@ -583,11 +583,11 @@ class SEDModel(BasePhysicalModel):
                 # the list of wavelengths to extrapolate.
                 valid_mask = query_waves <= max_valid_wave
                 after_wave_queries = query_waves[~valid_mask]
-                n_select_wave_after = self._wave_extrap_after.nfit
+                n_added_wave_after = self._wave_extrap_after.nfit
                 query_waves = np.concatenate(
                     (
                         query_waves[valid_mask],
-                        max_valid_wave - 10.0 * np.arange(n_select_wave_after - 1, -1, -1),
+                        max_valid_wave - 10.0 * np.arange(n_added_wave_after - 1, -1, -1),
                     )
                 )
 
@@ -630,9 +630,9 @@ class SEDModel(BasePhysicalModel):
                 # the list of times to extrapolate.
                 valid_mask = query_times >= min_valid_time
                 before_time_queries = query_times[~valid_mask]
-                n_select_time_before = self._time_extrap_before.nfit
+                n_added_time_before = self._time_extrap_before.nfit
                 query_times = np.concatenate(
-                    (min_valid_time + np.arange(n_select_time_before), query_times[valid_mask])
+                    (min_valid_time + np.arange(n_added_time_before), query_times[valid_mask])
                 )
 
         # We check if we can do extrapolation for times after the valid time range and, if so, modify
@@ -657,9 +657,9 @@ class SEDModel(BasePhysicalModel):
                 # the list of times to extrapolate.
                 valid_mask = query_times <= max_valid_time
                 after_time_queries = query_times[~valid_mask]
-                n_select_time_after = self._time_extrap_after.nfit
+                n_added_time_after = self._time_extrap_after.nfit
                 query_times = np.concatenate(
-                    (query_times[valid_mask], max_valid_time - np.arange(n_select_time_after - 1, -1, -1))
+                    (query_times[valid_mask], max_valid_time - np.arange(n_added_time_after - 1, -1, -1))
                 )
 
         # Check if the times are sorted and, if not, create sorting indices. We do this AFTER we
@@ -687,84 +687,86 @@ class SEDModel(BasePhysicalModel):
         # We do the extrapolation in two steps: first for wavelengths and then for times.
         # The result is that we combine the extrapolation for both dimensions at the corners.
         if before_wave_queries is not None or after_wave_queries is not None:
-            new_computed_flux = np.zeros((len(query_times), len(wavelengths)))
+            new_computed_flux = np.empty((len(query_times), len(wavelengths)))
             in_bounds_mask = np.full(len(wavelengths), True)
 
             if before_wave_queries is not None:
                 # Compute the flux values before the model's first valid wavelength and
                 # fill the extrapolated values in the correct locations.
                 before_wave_mask = wavelengths < min_valid_wave
-                before_fit_waves = query_waves[0:n_select_wave_before]
+                before_fit_waves = query_waves[0:n_added_wave_before]
                 extrapolated_values = self._wave_extrap_before.extrapolate_wavelength(
                     before_fit_waves,
-                    computed_flux[:, 0:n_select_wave_before],
+                    computed_flux[:, 0:n_added_wave_before],
                     before_wave_queries,
                 )
                 new_computed_flux[:, before_wave_mask] = extrapolated_values
                 in_bounds_mask[before_wave_mask] = False
-
-                # Drop the first column (which was added for extrapolation).
-                computed_flux = computed_flux[:, n_select_wave_before:]
+                start_idx = n_added_wave_before
+            else:
+                start_idx = None
 
             if after_wave_queries is not None:
                 # Compute the flux values after the model's last valid wavelength and
                 # fill the extrapolated values in the correct locations.
                 after_wave_mask = wavelengths > max_valid_wave
-                after_fit_waves = query_waves[-n_select_wave_after:]
+                after_fit_waves = query_waves[-n_added_wave_after:]
                 extrapolated_values = self._wave_extrap_after.extrapolate_wavelength(
                     after_fit_waves,
-                    computed_flux[:, -n_select_wave_after:],
+                    computed_flux[:, -n_added_wave_after:],
                     after_wave_queries,
                 )
                 new_computed_flux[:, after_wave_mask] = extrapolated_values
                 in_bounds_mask[after_wave_mask] = False
+                end_idx = -n_added_wave_after
+            else:
+                end_idx = None
 
-                # Drop the last column (which was added for extrapolation).
-                computed_flux = computed_flux[:, :-n_select_wave_after]
-
-            # Fill in the non-extrapolated values and rename it to computed_flux.
-            new_computed_flux[:, in_bounds_mask] = computed_flux
+            # Fill in the non-extrapolated values (dropping the first and last few values at the
+            # wavelengths added for extrapolation) and rename the array to computed_flux.
+            new_computed_flux[:, in_bounds_mask] = computed_flux[:, start_idx:end_idx]
             computed_flux = new_computed_flux
 
         # Do a similiar process for time extrapolation.
         if before_time_queries is not None or after_time_queries is not None:
-            new_computed_flux = np.zeros((len(times), len(wavelengths)))
+            new_computed_flux = np.empty((len(times), len(wavelengths)))
             in_bounds_mask = np.full(len(times), True)
 
             if before_time_queries is not None:
                 # Compute the flux values before the model's first valid time and
                 # fill the extrapolated values in the correct locations.
                 before_time_mask = times < min_valid_time
-                before_fit_times = query_times[:n_select_time_before]
+                before_fit_times = query_times[:n_added_time_before]
                 extrapolated_values = self._time_extrap_before.extrapolate_time(
                     before_fit_times,
-                    computed_flux[:n_select_time_before, :],
+                    computed_flux[:n_added_time_before, :],
                     before_time_queries,
                 )
                 new_computed_flux[before_time_mask, :] = extrapolated_values
                 in_bounds_mask[before_time_mask] = False
-
-                # Drop the first row (which was added for extrapolation).
-                computed_flux = computed_flux[n_select_time_before:, :]
+                start_idx = n_added_time_before
+            else:
+                start_idx = None
 
             if after_time_queries is not None:
                 # Compute the flux values after the model's last valid time and
                 # fill the extrapolated values in the correct locations.
                 after_time_mask = times > max_valid_time
-                after_fit_times = query_times[-n_select_time_after:]
+                after_fit_times = query_times[-n_added_time_after:]
                 extrapolated_values = self._time_extrap_after.extrapolate_time(
                     after_fit_times,
-                    computed_flux[-n_select_time_after:, :],
+                    computed_flux[-n_added_time_after:, :],
                     after_time_queries,
                 )
                 new_computed_flux[after_time_mask, :] = extrapolated_values
                 in_bounds_mask[after_time_mask] = False
+                end_idx = -n_added_time_after
+            else:
+                end_idx = None
 
-                # Drop the last row (which was added for extrapolation).
-                computed_flux = computed_flux[:-n_select_time_after, :]
-
-            # Fill in the non-extrapolated values and rename it to computed_flux.
-            new_computed_flux[in_bounds_mask, :] = computed_flux
+            # Fill in the non-extrapolated values (dropping the first and last few values at the
+            # times added for extrapolation) and rename the array to computed_flux.
+            new_computed_flux[in_bounds_mask, :] = computed_flux[start_idx:end_idx, :]
             computed_flux = new_computed_flux
 
         return computed_flux
@@ -1077,9 +1079,9 @@ class BandfluxModel(BasePhysicalModel, ABC):
                 # the list of times to extrapolate.
                 valid_mask = query_times >= min_valid_time
                 before_time_queries = query_times[~valid_mask]
-                n_select_time_before = self._time_extrap_before.nfit
+                n_added_time_before = self._time_extrap_before.nfit
                 query_times = np.concatenate(
-                    (min_valid_time + np.arange(n_select_time_before), query_times[valid_mask])
+                    (min_valid_time + np.arange(n_added_time_before), query_times[valid_mask])
                 )
 
         # We check if we can do extrapolation for times after the valid time range and, if so, modify
@@ -1104,9 +1106,9 @@ class BandfluxModel(BasePhysicalModel, ABC):
                 # the list of times to extrapolate.
                 valid_mask = query_times <= max_valid_time
                 after_time_queries = query_times[~valid_mask]
-                n_select_time_after = self._time_extrap_after.nfit
+                n_added_time_after = self._time_extrap_after.nfit
                 query_times = np.concatenate(
-                    (query_times[valid_mask], max_valid_time - np.arange(n_select_time_after - 1, -1, -1))
+                    (query_times[valid_mask], max_valid_time - np.arange(n_added_time_after - 1, -1, -1))
                 )
 
         # Check if the times are sorted and, if not, create sorting indices. We do this AFTER we
@@ -1127,7 +1129,7 @@ class BandfluxModel(BasePhysicalModel, ABC):
         # Then do extrapolation for times that fell outside the model's bounds. These might
         # not be in order, so we use masks to keep track of where they go.
         if before_time_queries is not None or after_time_queries is not None:
-            new_computed_flux = np.zeros(len(times))
+            new_computed_flux = np.empty(len(times))
             in_bounds_mask = np.full(len(times), True)
 
             if before_time_queries is not None:
@@ -1135,33 +1137,34 @@ class BandfluxModel(BasePhysicalModel, ABC):
                 # flux values to be (T, W=1) for the extrapolation, so we add a new axis.
                 before_time_mask = times < min_valid_time
                 extrapolated_values = self._time_extrap_before.extrapolate_time(
-                    query_times[:n_select_time_before],
-                    computed_flux[:n_select_time_before, np.newaxis],
+                    query_times[:n_added_time_before],
+                    computed_flux[:n_added_time_before, np.newaxis],
                     before_time_queries,
                 )
                 new_computed_flux[before_time_mask] = extrapolated_values[:, 0]
                 in_bounds_mask[before_time_mask] = False
-
-                # Drop the first entry (which was added for extrapolation).
-                computed_flux = computed_flux[n_select_time_before:]
+                start_idx = n_added_time_before
+            else:
+                start_idx = None
 
             if after_time_queries is not None:
                 # Compute the flux values after the model's last valid time. We need the shape of the
                 # flux values to be (T, W=1) for the extrapolation, so we add a new axis.
                 after_time_mask = times > max_valid_time
                 extrapolated_values = self._time_extrap_after.extrapolate_time(
-                    query_times[-n_select_time_after:],
-                    computed_flux[-n_select_time_after:, np.newaxis],
+                    query_times[-n_added_time_after:],
+                    computed_flux[-n_added_time_after:, np.newaxis],
                     after_time_queries,
                 )
                 new_computed_flux[after_time_mask] = extrapolated_values[:, 0]
                 in_bounds_mask[after_time_mask] = False
+                end_idx = -n_added_time_after
+            else:
+                end_idx = None
 
-                # Drop the last entry (which was added for extrapolation).
-                computed_flux = computed_flux[:-n_select_time_after]
-
-            # Fill in the valid flux values.
-            new_computed_flux[in_bounds_mask] = computed_flux
+            # Fill in the valid flux values for the non-extrapolated times (dropping the first and last few
+            # values at the times added for extrapolation)
+            new_computed_flux[in_bounds_mask] = computed_flux[start_idx:end_idx]
             computed_flux = new_computed_flux
 
         return computed_flux

--- a/tests/lightcurvelynx/models/test_model_extrapolation.py
+++ b/tests/lightcurvelynx/models/test_model_extrapolation.py
@@ -322,20 +322,38 @@ def test_linear_linear_model_diff_extrapolators() -> None:
     assert np.allclose(values, expected)
 
     # We can specify extrapolators that are not used because the times or wavelengths are in bounds.
-    values = model.evaluate_sed(query_times[2:], query_waves)  # None before time
+    values = model.evaluate_sed(query_times[2:], query_waves)  # No times before
     assert np.allclose(values, expected[2:, :])
 
-    values = model.evaluate_sed(query_times[:3], query_waves)  # None after time
+    values = model.evaluate_sed(query_times[:1], query_waves)  # All times before
+    assert np.allclose(values, expected[:1, :])
+
+    values = model.evaluate_sed(query_times[:3], query_waves)  # No times after
     assert np.allclose(values, expected[:3, :])
 
-    values = model.evaluate_sed(query_times, query_waves[1:])  # None before wavelength
+    values = model.evaluate_sed(query_times[4:], query_waves)  # All times after
+    assert np.allclose(values, expected[4:, :])
+
+    values = model.evaluate_sed(query_times, query_waves[1:])  # No wavelengths before
     assert np.allclose(values, expected[:, 1:])
 
-    values = model.evaluate_sed(query_times, query_waves[:3])  # None after wavelength
+    values = model.evaluate_sed(query_times, query_waves[3:])  # All wavelengths after
+    assert np.allclose(values, expected[:, 3:])
+
+    values = model.evaluate_sed(query_times, query_waves[:3])  # No wavelengths after
     assert np.allclose(values, expected[:, :3])
+
+    values = model.evaluate_sed(query_times, query_waves[:1])  # All wavelengths before
+    assert np.allclose(values, expected[:, :1])
 
     values = model.evaluate_sed(query_times[2:4], query_waves[1:3])  # All valid
     assert np.allclose(values, expected[2:4, 1:3])
+
+    values = model.evaluate_sed(query_times[:1], query_waves[:1])  # Everything before
+    assert np.allclose(values, expected[:1, :1])
+
+    values = model.evaluate_sed(query_times[4:], query_waves[3:])  # Everything after
+    assert np.allclose(values, expected[4:, 3:])
 
     # We fail if we use any Nones since the model doesn't know how to extrapolate.
     model = _LinearLinearTestModel(

--- a/tests/lightcurvelynx/models/test_model_extrapolation.py
+++ b/tests/lightcurvelynx/models/test_model_extrapolation.py
@@ -321,6 +321,22 @@ def test_linear_linear_model_diff_extrapolators() -> None:
     )
     assert np.allclose(values, expected)
 
+    # We can specify extrapolators that are not used because the times or wavelengths are in bounds.
+    values = model.evaluate_sed(query_times[2:], query_waves)  # None before time
+    assert np.allclose(values, expected[2:, :])
+
+    values = model.evaluate_sed(query_times[:3], query_waves)  # None after time
+    assert np.allclose(values, expected[:3, :])
+
+    values = model.evaluate_sed(query_times, query_waves[1:])  # None before wavelength
+    assert np.allclose(values, expected[:, 1:])
+
+    values = model.evaluate_sed(query_times, query_waves[:3])  # None after wavelength
+    assert np.allclose(values, expected[:, :3])
+
+    values = model.evaluate_sed(query_times[2:4], query_waves[1:3])  # All valid
+    assert np.allclose(values, expected[2:4, 1:3])
+
     # We fail if we use any Nones since the model doesn't know how to extrapolate.
     model = _LinearLinearTestModel(
         wave_extrapolation=(wave_linear, zero_extrap),


### PR DESCRIPTION
Make a small optimization to the extrapolation code. Instead of making multiple temporary copies of `computed_flux` as the code drops rows, only do the copying once to move the values into `new_computed_flux`. We do this by tracking the start and end indices instead of repeatedly subsetting the array.

In addition rename the `n_select_` variables to `n_added_` to be clearer that these are the number of new points we are appending.