### PR TITLE
Small Spectrograph changes

### DIFF
--- a/src/lightcurvelynx/astro_utils/spectrograph.py
+++ b/src/lightcurvelynx/astro_utils/spectrograph.py
@@ -16,10 +16,14 @@ class Spectrograph:
         The start of each wavelength bin in Angstroms.
     waves_max : np.ndarray
         The end of each wavelength bin in Angstroms.
-    waves : np.ndarray
-        The center of each wavelength bin in Angstroms.
+    num_bins : int
+        The number of bins of the spectrograph.
     bin_widths : np.ndarray
         The width of each wavelength bin in Angstroms.
+    query_waves : np.ndarray
+        The points at which to evaluate the flux density of the spectral model in Angstroms.
+    num_query_waves : int
+        The number of wavelength points at which to evaluate the flux density of the spectral model.
     instrument : str
         The instrument name for the spectrograph. Default is "Spectrograph".
     scale : np.ndarray
@@ -35,7 +39,11 @@ class Spectrograph:
         scale=None,
         instrument: str | None = None,
     ):
-        if len(waves_min) != len(waves_max):
+        # Check that the input arrays are valid and convert them to numpy arrays.
+        self.waves_min = np.asarray(waves_min, dtype=float)
+        self.waves_max = np.asarray(waves_max, dtype=float)
+        self.num_bins = len(self.waves_min)
+        if len(self.waves_max) != self.num_bins:
             raise ValueError("waves_min and waves_max must have the same length.")
         if np.any(np.diff(waves_min) <= 0):
             raise ValueError("waves_min must be in strictly increasing order.")
@@ -45,10 +53,12 @@ class Spectrograph:
             raise ValueError(
                 "Each element of waves_max must be greater than the corresponding element of waves_min."
             )
-        self.waves_min = np.asarray(waves_min)
-        self.waves_max = np.asarray(waves_max)
-        self.waves = (self.waves_min + self.waves_max) / 2
+        self.query_waves = (self.waves_min + self.waves_max) / 2
+
+        # Compute the width of each bin and check that none of the bins have negative width.
         self.bin_widths = self.waves_max - self.waves_min
+        if np.any(self.bin_widths <= 0):
+            raise ValueError("Bins must have positive width.")
 
         # Scale is the multiplicative factor to apply to each bin's flux. If None, we use 1.0 for all bins.
         if scale is None:
@@ -65,15 +75,17 @@ class Spectrograph:
         return f"{self.instrument} (spectra) [{self.waves_min[0]}A - {self.waves_max[-1]}A]"
 
     def __len__(self) -> int:
-        return len(self.waves)
+        return self.num_bins
 
     def __eq__(self, other) -> bool:
-        """Determine if two passbands have equal values for the processed tables."""
-        if len(self.waves_min) != len(other.waves_min):
+        """Determine if two spectrographs have equal values for their internal data."""
+        if self.num_bins != other.num_bins:
             return False
         if not np.allclose(self.waves_min, other.waves_min):
             return False
         if not np.allclose(self.waves_max, other.waves_max):
+            return False
+        if self.instrument != other.instrument:  # pragma: no cover
             return False
         if not np.allclose(self.scale, other.scale):
             return False
@@ -145,25 +157,8 @@ class Spectrograph:
         waves_max = wave_midpoints + bin_widths / 2
         return cls(waves_min, waves_max, **kwargs)
 
-    def bin_width(self, index):
-        """Get the width of the bin at the given index.
-
-        Parameters
-        ----------
-        index : int
-            The index of the bin.
-
-        Returns
-        -------
-        float
-            The width of the bin in Angstroms.
-        """
-        if index < 0 or index >= len(self.waves_min):
-            raise IndexError(f"Index {index} out of bounds for {len(self.waves_min)} bin widths.")
-        return self.bin_widths[index]
-
     def wave_bounds(self):
-        """Get the minimum and maximum wavelength for this spectra.
+        """Get the minimum and maximum wavelength bin boundaries for this spectra.
 
         Returns
         -------

--- a/src/lightcurvelynx/astro_utils/spectrograph.py
+++ b/src/lightcurvelynx/astro_utils/spectrograph.py
@@ -22,8 +22,6 @@ class Spectrograph:
         The width of each wavelength bin in Angstroms.
     query_waves : np.ndarray
         The points at which to evaluate the flux density of the spectral model in Angstroms.
-    num_query_waves : int
-        The number of wavelength points at which to evaluate the flux density of the spectral model.
     instrument : str
         The instrument name for the spectrograph. Default is "Spectrograph".
     scale : np.ndarray

--- a/src/lightcurvelynx/astro_utils/spectrograph.py
+++ b/src/lightcurvelynx/astro_utils/spectrograph.py
@@ -83,6 +83,8 @@ class Spectrograph:
             return False
         if not np.allclose(self.waves_max, other.waves_max):
             return False
+        if not np.allclose(self.bin_widths, other.bin_widths):  # pragma: no cover
+            return False
         if self.instrument != other.instrument:  # pragma: no cover
             return False
         if not np.allclose(self.scale, other.scale):

--- a/src/lightcurvelynx/models/physical_model.py
+++ b/src/lightcurvelynx/models/physical_model.py
@@ -354,13 +354,13 @@ class BasePhysicalModel(ParameterizedNode, ABC):
 
         # If we only have a single sample, we can return the spectrograph fluxes directly.
         if state.num_samples == 1:
-            spectral_fluxes = self.evaluate_sed(times, spectrograph.waves, state)
+            spectral_fluxes = self.evaluate_sed(times, spectrograph.query_waves, state)
             return spectrograph.evaluate(spectral_fluxes)
 
-        # Fill in the band fluxes one at a time and return them all.
+        # Fill in the spectra for each model one at a time and return them all.
         bandfluxes = np.empty((state.num_samples, len(times), len(spectrograph)))
         for sample_num, current_state in enumerate(state):
-            spectral_fluxes = self.evaluate_sed(times, spectrograph.waves, current_state)
+            spectral_fluxes = self.evaluate_sed(times, spectrograph.query_waves, current_state)
             bandfluxes[sample_num, :, :] = spectrograph.evaluate(spectral_fluxes)
         return bandfluxes
 

--- a/src/lightcurvelynx/simulate.py
+++ b/src/lightcurvelynx/simulate.py
@@ -453,7 +453,7 @@ def _simulate_lightcurves_batch(simulation_info):
             # Split on whether we are evaluating bandfluxes or spectra.
             if isinstance(passbands[survey_idx], Spectrograph):
                 # This is a spectrograph, so we compute the spectra for the spectra column.
-                sg_waves = passbands[survey_idx].waves
+                sg_waves = passbands[survey_idx].query_waves
 
                 sed = model.evaluate_sed(obs_times, sg_waves, state, rng_info=rng)
                 measured_flux_perfect = passbands[survey_idx].evaluate(sed)

--- a/tests/lightcurvelynx/astro_utils/test_spectrograph.py
+++ b/tests/lightcurvelynx/astro_utils/test_spectrograph.py
@@ -7,15 +7,16 @@ def test_create_spectrograph_from_regular_grid():
     """Test that we can create and query a Spectrograph object."""
     spgraph = Spectrograph.from_regular_grid(wave_start=3000, wave_end=11000, bin_width=5.0)
     assert spgraph.instrument == "Spectrograph"
+    assert spgraph.num_bins == 1600
     assert len(spgraph) == 1600  # (11000 - 3000) / 5 = 1600 bins
-    assert np.array_equal(spgraph.waves, np.arange(3000 + 2.5, 11000, 5.0))
+    assert np.array_equal(spgraph.query_waves, np.arange(3000 + 2.5, 11000, 5.0))
 
     l_val, h_val = spgraph.wave_bounds()
     assert l_val == 3000
     assert h_val == 11000
 
     for i in range(len(spgraph)):
-        assert spgraph.bin_width(i) == pytest.approx(5.0)
+        assert spgraph.bin_widths[i] == pytest.approx(5.0)
 
     assert str(spgraph) == "Spectrograph (spectra) [3000.0A - 11000.0A]"
 
@@ -42,19 +43,14 @@ def test_create_spectrograph_from_irregular_grid():
     waves_max = np.array([4000.0, 5000.0, 7000.0, 7500.0, 8000.0, 8500.0])
     spgraph = Spectrograph(waves_min, waves_max, instrument="custom_spectrograph")
     assert spgraph.instrument == "custom_spectrograph"
+    assert spgraph.num_bins == 6
     assert len(spgraph) == 6
-    assert np.array_equal(spgraph.waves, (waves_min + waves_max) / 2)
+    assert np.array_equal(spgraph.query_waves, (waves_min + waves_max) / 2)
 
     l_val, h_val = spgraph.wave_bounds()
     assert l_val == 3500.0
     assert h_val == 8500.0
-
-    assert spgraph.bin_width(0) == pytest.approx(500.0)
-    assert spgraph.bin_width(1) == pytest.approx(1000.0)
-    assert spgraph.bin_width(2) == pytest.approx(2000.0)
-    assert spgraph.bin_width(3) == pytest.approx(500.0)
-    assert spgraph.bin_width(4) == pytest.approx(500.0)
-    assert spgraph.bin_width(5) == pytest.approx(500.0)
+    assert np.allclose(spgraph.bin_widths, [500.0, 1000.0, 2000.0, 500.0, 500.0, 500.0])
 
     assert str(spgraph) == "custom_spectrograph (spectra) [3500.0A - 8500.0A]"
     # Two dimensional fluxes to spec_fluxes
@@ -66,6 +62,14 @@ def test_create_spectrograph_from_irregular_grid():
     values_3d = np.random.random((4, 10, len(spgraph)))
     spec_fluxes_3d = spgraph.evaluate(values_3d)
     assert np.allclose(spec_fluxes_3d, values_3d)
+
+    # We fail a query if the flux density matrix is empty.
+    with pytest.raises(ValueError):
+        _ = spgraph.evaluate(np.array([]))
+
+    # We fail a query if the flux density matrix is more than 3-dimensional.
+    with pytest.raises(ValueError):
+        _ = spgraph.evaluate(np.array([[[[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]]]]))
 
     # Test that we fail to create a Spectrograph object with invalid parameters.
     with pytest.raises(ValueError):
@@ -100,10 +104,10 @@ def test_create_spectrograph_with_scale():
     """Test that we can create and query a Spectrograph object."""
     scale = np.array([0.5, 1.0, 1.0, 1.0, 0.8])
     spgraph = Spectrograph.from_regular_grid(wave_start=4000, wave_end=5000, bin_width=200.0, scale=scale)
-    assert np.allclose(spgraph.waves, np.array([4100.0, 4300.0, 4500.0, 4700.0, 4900.0]))
+    assert np.allclose(spgraph.query_waves, np.array([4100.0, 4300.0, 4500.0, 4700.0, 4900.0]))
 
     # Two dimensional fluxes to spec_fluxes
-    input = np.array(
+    measurement = np.array(
         [
             [10.0, 20.0, 30.0, 40.0, 50.0],
             [5.0, 15.0, 25.0, 35.0, 45.0],
@@ -115,11 +119,11 @@ def test_create_spectrograph_with_scale():
             [2.5, 15.0, 25.0, 35.0, 36.0],
         ]
     )
-    results = spgraph.evaluate(input)
+    results = spgraph.evaluate(measurement)
     assert np.allclose(results, expected)
 
     # Three dimensional fluxes to bandfluxes
-    input = np.array(
+    measurement = np.array(
         [
             [
                 [10.0, 20.0, 30.0, 40.0, 50.0],
@@ -143,7 +147,7 @@ def test_create_spectrograph_with_scale():
             ],
         ]
     )
-    results = spgraph.evaluate(input)
+    results = spgraph.evaluate(measurement)
     assert np.allclose(results, expected)
 
     # Test equality with scales.


### PR DESCRIPTION
This PR pulls out some of the small and independent changes from #939 while we discuss the details of that PR. The goal is to submit the small changes now to simplify both discussion and a later review.

Changes include:
- Add a `num_bins` attribute.
- Rename `waves` to `query_waves` for clarity (suggested by @mi-dai)
- Add a check on non-positive bin widths
- Remove the `bin_width` function since we have the information stored in the `bin_widths` array.
- Rename `input` to `measurement` in the tests so the variable does not overlap with the builtin function (Copilot suggestion)
- Add tests
- Fix comments