### PR TITLE
Code cleanups

### DIFF
--- a/src/lightcurvelynx/astro_utils/coordinate_utils.py
+++ b/src/lightcurvelynx/astro_utils/coordinate_utils.py
@@ -23,10 +23,15 @@ def validate_ra_dec_degrees(ra, dec):
     dec: numpy.ndarray
         Validated declination array in degrees.
     """
+    if ra is None or dec is None:
+        raise ValueError("RA and Dec must not be None.")
+
     ra = np.atleast_1d(ra).astype(float) % 360.0
     dec = np.atleast_1d(dec).astype(float)
     if np.any(dec < -90.0) or np.any(dec > 90.0):
         raise ValueError("Declination values must be in the range [-90, 90] degrees.")
+    if not np.all(np.isfinite(ra)) or not np.all(np.isfinite(dec)):
+        raise ValueError("RA and Dec cannot contain NaN or infinite values.")
 
     # Check that the shapes of RA and Dec match.
     if ra.shape != dec.shape:

--- a/src/lightcurvelynx/astro_utils/coordinate_utils.py
+++ b/src/lightcurvelynx/astro_utils/coordinate_utils.py
@@ -88,7 +88,7 @@ def dedup_coords(ra, dec, threshold=1e-5):
     for idx, matches in enumerate(close_points):
         if len(matches) == 1 or idx == np.min(matches):
             unique_indices.append(idx)
-    unique_indices = np.array(unique_indices)
+    unique_indices = np.asarray(unique_indices)
 
     unique_ra = ra[unique_indices]
     unique_dec = dec[unique_indices]

--- a/src/lightcurvelynx/astro_utils/milky_way_density.py
+++ b/src/lightcurvelynx/astro_utils/milky_way_density.py
@@ -124,7 +124,8 @@ class MilkyWayDensityBase(ABC):
         z : numpy.ndarray
             Heights above the Galactic mid-plane in kpc, shape (n_samples,).
         """
-        rng = np.random.default_rng(rng)
+        if rng is None:
+            rng = np.random.default_rng()
 
         # Draw uniform random numbers and find the corresponding grid indices
         # via binary search on the cumulative distribution.

--- a/src/lightcurvelynx/astro_utils/obs_utils.py
+++ b/src/lightcurvelynx/astro_utils/obs_utils.py
@@ -43,7 +43,7 @@ def spec_eff_function(peak_imag):
     s1 = 2.36
     s2 = 51.9
 
-    peak_imag = np.array(peak_imag)
+    peak_imag = np.asarray(peak_imag)
     eff = s0 * np.power((1.0 + np.exp(s1 * peak_imag - s2)), -1)
 
     return eff

--- a/src/lightcurvelynx/astro_utils/sed.py
+++ b/src/lightcurvelynx/astro_utils/sed.py
@@ -13,15 +13,19 @@ class SED:
     Attributes
     ----------
     wavelengths : np.ndarray
-        The wavelength values of the SED.
+        The 1-dimensional array of wavelength values of the SED.
     fluxes : np.ndarray
-        The flux values of the SED.
+        The 1-dimensional array of flux values of the SED.
     """
 
     def __init__(self, wavelengths, fluxes, **kwargs):
-        self.wavelengths = np.array(wavelengths)
-        self.fluxes = np.array(fluxes)
+        self.wavelengths = np.asarray(wavelengths, dtype=float)
+        self.fluxes = np.asarray(fluxes, dtype=float)
 
+        if self.wavelengths.ndim != 1:
+            raise ValueError("Wavelengths must be a 1D array.")
+        if self.fluxes.ndim != 1:
+            raise ValueError("Fluxes must be a 1D array.")
         if len(wavelengths) < 2:
             raise ValueError("SED must have at least two wavelength and flux values.")
         if len(wavelengths) != len(fluxes):

--- a/src/lightcurvelynx/astro_utils/sed_basis_models.py
+++ b/src/lightcurvelynx/astro_utils/sed_basis_models.py
@@ -170,7 +170,7 @@ class SEDBasisModel:
             if filter not in self.sed_values:
                 raise ValueError(f"Filter {filter} not found in SED basis model.")
 
-            filter_mask = np.array(filters) == filter
+            filter_mask = np.asarray(filters) == filter
             sed_values = self.compute_sed(filter, wavelengths)
             flux_density[filter_mask, :] = np.outer(bandfluxes[filter_mask], sed_values)
 

--- a/src/lightcurvelynx/base_models.py
+++ b/src/lightcurvelynx/base_models.py
@@ -691,6 +691,7 @@ class ParameterizedNode:
                 if graph_state.num_samples == 1:
                     graph_state.set(self.node_string, name, setter.value)
                 else:
+                    # Note we can't use np.full here in case setter.value is an array itself.
                     repeated_value = np.array([setter.value] * graph_state.num_samples)
                     graph_state.set(self.node_string, name, repeated_value)
             elif setter.source_type == _ParameterSource.MODEL_PARAMETER:

--- a/src/lightcurvelynx/graph_state.py
+++ b/src/lightcurvelynx/graph_state.py
@@ -496,7 +496,7 @@ class GraphState:
                 f"variable={var_name}: {self.num_samples} vs {len(value)}."
             )
         elif force_copy:
-            self.states[node_name][var_name] = np.array(value.copy())
+            self.states[node_name][var_name] = np.array(value, copy=True)
         else:
             self.states[node_name][var_name] = np.asarray(value)
 

--- a/src/lightcurvelynx/noise_models/pzflow_noise_model.py
+++ b/src/lightcurvelynx/noise_models/pzflow_noise_model.py
@@ -290,7 +290,8 @@ class PZFlowNoiseModel(FluxNoiseModel, CiteClass):
             raise ValueError("Length of indices must match length of bandflux.")
 
         # Set up the random number generator.
-        rng = np.random.default_rng(rng)
+        if rng is None:
+            rng = np.random.default_rng()
 
         # Get the input parameters for the flow (if there are any).
         if self._flow.conditional_columns is not None and len(self._flow.conditional_columns) > 0:
@@ -319,7 +320,8 @@ class PZFlowNoiseModel(FluxNoiseModel, CiteClass):
             input_df = None
 
         # Sample from the flow to get the noise parameters.
-        rng = np.random.default_rng(rng)
+        if rng is None:
+            rng = np.random.default_rng()
         pzflow_seed = rng.integers(0, 1e9)
         samples = self._flow.sample(nsamples=1, conditions=input_df, seed=pzflow_seed)
         flux_err = np.clip(samples[self._output_column].values, a_min=0, a_max=None)

--- a/src/lightcurvelynx/noise_models/spectrograph_noise_models.py
+++ b/src/lightcurvelynx/noise_models/spectrograph_noise_models.py
@@ -96,7 +96,8 @@ class SpectrographNoiseModel(ABC):
             same units as the input measurements.
         """
         # Define the random number generator if not provided.
-        rng = np.random.default_rng(rng)
+        if rng is None:
+            rng = np.random.default_rng()
 
         # Compute the standard deviation of the noise and make sure it is a numpy array.
         flux_err = self.compute_flux_error(

--- a/src/lightcurvelynx/obstable/location_free_obstable.py
+++ b/src/lightcurvelynx/obstable/location_free_obstable.py
@@ -6,6 +6,7 @@ import numpy as np
 import pandas as pd
 from mocpy import MOC
 
+from lightcurvelynx.astro_utils.coordinate_utils import validate_ra_dec_degrees
 from lightcurvelynx.obstable.obs_table import ObsTable
 
 
@@ -140,24 +141,10 @@ class LocationFreeObsTable(ObsTable):
             If the input is a single query point, this is a 1D array of row indices.
             If the input is an array of query points, this is a list of index arrays (one per query).
         """
-        if query_ra is None or query_dec is None:
-            raise ValueError("Query RA and dec must be provided for range search, but got None.")
-
-        # If the query RA and Dec are scalars, convert them to 1D arrays for consistent processing.
         is_scalar = np.isscalar(query_ra) and np.isscalar(query_dec)
-        try:
-            query_ra = np.atleast_1d(query_ra).astype(float)
-            query_dec = np.atleast_1d(query_dec).astype(float)
-        except ValueError as err:
-            raise ValueError("Query RA and Dec must be convertible to float.") from err
-
+        query_ra, query_dec = validate_ra_dec_degrees(query_ra, query_dec)
         if query_ra.ndim != 1 or query_dec.ndim != 1:
             raise ValueError("Query RA and Dec must be 1-dimensional arrays.")
-        if len(query_ra) != len(query_dec):
-            raise ValueError("Query RA and Dec must have the same length.")
-        if np.any(np.isnan(query_ra)) or np.any(np.isnan(query_dec)):
-            raise ValueError("Query RA and Dec cannot contain NaN.")
-
         num_queries = len(query_ra)
 
         # If t_min is a scalar, convert it to a 1D array for consistent processing.

--- a/src/lightcurvelynx/obstable/obs_table.py
+++ b/src/lightcurvelynx/obstable/obs_table.py
@@ -727,15 +727,19 @@ class ObsTable:
         """
         # Check if we are dealing with a mask of a list of indices.
         rows = np.asarray(rows)
+        if rows.ndim != 1:
+            raise ValueError("Rows array must be one-dimensional.")
         if rows.dtype == bool:
             if len(rows) != len(self._table):
                 raise ValueError(
                     f"Mask length mismatch. Expected {len(self._table)} rows, but found {len(rows)}."
                 )
             mask = rows
-        else:
+        elif np.issubdtype(rows.dtype, np.integer):
             mask = np.full((len(self._table),), False)
             mask[rows] = True
+        else:
+            raise ValueError("Rows array must be either a Boolean mask or a list of integer indices.")
 
         # Filter the rows. Update all of the cached data.
         self._table = self._table[mask]

--- a/src/lightcurvelynx/obstable/obs_table.py
+++ b/src/lightcurvelynx/obstable/obs_table.py
@@ -1082,7 +1082,7 @@ class ObsTable:
         # If filters were given, set those up as an array of the correct size.
         if filter is not None:
             if isinstance(filter, str):
-                filter = np.array([filter] * num_samples, dtype=object)
+                filter = np.full(num_samples, filter, dtype=object)
             elif len(filter) != num_samples:
                 raise ValueError("If filter is an array, it must have the same length as times.")
 

--- a/src/lightcurvelynx/utils/post_process_results.py
+++ b/src/lightcurvelynx/utils/post_process_results.py
@@ -273,7 +273,7 @@ def results_augment_lightcurves(results, *, min_snr=0.0):
         # Get the index for the t0 entry for each lightcurve MJD and use that
         # to subtract out the reference t0.
         t0 = np.asanyarray(results["t0"])
-        t0_idx = np.array(results["lightcurve"]["mjd"].index)
+        t0_idx = np.asarray(results["lightcurve"]["mjd"].index)
         results["lightcurve.time_rel"] = results["lightcurve.mjd"] - t0[t0_idx]
 
     return results

--- a/tests/lightcurvelynx/astro_utils/test_coordinate_utils.py
+++ b/tests/lightcurvelynx/astro_utils/test_coordinate_utils.py
@@ -40,6 +40,22 @@ def test_validate_ra_dec_degrees():
     np.testing.assert_array_equal(validated_ra, np.array([180]))
     np.testing.assert_array_equal(validated_dec, np.array([45]))
 
+    # We fail when either RA or Dec is None.
+    with pytest.raises(ValueError):
+        validate_ra_dec_degrees(None, [0])
+    with pytest.raises(ValueError):
+        validate_ra_dec_degrees([0], None)
+
+    # We fail with non-finite values (NaN or Inf).
+    with pytest.raises(ValueError):
+        validate_ra_dec_degrees([0], [np.nan])
+    with pytest.raises(ValueError):
+        validate_ra_dec_degrees([np.nan], [0])
+    with pytest.raises(ValueError):
+        validate_ra_dec_degrees([0], [np.inf])
+    with pytest.raises(ValueError):
+        validate_ra_dec_degrees([np.inf], [0])
+
 
 def test_ra_dec_to_cartesian():
     """Test the conversion from RA/Dec to Cartesian coordinates."""

--- a/tests/lightcurvelynx/astro_utils/test_sed.py
+++ b/tests/lightcurvelynx/astro_utils/test_sed.py
@@ -24,6 +24,12 @@ def test_create_sed() -> None:
     expected = np.array([0.0, 10.0, 15.0, 20.0, 20.0, 20.0, 15.0, 10.0, 0.0])
     np.testing.assert_array_equal(values, expected)
 
+    # We should fail with 2-dimensional arrays for wavelengths or fluxes.
+    with pytest.raises(ValueError):
+        _ = SED([[100.0, 200.0], [300.0, 400.0]], [10.0, 20.0])
+    with pytest.raises(ValueError):
+        _ = SED([100.0, 200.0], [[10.0, 20.0], [30.0, 40.0]])
+
 
 def test_sed_fail() -> None:
     """Test that we correctly fail on bad SEDs."""

--- a/tests/lightcurvelynx/obstable/test_obs_table.py
+++ b/tests/lightcurvelynx/obstable/test_obs_table.py
@@ -476,7 +476,7 @@ def test_obs_table_filter_rows():
     with pytest.raises(ValueError):
         _ = ops_data.filter_rows(bad_mask)
 
-    # We throw and error if the rows array is not one-dimensional.
+    # We throw an error if the rows array is not one-dimensional.
     bad_rows = np.array([[True, False]])
     with pytest.raises(ValueError):
         _ = ops_data.filter_rows(bad_rows)

--- a/tests/lightcurvelynx/obstable/test_obs_table.py
+++ b/tests/lightcurvelynx/obstable/test_obs_table.py
@@ -476,6 +476,16 @@ def test_obs_table_filter_rows():
     with pytest.raises(ValueError):
         _ = ops_data.filter_rows(bad_mask)
 
+    # We throw and error if the rows array is not one-dimensional.
+    bad_rows = np.array([[True, False]])
+    with pytest.raises(ValueError):
+        _ = ops_data.filter_rows(bad_rows)
+
+    # We throw an error if the rows array is neither a Boolean mask nor a list of integer indices.
+    bad_rows = np.array([0.5, 1.5])
+    with pytest.raises(ValueError):
+        _ = ops_data.filter_rows(bad_rows)
+
 
 def test_obs_table_filter_invalid_rows():
     """Test that we can filter out rows with invalid values in the required columns."""


### PR DESCRIPTION
Inspired by copilots suggestions in #944 , I manually checked and cleaned up some code throughout the project, including:

Efficiency:
- Change `np.array` to `np.asarray` where possible
- Change `rng = np.random.default_rng(rng)` to `if rng is None:`. While the former is more general (can take int seeds), our API requires rng to either be a random number generator or None. The `if` check is 1/4 the time when rng is already defined. They take the same time when rng is None.

Correctness:
- Add some more array dimensionality checks.
- Add some more checks to `validate_ra_dec_degrees`