### PR TITLE
Small cleanup on inverse sorting

### DIFF
--- a/src/lightcurvelynx/models/physical_model.py
+++ b/src/lightcurvelynx/models/physical_model.py
@@ -595,7 +595,8 @@ class SEDModel(BasePhysicalModel):
         # augment the query waves in case the new boundary points interleave with the original queries.
         if len(query_waves) > 1 and not np.all(query_waves[:-1] <= query_waves[1:]):
             w_idx = np.argsort(query_waves)
-            w_inv_idx = np.argsort(w_idx)
+            w_inv_idx = np.empty_like(w_idx)
+            w_inv_idx[w_idx] = np.arange(w_idx.size)
         else:
             w_idx = slice(None)
             w_inv_idx = None
@@ -666,7 +667,8 @@ class SEDModel(BasePhysicalModel):
         # augment the query times in case the new boundary points interleave with the original queries.
         if len(query_times) > 1 and not np.all(query_times[:-1] <= query_times[1:]):
             t_idx = np.argsort(query_times)
-            t_inv_idx = np.argsort(t_idx)
+            t_inv_idx = np.empty_like(t_idx)
+            t_inv_idx[t_idx] = np.arange(t_idx.size)
         else:
             t_idx = slice(None)
             t_inv_idx = None
@@ -1115,7 +1117,8 @@ class BandfluxModel(BasePhysicalModel, ABC):
         # augment the query times in case the new boundary points interleave with the original queries.
         if len(query_times) > 1 and not np.all(query_times[:-1] <= query_times[1:]):
             t_idx = np.argsort(query_times)
-            t_inv_idx = np.argsort(t_idx)
+            t_inv_idx = np.empty_like(t_idx)
+            t_inv_idx[t_idx] = np.arange(t_idx.size)
         else:
             t_idx = slice(None)
             t_inv_idx = None

--- a/src/lightcurvelynx/models/sed_template_model.py
+++ b/src/lightcurvelynx/models/sed_template_model.py
@@ -207,7 +207,7 @@ class SEDTemplate:
             # Create the modulo times for periodic evaluation and an inverse mapping to original order.
             times = np.mod(times, self.period)
             argsort_idx = np.argsort(times)
-            inv_idx = np.zeros_like(argsort_idx)
+            inv_idx = np.empty_like(argsort_idx)
             inv_idx[argsort_idx] = np.arange(len(times))
 
             sed_values = self.interp(times[argsort_idx], wavelengths, grid=True)

--- a/src/lightcurvelynx/utils/extrapolate.py
+++ b/src/lightcurvelynx/utils/extrapolate.py
@@ -94,7 +94,6 @@ class FluxExtrapolationModel(abc.ABC):
         flux : numpy.ndarray
             A T x W2 matrix of extrapolated values.
         """
-        # We transpose the result to turn the W2 x T matrix into a T x W matrix.
         return self._extrapolate(last_waves, last_fluxes, query_waves)
 
 


### PR DESCRIPTION
Instead of using `argsort` twice to generate forward sorting order and then inverse order, use a direct mapping (linear time) to compute the inverse mapping.

Also cleans up a comment that is incorrect.