### PR TITLE
Apply gaussian smearing to flux in spectrograph bins

### DIFF
--- a/src/lightcurvelynx/astro_utils/spectrograph.py
+++ b/src/lightcurvelynx/astro_utils/spectrograph.py
@@ -113,9 +113,7 @@ class Spectrograph:
         else:
             self.wavelength_resolution = np.asarray(wavelength_resolution, dtype=float)
         if len(self.wavelength_resolution) != self.num_bins:
-            raise ValueError(
-                "wavelength_resolution must have the same length as waves_min and waves_max."
-            )
+            raise ValueError("wavelength_resolution must have the same length as waves_min and waves_max.")
 
         if self.num_bins <= 0:  # pragma: no cover
             raise ValueError("Spectrograph must have at least one bin.")

--- a/src/lightcurvelynx/astro_utils/spectrograph.py
+++ b/src/lightcurvelynx/astro_utils/spectrograph.py
@@ -15,7 +15,6 @@ def gaussian_integral(nsigma_low, nsigma_high):
 
     Parameters
     ----------
-
     nsigma_low : float
         The lower limit of the integral in units of sigma.
     nsigma_high : float
@@ -94,8 +93,9 @@ class Spectrograph:
             The multiplicative factor to apply to each bin's flux. If None, no additional scaling
             is applied.
             Default: None
-        wavelength_resolution : np.ndarray
+        wavelength_resolution : np.ndarray | float
             The Gaussian sigma wavelength resolution for each bin in Angstroms.
+            If float, the same value is applied to all bins. If None, no smearing is applied.
         compute_smear : bool, optional
             Flag to enable smearing of flux between bins based on the wavelength resolution.
             If true, fluxes from Spectrograph.evaluate() will be smeared.
@@ -105,11 +105,17 @@ class Spectrograph:
         self.waves_min = np.asarray(waves_min, dtype=float)
         self.waves_max = np.asarray(waves_max, dtype=float)
         self.num_bins = len(self.waves_min)
-        self.wavelength_resolution = (
-            np.asarray(wavelength_resolution, dtype=float)
-            if wavelength_resolution is not None
-            else np.zeros(self.num_bins, dtype=float)
-        )
+
+        if wavelength_resolution is None:
+            self.wavelength_resolution = np.zeros(self.num_bins, dtype=float)
+        elif np.isscalar(wavelength_resolution):
+            self.wavelength_resolution = np.full(self.num_bins, float(wavelength_resolution), dtype=float)
+        else:
+            self.wavelength_resolution = np.asarray(wavelength_resolution, dtype=float)
+        if len(self.wavelength_resolution) != self.num_bins:
+            raise ValueError(
+                "wavelength_resolution must have the same length as waves_min and waves_max."
+            )
 
         if self.num_bins <= 0:  # pragma: no cover
             raise ValueError("Spectrograph must have at least one bin.")
@@ -244,7 +250,7 @@ class Spectrograph:
 
     def _compute_padded_bins(self):
         """Compute the parameters for padded bins on either side of the main spectrograph bins. This allows
-        for flux beyond the edges of the spectrograph to be possibily smeared into the main bins.
+        for flux beyond the edges of the spectrograph to be possibly smeared into the main bins.
 
         Returns
         -------
@@ -261,6 +267,9 @@ class Spectrograph:
 
         # determine the extended region
         # snana expanded by 2.5 sigma of the edge bins
+        # note: if the wavelength resolution negative for a given side, then the num_pad_[side] is 0,
+        # the pad_[side]_min/max are empty, and no padding is added on that side.
+        # otherwise, at least 1 bin will be added on a given side
         sigma_blue = self.wavelength_resolution[0]
         width_blue = self.bin_widths[0]
         num_pad_blue = int(2.5 * sigma_blue / width_blue) + 1 if sigma_blue > 0 else 0

--- a/src/lightcurvelynx/astro_utils/spectrograph.py
+++ b/src/lightcurvelynx/astro_utils/spectrograph.py
@@ -229,15 +229,17 @@ class Spectrograph:
         return True
 
     def _compute_padded_bins(self):
-        """Compute the parameters for padded bins on either side of the main spectrograph bins. This allows 
+        """Compute the parameters for padded bins on either side of the main spectrograph bins. This allows
         for flux beyond the edges of the spectrograph to be possibily smeared into the main bins.
 
         Returns
         -------
         padded_bins_min : np.ndarray
-            the minimum wavelength of each padded bin in Angstroms.
+            the minimum wavelength of each bin, include the new padding bins, in Angstroms.
         padded_bins_max : np.ndarray
-            the maximum wavelength of each padded bin in Angstroms.
+            the maximum wavelength of each bin, include the new padding bins, in Angstroms.
+        padded_wavelength_resolution : np.ndarray
+            the wavelength resolution of each bin, include the new padding bins, in Angstroms.
         is_padding : np.ndarray
             a boolean array indicating which bins are padding (True) and which are in the
             original spectrograph.
@@ -263,11 +265,13 @@ class Spectrograph:
         padded_bins_min = np.concatenate((pad_blue_min, self.waves_min, pad_red_min))
         padded_bins_max = np.concatenate((pad_blue_max, self.waves_max, pad_red_max))
 
-        padded_wavelength_resolution = np.concatenate([ # TODO: needed?
-            np.full(num_pad_blue, sigma_blue),
-            self.wavelength_resolution,
-            np.full(num_pad_red, sigma_red)
-        ])
+        padded_wavelength_resolution = np.concatenate(
+            [
+                np.full(num_pad_blue, sigma_blue),
+                self.wavelength_resolution,
+                np.full(num_pad_red, sigma_red)
+            ]
+        )
 
         is_padding = np.concatenate(
             [

--- a/src/lightcurvelynx/astro_utils/spectrograph.py
+++ b/src/lightcurvelynx/astro_utils/spectrograph.py
@@ -8,6 +8,7 @@ from astropy import units as u
 from lightcurvelynx.astro_utils.unit_utils import fnu_to_flam
 import scipy
 
+
 def gaussian_integral(nsigma_low, nsigma_high):
     """
     Computes the integral of a Gaussian between two limits in units of sigma.
@@ -25,7 +26,10 @@ def gaussian_integral(nsigma_low, nsigma_high):
     integral : float
         The integral of the Gaussian between the limits.
     """
-    return 0.5 * (scipy.special.erf(nsigma_high / np.sqrt(2.0)) - scipy.special.erf(nsigma_low / np.sqrt(2.0)))
+    return 0.5 * (
+        scipy.special.erf(nsigma_high / np.sqrt(2.0)) - scipy.special.erf(nsigma_low / np.sqrt(2.0))
+    )
+
 
 class Spectrograph:
     """Models all of the bins of a spectrograph, producing bandfluxes for each
@@ -259,8 +263,7 @@ class Spectrograph:
         pad_blue_min = self.waves_min[0] - width_blue * np.arange(num_pad_blue, 0, -1)
         pad_blue_max = pad_blue_min + width_blue
 
-
-        red_edge_idx = -2 if self.num_bins >= 2 else -1 # snana takes the 2nd to last bin
+        red_edge_idx = -2 if self.num_bins >= 2 else -1  # snana takes the 2nd to last bin
         sigma_red = self.wavelength_resolution[red_edge_idx]
         width_red = self.bin_widths[red_edge_idx]
         num_pad_red = int(2.5 * sigma_red / width_red) + 1 if sigma_red > 0 else 0
@@ -272,11 +275,7 @@ class Spectrograph:
         padded_bins_max = np.concatenate((pad_blue_max, self.waves_max, pad_red_max))
 
         padded_wavelength_resolution = np.concatenate(
-            [
-                np.full(num_pad_blue, sigma_blue),
-                self.wavelength_resolution,
-                np.full(num_pad_red, sigma_red)
-            ]
+            [np.full(num_pad_blue, sigma_blue), self.wavelength_resolution, np.full(num_pad_red, sigma_red)]
         )
 
         is_padding = np.concatenate(
@@ -294,7 +293,7 @@ class Spectrograph:
         Parameters
         ----------
         n_sigma : int, optional
-            The number of standard deviations to consider for the Gaussian smearing. 
+            The number of standard deviations to consider for the Gaussian smearing.
             Default is 3.
 
         Returns
@@ -330,7 +329,7 @@ class Spectrograph:
                     lam_sig0 = (self.padded_min[j] - bin_center) / sigma
                     lam_sig1 = (self.padded_max[j] - bin_center) / sigma
                     smear_matrix[i, j] = gaussian_integral(lam_sig0, lam_sig1)
-                else: # sigma == 0, no smearing to outer bins
+                else:  # sigma == 0, no smearing to outer bins
                     smear_matrix[i, j] = 0.0 if i != j else 1.0
 
         return smear_matrix

--- a/src/lightcurvelynx/astro_utils/spectrograph.py
+++ b/src/lightcurvelynx/astro_utils/spectrograph.py
@@ -97,6 +97,11 @@ class Spectrograph:
         self.waves_min = np.asarray(waves_min, dtype=float)
         self.waves_max = np.asarray(waves_max, dtype=float)
         self.num_bins = len(self.waves_min)
+        self.wavelength_resolution = (
+            np.asarray(wavelength_resolution, dtype=float)
+            if wavelength_resolution is not None
+            else np.zeros(self.num_bins, dtype=float)
+        )
 
         if self.num_bins <= 0:  # pragma: no cover
             raise ValueError("Spectrograph must have at least one bin.")
@@ -187,9 +192,10 @@ class Spectrograph:
         )
         # compute the smear matrix, if requested
         if compute_smear:
-            if self.wavelength_resolution is None:
+            # check on the argument wavelength_resolution because a default array is set for
+            # the wavelength_resolution attribute for the padded bin calculation
+            if wavelength_resolution is None:
                 raise ValueError("wavelength_resolution is required for smear computation.")
-            self.wavelength_resolution = np.asarray(wavelength_resolution, dtype=float)
             self.smear_matrix = self._compute_smear_matrix()
         else:
             self.smear_matrix = None
@@ -298,6 +304,9 @@ class Spectrograph:
             where smear_matrix[i, j] represents the fraction of flux from bin i that smears into j
         """
 
+        if np.any(np.abs(self.padded_max[:-1] - self.padded_min[1:]) > 1e-8):
+            raise ValueError("The spectrograph bins cannot have gaps when using smearing.")
+
         smear_matrix = np.zeros((self.num_padded_bins, self.num_padded_bins))
         for i in range(self.num_padded_bins):
             sigma = self.padded_resolution[i]
@@ -310,6 +319,7 @@ class Spectrograph:
             bin_center = (self.padded_min[i] + self.padded_max[i]) / 2
 
             # get smearing factor, if the bin is not padding
+            # padded bins can be sources but not receivers of flux
             for j in range(j_low, j_high + 1):
                 # skip if in the padded region
                 if self.is_padding[j]:

--- a/src/lightcurvelynx/astro_utils/spectrograph.py
+++ b/src/lightcurvelynx/astro_utils/spectrograph.py
@@ -3,10 +3,10 @@ and provides methods to compute fluxes for each bin.
 """
 
 import numpy as np
+import scipy
 from astropy import units as u
 
 from lightcurvelynx.astro_utils.unit_utils import fnu_to_flam
-import scipy
 
 
 def gaussian_integral(nsigma_low, nsigma_high):
@@ -96,6 +96,10 @@ class Spectrograph:
             Default: None
         wavelength_resolution : np.ndarray
             The Gaussian sigma wavelength resolution for each bin in Angstroms.
+        compute_smear : bool, optional
+            Flag to enable smearing of flux between bins based on the wavelength resolution.
+            If true, fluxes from Spectrograph.evaluate() will be smeared.
+            Default: False
         """
         # Check that the input arrays are valid and convert them to numpy arrays.
         self.waves_min = np.asarray(waves_min, dtype=float)

--- a/src/lightcurvelynx/astro_utils/spectrograph.py
+++ b/src/lightcurvelynx/astro_utils/spectrograph.py
@@ -229,8 +229,8 @@ class Spectrograph:
         return True
 
     def _compute_padded_bins(self):
-        """Compute the parameters for padded bins for the spectrograph. This allows for flux beyond the edges
-        of the spectrograph to be possibily smeared into the spectrograph's bins.
+        """Compute the parameters for padded bins on either side of the main spectrograph bins. This allows 
+        for flux beyond the edges of the spectrograph to be possibily smeared into the main bins.
 
         Returns
         -------
@@ -239,12 +239,12 @@ class Spectrograph:
         padded_bins_max : np.ndarray
             the maximum wavelength of each padded bin in Angstroms.
         is_padding : np.ndarray
-            a boolean array indicating which bins are padding (True) and which are in the 
+            a boolean array indicating which bins are padding (True) and which are in the
             original spectrograph.
         """
 
         # determine the extended region
-            # snana expanded by 2.5 sigma of the edge bins
+        # snana expanded by 2.5 sigma of the edge bins
         sigma_blue = self.wavelength_resolution[0]
         width_blue = self.bin_widths[0]
         num_pad_blue = int(2.5 * sigma_blue / width_blue) + 1 if sigma_blue > 0 else 0

--- a/src/lightcurvelynx/astro_utils/spectrograph.py
+++ b/src/lightcurvelynx/astro_utils/spectrograph.py
@@ -407,7 +407,6 @@ class Spectrograph:
     def evaluate(
         self,
         flux_density_matrix: np.ndarray,
-        smear: bool = True,
     ) -> np.ndarray:
         """Calculate the bin-integrated flux for each bin in the spectrograph
         (in F_lambda units of erg/s/cm²).
@@ -419,9 +418,6 @@ class Spectrograph:
             flux density values at the wavelengths specified by self.query_waves for a single
             sample. The other dimensions are used to represent multiple times (2D and 3D) and
             multiple objects (3D).
-        smear : bool, optional
-            Whether to smear the flux density values across the bins using the wavelength resolution. 
-            Default is True.
 
         Returns
         -------
@@ -480,7 +476,8 @@ class Spectrograph:
         # Add per-bin smearing. By computing a B x B
         # smearing matrix in the __init__ method and then apply it here. This will allow us to model
         # the effects of the spectrograph's point spread function on the measured fluxes.
-        if smear and self.smear_matrix is not None:
+        # smear_matrix will not be None if compute_smear was set to True in the __init__ method.
+        if self.smear_matrix is not None:
             spectro_bin_flux @= self.smear_matrix
 
         # get the flux in the spectrograph's native bins (not the padded bins)

--- a/src/lightcurvelynx/astro_utils/spectrograph.py
+++ b/src/lightcurvelynx/astro_utils/spectrograph.py
@@ -6,7 +6,13 @@ import numpy as np
 from astropy import units as u
 
 from lightcurvelynx.astro_utils.unit_utils import fnu_to_flam
+import scipy
 
+def gaussian_integral(nsig_low, nsig_high):
+    """
+    Compute the integral of a Gaussian between two limits in units of sigma.
+    """
+    return 0.5 * (scipy.special.erf(nsig_high / np.sqrt(2.0)) - scipy.special.erf(nsig_low / np.sqrt(2.0)))
 
 class Spectrograph:
     """Models all of the bins of a spectrograph, producing bandfluxes for each
@@ -36,7 +42,9 @@ class Spectrograph:
         The instrument name for the spectrograph. Default is "Spectrograph".
     scale : float | np.ndarray | None
         The multiplicative factor to apply to each bin's flux to capture sensor
-        sensitivity, etc. If None, no additional scaling is applied.
+        sensitivity, etc. If None, no scaling is applied.
+    wavelength_resolution : np.ndarray
+        The Gaussian sigma wavelength resolution for each bin in Angstroms.
     """
 
     def __init__(
@@ -44,9 +52,11 @@ class Spectrograph:
         waves_min,
         waves_max,
         *,
+        wavelength_resolution=None,
         instrument: str | None = None,
-        max_wave_step: float | None = None,
         scale=None,
+        max_wave_step: float | None = None,
+        oversample_factor: int = 10,
     ):
         """Initialize the Spectrograph object.
 
@@ -63,15 +73,26 @@ class Spectrograph:
             that are evaluated while computing the bin's flux. The smaller this value, the more
             accurate and expensive the integration. If None, a single sample per bin is used.
             Default: None
+        oversample_factor: int, optional
+            If max_wave_step is not provided, divide each bin into this many sub-bins to evaluate 
+            the flux density of the object at a resolution higher than the spectrograph's.
+            Default: 10
         scale : float | array-like, optional
             The multiplicative factor to apply to each bin's flux. If None, no additional scaling
             is applied.
             Default: None
+        wavelength_resolution : np.ndarray
+            The Gaussian sigma wavelength resolution for each bin in Angstroms.
         """
         # Check that the input arrays are valid and convert them to numpy arrays.
         self.waves_min = np.asarray(waves_min, dtype=float)
         self.waves_max = np.asarray(waves_max, dtype=float)
         self.num_bins = len(self.waves_min)
+
+        oversample_factor = 1 if wavelength_resolution is None else oversample_factor
+        self.wavelength_resolution = np.asarray(wavelength_resolution, dtype=float) \
+            if wavelength_resolution is not None else np.zeros(self.num_bins, dtype=float)
+        
         if self.num_bins <= 0:  # pragma: no cover
             raise ValueError("Spectrograph must have at least one bin.")
         if len(self.waves_max) != self.num_bins:
@@ -84,27 +105,49 @@ class Spectrograph:
         if np.any(self.bin_widths <= 0):
             raise ValueError("Bins must have positive width.")
 
+        # check the oversample_factor
+        if type(oversample_factor) is not int or oversample_factor < 1:
+            raise ValueError(f"oversample_factor must be a positive integer, got {oversample_factor}.")
+
+        
+
         # Compute the query wavelengths at which to evaluate the flux density of the object.
-        # By default, we use the midpoint of each bin. However, if max_wave_step is provided AND
+        # First, we pad the bins to account for smearing later.
+        # Then, we evaluate at 10x the bin resolution.
+        # However, if max_wave_step is provided AND
         # we need to split at least one bin, we will add multiple points per bin (evenly space
         # throughout the bin) until the maximum gap is LESS than max_wave_step.
         self._wave_to_bin_map = None
-        if max_wave_step is None or np.max(self.bin_widths) <= max_wave_step:
-            self.query_waves = (self.waves_min + self.waves_max) / 2
-            self._query_widths = self.bin_widths
-            self._bin_counts = np.ones(self.num_bins, dtype=int)
+        padded_min, padded_max, padded_resolution, is_padding = self._compute_padded_bins()
+        self.padded_min = padded_min
+        self.padded_max = padded_max
+        self.padded_widths = padded_max - padded_min
+        self.padded_resolution = padded_resolution
+        self.is_padding = is_padding
+        self.num_padded_bins = len(self.padded_min)
+        if (max_wave_step is None or np.max(self.bin_widths) <= max_wave_step) and oversample_factor == 1:
+            self.query_waves = (self.padded_min + self.padded_max) / 2
+            self._query_widths = self.padded_widths
+            self._bin_counts = np.ones(self.num_padded_bins, dtype=int)
+            wave_to_bin_map = list(range(self.num_padded_bins))
         else:
-            if max_wave_step <= 0:
-                raise ValueError(f"max_wave_step must be positive, got {max_wave_step}.")
+            if max_wave_step is not None and max_wave_step <= 0:
+                    raise ValueError(f"max_wave_step must be positive, got {max_wave_step}.")
 
             # For each bin: compute the number of points that need to be sampled and
             # spread them evenly throughout the bin.
             query_waves = []
             wave_to_bin_map = []
             query_widths = []  # The width of each query wavelength point (used for integration).
-            self._bin_counts = np.zeros(self.num_bins, dtype=int)
-            for bin_idx, (w_min, w_max) in enumerate(zip(self.waves_min, self.waves_max, strict=False)):
-                num_points = int(np.ceil((w_max - w_min) / max_wave_step))
+            self._bin_counts = np.zeros(self.num_padded_bins, dtype=int)
+            for bin_idx, (w_min, w_max) in enumerate(zip(self.padded_min, self.padded_max, strict=False)):
+
+                # Determine the number of points based on argument used
+                if max_wave_step is not None:
+                    num_points = int(np.ceil((w_max - w_min) / max_wave_step))
+                else:
+                    num_points = oversample_factor
+
                 self._bin_counts[bin_idx] = num_points
 
                 # Split the bin into num_points equal-width sub-bins and evaluate at each
@@ -118,10 +161,10 @@ class Spectrograph:
             self.query_waves = np.array(query_waves, dtype=float)
             self._query_widths = np.array(query_widths, dtype=float)
 
-            # In the waves original order save the mapping from wave index to bin index and a mapping
-            # of bin index to where the bin starts in the waves array.
-            self._wave_to_bin_map = np.array(wave_to_bin_map, dtype=int)
-            self._bin_starts = np.concatenate(([0], np.cumsum(self._bin_counts)[:-1]))
+        # In the waves original order save the mapping from wave index to bin index and a mapping
+        # of bin index to where the bin starts in the waves array.
+        self._wave_to_bin_map = np.array(wave_to_bin_map, dtype=int)
+        self._bin_starts = np.concatenate(([0], np.cumsum(self._bin_counts)[:-1]))
 
         # The query wavelengths should always be in increasing order.
         if not np.all(np.diff(self.query_waves) > 0):  # pragma: no cover
@@ -137,6 +180,7 @@ class Spectrograph:
                 self.scale = np.asarray(scale)
         else:
             self.scale = None
+        self.wavelength_resolution = wavelength_resolution if wavelength_resolution is not None else np.zeros(self.num_bins)
 
         # Save the other spectrograph properties if provided.
         self.instrument = instrument if instrument is not None else "Spectrograph"
@@ -150,6 +194,8 @@ class Spectrograph:
             flam_unit=u.erg / u.s / u.cm**2 / u.AA,
             fnu_unit=u.nJy,
         )
+        # compute the smear matrix, if there are wavelength resolutions
+        self.smear_matrix = self._compute_smear_matrix() if self.wavelength_resolution is not None else None
 
     def __str__(self) -> str:
         """Return a string representation of the spectra filter."""
@@ -176,12 +222,111 @@ class Spectrograph:
             return False
         if not np.allclose(self.query_waves, other.query_waves):  # pragma: no cover
             return False
+        if not np.allclose(self.wavelength_resolution, other.wavelength_resolution):
+            return False
         if self.scale is not None or other.scale is not None:
             if self.scale is None or other.scale is None:
                 return False
             if not np.allclose(self.scale, other.scale):
                 return False
         return True
+    
+
+    def _compute_padded_bins(self):
+        """Compute the padded bins for the spectrograph.
+
+        Parameters
+        ----------
+        oversampling : int, optional
+            The factor by which to oversample the bins. Default is 10.
+
+        Returns
+        -------
+        padded_bins : np.ndarray
+            A 2D array of shape (num_bins, oversampling) representing the padded bins.
+        """
+
+        # determine the extended region
+            # snana expanded by 2.5 sigma of the edge bins
+        sigma_blue = self.wavelength_resolution[0]
+        width_blue = self.bin_widths[0]
+        num_pad_blue = int(2.5 * sigma_blue / width_blue) + 1 if sigma_blue > 0 else 0
+        pad_blue_min = self.waves_min[0] - width_blue * np.arange(num_pad_blue, 0, -1)
+        pad_blue_max = pad_blue_min + width_blue
+
+
+        red_edge_idx = -2 if self.num_bins >= 2 else -1 # snana takes the 2nd to last bin
+        sigma_red = self.wavelength_resolution[red_edge_idx]
+        width_red = self.bin_widths[red_edge_idx]
+        num_pad_red = int(2.5 * sigma_red / width_red) + 1 if sigma_red > 0 else 0
+        pad_red_min = self.waves_max[-1] + width_red * np.arange(num_pad_red)
+        pad_red_max = pad_red_min + width_red
+
+        # combine the original bins with the padded bins
+        padded_bins_min = np.concatenate((pad_blue_min, self.waves_min, pad_red_min))
+        padded_bins_max = np.concatenate((pad_blue_max, self.waves_max, pad_red_max))
+
+        padded_wavelength_resolution = np.concatenate([ # TODO: needed?
+            np.full(num_pad_blue, sigma_blue),
+            self.wavelength_resolution,
+            np.full(num_pad_red, sigma_red)
+        ])
+
+        is_padding = np.concatenate(
+            [
+                np.ones(num_pad_blue, dtype=bool),
+                np.zeros(self.num_bins, dtype=bool),
+                np.ones(num_pad_red, dtype=bool),
+            ]
+        )
+        return padded_bins_min, padded_bins_max, padded_wavelength_resolution, is_padding
+
+    def _compute_smear_matrix(self, n_sigma=3):
+        """Compute the smearing matrix for the spectrograph based on the wavelength resolution.
+
+        Parameters
+        ----------
+        n_sigma : int, optional
+            The number of standard deviations to consider for the Gaussian smearing. Default is 3.
+
+        Returns
+        -------
+        smear_matrix : np.ndarray
+            A 2D array of shape (num_bins, num_bins) representing the smearing matrix.
+            where smear_matrix[i, j] represents the fraction of flux from bin i that smears into j
+        """
+
+        smear_matrix = np.zeros((self.num_padded_bins, self.num_padded_bins))
+        for i in range(self.num_padded_bins):
+            sigma = self.padded_resolution[i]
+
+            # Determine the range of the smearing
+            lambda_bin = self.padded_widths[i]
+            n_bins_index = int(n_sigma * sigma / lambda_bin + 0.5)
+            j_low = max(i - n_bins_index, 0)
+            j_high = min(i + n_bins_index, self.num_padded_bins - 1)
+            bin_center = (self.padded_min[i] + self.padded_max[i]) / 2
+
+            # get smearing factor, if the bin is not padding
+            for j in range(j_low, j_high + 1):
+                # skip if in the padded region
+                if self.is_padding[j]:
+                    continue
+
+                if sigma > 0:
+                    # compute the limits of the Gaussian integral in units of sigma
+                    lam_sig0 = (self.padded_min[j] - bin_center) / sigma
+                    lam_sig1 = (self.padded_max[j] - bin_center) / sigma
+                    smear_matrix[i, j] = gaussian_integral(lam_sig0, lam_sig1)
+                else: # sigma == 0, no smearing to outer bins
+                    smear_matrix[i, j] = 0.0 if i != j else 1.0
+
+        return smear_matrix
+
+    @property
+    def bin_centers(self) -> np.ndarray:
+        """Get the center of each wavelength bin in Angstroms."""
+        return (self.waves_min + self.waves_max) / 2
 
     @property
     def bin_centers(self) -> np.ndarray:
@@ -269,6 +414,7 @@ class Spectrograph:
     def evaluate(
         self,
         flux_density_matrix: np.ndarray,
+        smear: bool = True,
     ) -> np.ndarray:
         """Calculate the bin-integrated flux for each bin in the spectrograph
         (in F_lambda units of erg/s/cm²).
@@ -280,6 +426,9 @@ class Spectrograph:
             flux density values at the wavelengths specified by self.query_waves for a single
             sample. The other dimensions are used to represent multiple times (2D and 3D) and
             multiple objects (3D).
+        smear : bool, optional
+            Whether to smear the flux density values across the bins using the wavelength resolution. 
+            Default is True.
 
         Returns
         -------
@@ -331,18 +480,22 @@ class Spectrograph:
             # that the query flux values for each bin are contiguous.
             spectro_bin_flux_flat = np.add.reduceat(query_bin_flux_flat, self._bin_starts, axis=1)
 
-        # Multiply by any per-bin scaling factors.
-        if self.scale is not None:
-            spectro_bin_flux_flat *= self.scale[np.newaxis, :]
-
         # Reshape the bin flux density back to the original dimensions, but with the last
         # dimension corresponding to the number of bins.
-        spectro_bin_flux = spectro_bin_flux_flat.reshape(*initial_dimensions, self.num_bins)
+        spectro_bin_flux = spectro_bin_flux_flat.reshape(*initial_dimensions, self.num_padded_bins)
 
-        # If we want to add per-bin smearing, we can do that here. We should pre-compute a B x B
+        # Add per-bin smearing. By computing a B x B
         # smearing matrix in the __init__ method and then apply it here. This will allow us to model
         # the effects of the spectrograph's point spread function on the measured fluxes.
-        # For now, we will skip this step.
+        if smear and self.smear_matrix is not None:
+            spectro_bin_flux @= self.smear_matrix
 
-        # Return the final result.
+        # get the flux in the spectrograph's native bins (not the padded bins)
+        spectro_bin_flux = spectro_bin_flux[..., ~self.is_padding]
+
+        # Multiply by any per-bin scaling factors.
+        if self.scale is not None:
+            spectro_bin_flux *= self.scale
+
+        # Return the final result in the spectrograph's native bins.
         return spectro_bin_flux

--- a/src/lightcurvelynx/astro_utils/spectrograph.py
+++ b/src/lightcurvelynx/astro_utils/spectrograph.py
@@ -8,11 +8,24 @@ from astropy import units as u
 from lightcurvelynx.astro_utils.unit_utils import fnu_to_flam
 import scipy
 
-def gaussian_integral(nsig_low, nsig_high):
+def gaussian_integral(nsigma_low, nsigma_high):
     """
-    Compute the integral of a Gaussian between two limits in units of sigma.
+    Computes the integral of a Gaussian between two limits in units of sigma.
+
+    Parameters
+    ----------
+
+    nsigma_low : float
+        The lower limit of the integral in units of sigma.
+    nsigma_high : float
+        The upper limit of the integral in units of sigma.
+
+    Returns
+    -------
+    integral : float
+        The integral of the Gaussian between the limits.
     """
-    return 0.5 * (scipy.special.erf(nsig_high / np.sqrt(2.0)) - scipy.special.erf(nsig_low / np.sqrt(2.0)))
+    return 0.5 * (scipy.special.erf(nsigma_high / np.sqrt(2.0)) - scipy.special.erf(nsigma_low / np.sqrt(2.0)))
 
 class Spectrograph:
     """Models all of the bins of a spectrograph, producing bandfluxes for each
@@ -56,7 +69,7 @@ class Spectrograph:
         instrument: str | None = None,
         scale=None,
         max_wave_step: float | None = None,
-        oversample_factor: int = 10,
+        compute_smear: bool = False,
     ):
         """Initialize the Spectrograph object.
 
@@ -73,10 +86,6 @@ class Spectrograph:
             that are evaluated while computing the bin's flux. The smaller this value, the more
             accurate and expensive the integration. If None, a single sample per bin is used.
             Default: None
-        oversample_factor: int, optional
-            If max_wave_step is not provided, divide each bin into this many sub-bins to evaluate 
-            the flux density of the object at a resolution higher than the spectrograph's.
-            Default: 10
         scale : float | array-like, optional
             The multiplicative factor to apply to each bin's flux. If None, no additional scaling
             is applied.
@@ -89,10 +98,6 @@ class Spectrograph:
         self.waves_max = np.asarray(waves_max, dtype=float)
         self.num_bins = len(self.waves_min)
 
-        oversample_factor = 1 if wavelength_resolution is None else oversample_factor
-        self.wavelength_resolution = np.asarray(wavelength_resolution, dtype=float) \
-            if wavelength_resolution is not None else np.zeros(self.num_bins, dtype=float)
-        
         if self.num_bins <= 0:  # pragma: no cover
             raise ValueError("Spectrograph must have at least one bin.")
         if len(self.waves_max) != self.num_bins:
@@ -105,17 +110,10 @@ class Spectrograph:
         if np.any(self.bin_widths <= 0):
             raise ValueError("Bins must have positive width.")
 
-        # check the oversample_factor
-        if type(oversample_factor) is not int or oversample_factor < 1:
-            raise ValueError(f"oversample_factor must be a positive integer, got {oversample_factor}.")
-
-        
-
         # Compute the query wavelengths at which to evaluate the flux density of the object.
         # First, we pad the bins to account for smearing later.
-        # Then, we evaluate at 10x the bin resolution.
-        # However, if max_wave_step is provided AND
-        # we need to split at least one bin, we will add multiple points per bin (evenly space
+        # if max_wave_step is provided AND we need to split at least one bin,
+        # we will add multiple points per bin (evenly space
         # throughout the bin) until the maximum gap is LESS than max_wave_step.
         self._wave_to_bin_map = None
         padded_min, padded_max, padded_resolution, is_padding = self._compute_padded_bins()
@@ -125,14 +123,14 @@ class Spectrograph:
         self.padded_resolution = padded_resolution
         self.is_padding = is_padding
         self.num_padded_bins = len(self.padded_min)
-        if (max_wave_step is None or np.max(self.bin_widths) <= max_wave_step) and oversample_factor == 1:
+        if max_wave_step is None or np.max(self.bin_widths) <= max_wave_step:
             self.query_waves = (self.padded_min + self.padded_max) / 2
             self._query_widths = self.padded_widths
             self._bin_counts = np.ones(self.num_padded_bins, dtype=int)
             wave_to_bin_map = list(range(self.num_padded_bins))
         else:
-            if max_wave_step is not None and max_wave_step <= 0:
-                    raise ValueError(f"max_wave_step must be positive, got {max_wave_step}.")
+            if max_wave_step <= 0:
+                raise ValueError(f"max_wave_step must be positive, got {max_wave_step}.")
 
             # For each bin: compute the number of points that need to be sampled and
             # spread them evenly throughout the bin.
@@ -141,13 +139,7 @@ class Spectrograph:
             query_widths = []  # The width of each query wavelength point (used for integration).
             self._bin_counts = np.zeros(self.num_padded_bins, dtype=int)
             for bin_idx, (w_min, w_max) in enumerate(zip(self.padded_min, self.padded_max, strict=False)):
-
-                # Determine the number of points based on argument used
-                if max_wave_step is not None:
-                    num_points = int(np.ceil((w_max - w_min) / max_wave_step))
-                else:
-                    num_points = oversample_factor
-
+                num_points = int(np.ceil((w_max - w_min) / max_wave_step))
                 self._bin_counts[bin_idx] = num_points
 
                 # Split the bin into num_points equal-width sub-bins and evaluate at each
@@ -180,7 +172,6 @@ class Spectrograph:
                 self.scale = np.asarray(scale)
         else:
             self.scale = None
-        self.wavelength_resolution = wavelength_resolution if wavelength_resolution is not None else np.zeros(self.num_bins)
 
         # Save the other spectrograph properties if provided.
         self.instrument = instrument if instrument is not None else "Spectrograph"
@@ -194,8 +185,14 @@ class Spectrograph:
             flam_unit=u.erg / u.s / u.cm**2 / u.AA,
             fnu_unit=u.nJy,
         )
-        # compute the smear matrix, if there are wavelength resolutions
-        self.smear_matrix = self._compute_smear_matrix() if self.wavelength_resolution is not None else None
+        # compute the smear matrix, if requested
+        if compute_smear:
+            if self.wavelength_resolution is None:
+                raise ValueError("wavelength_resolution is required for smear computation.")
+            self.wavelength_resolution = np.asarray(wavelength_resolution, dtype=float)
+            self.smear_matrix = self._compute_smear_matrix()
+        else:
+            self.smear_matrix = None
 
     def __str__(self) -> str:
         """Return a string representation of the spectra filter."""
@@ -230,20 +227,20 @@ class Spectrograph:
             if not np.allclose(self.scale, other.scale):
                 return False
         return True
-    
 
     def _compute_padded_bins(self):
-        """Compute the padded bins for the spectrograph.
-
-        Parameters
-        ----------
-        oversampling : int, optional
-            The factor by which to oversample the bins. Default is 10.
+        """Compute the parameters for padded bins for the spectrograph. This allows for flux beyond the edges
+        of the spectrograph to be possibily smeared into the spectrograph's bins.
 
         Returns
         -------
-        padded_bins : np.ndarray
-            A 2D array of shape (num_bins, oversampling) representing the padded bins.
+        padded_bins_min : np.ndarray
+            the minimum wavelength of each padded bin in Angstroms.
+        padded_bins_max : np.ndarray
+            the maximum wavelength of each padded bin in Angstroms.
+        is_padding : np.ndarray
+            a boolean array indicating which bins are padding (True) and which are in the 
+            original spectrograph.
         """
 
         # determine the extended region
@@ -287,7 +284,8 @@ class Spectrograph:
         Parameters
         ----------
         n_sigma : int, optional
-            The number of standard deviations to consider for the Gaussian smearing. Default is 3.
+            The number of standard deviations to consider for the Gaussian smearing. 
+            Default is 3.
 
         Returns
         -------
@@ -322,11 +320,6 @@ class Spectrograph:
                     smear_matrix[i, j] = 0.0 if i != j else 1.0
 
         return smear_matrix
-
-    @property
-    def bin_centers(self) -> np.ndarray:
-        """Get the center of each wavelength bin in Angstroms."""
-        return (self.waves_min + self.waves_max) / 2
 
     @property
     def bin_centers(self) -> np.ndarray:

--- a/tests/lightcurvelynx/astro_utils/test_spectrograph.py
+++ b/tests/lightcurvelynx/astro_utils/test_spectrograph.py
@@ -621,15 +621,10 @@ def test_spectrograph_evaluate_with_smearing():
     # padding supplies the flux that would otherwise be lost at the edges.
     flux_density = 3.7
     flat_input = np.full(spgraph.query_waves.shape, flux_density)
-    expected = flux_density * spgraph.bin_widths
-
+    unsmeared = spgraph.evaluate(flat_input, smear=False)
     smeared = spgraph.evaluate(flat_input, smear=True)
     assert smeared.shape == (spgraph.num_bins,)
-    assert np.allclose(smeared, expected, rtol=5e-3)
-
-    # With smear=False, there is no cross-bin mixing and the result is exact.
-    unsmeared = spgraph.evaluate(flat_input, smear=False)
-    assert np.allclose(unsmeared, expected)
+    assert np.allclose(smeared, unsmeared, rtol=5e-3)
 
     # A single narrow spike of flux should spread into neighboring bins when smeared,
     # while approximately conserving total flux.

--- a/tests/lightcurvelynx/astro_utils/test_spectrograph.py
+++ b/tests/lightcurvelynx/astro_utils/test_spectrograph.py
@@ -200,19 +200,6 @@ def test_create_spectrograph_from_bad_bins():
         _ = Spectrograph(waves_min_ooo, waves_max_ooo)
 
 
-def test_create_spectrograph_from_bad_bins():
-    """Test that we fail if the bins overlap or are not in increasing order."""
-    waves_min_overlap = np.array([3500.0, 4000.0, 5000.0, 7000.0, 7500.0])
-    waves_max_overlap = np.array([4000.0, 5000.0, 7100.0, 7500.0, 8000.0])
-    with pytest.raises(ValueError):
-        _ = Spectrograph(waves_min_overlap, waves_max_overlap)
-
-    waves_min_ooo = np.array([3500.0, 4000.0, 7000.0, 5000.0])
-    waves_max_ooo = np.array([4000.0, 5000.0, 7500.0, 6000.0])
-    with pytest.raises(ValueError):
-        _ = Spectrograph(waves_min_ooo, waves_max_ooo)
-
-
 def test_spectrograph_equals():
     """Test that we can compare two Spectrograph objects for equality."""
     spgraph1 = Spectrograph.from_regular_grid(wave_start=4000, wave_end=8000, bin_width=5.0)

--- a/tests/lightcurvelynx/astro_utils/test_spectrograph.py
+++ b/tests/lightcurvelynx/astro_utils/test_spectrograph.py
@@ -601,7 +601,7 @@ def test_spectrograph_smear_matrix_values():
 
 
 def test_spectrograph_evaluate_with_smearing():
-    """Test that evaluate() smears flux across bins and that smear=False bypasses it."""
+    """Test that evaluate() smears flux across bins"""
     waves_min = np.arange(4000.0, 4400.0, 20.0)
     waves_max = np.arange(4020.0, 4420.0, 20.0)
     resolution = np.full(len(waves_min), 30.0)

--- a/tests/lightcurvelynx/astro_utils/test_spectrograph.py
+++ b/tests/lightcurvelynx/astro_utils/test_spectrograph.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 from astropy import units as u
-from lightcurvelynx.astro_utils.spectrograph import Spectrograph
+from lightcurvelynx.astro_utils.spectrograph import Spectrograph, gaussian_integral
 from lightcurvelynx.astro_utils.unit_utils import fnu_to_flam
 
 
@@ -200,6 +200,19 @@ def test_create_spectrograph_from_bad_bins():
         _ = Spectrograph(waves_min_ooo, waves_max_ooo)
 
 
+def test_create_spectrograph_from_bad_bins():
+    """Test that we fail if the bins overlap or are not in increasing order."""
+    waves_min_overlap = np.array([3500.0, 4000.0, 5000.0, 7000.0, 7500.0])
+    waves_max_overlap = np.array([4000.0, 5000.0, 7100.0, 7500.0, 8000.0])
+    with pytest.raises(ValueError):
+        _ = Spectrograph(waves_min_overlap, waves_max_overlap)
+
+    waves_min_ooo = np.array([3500.0, 4000.0, 7000.0, 5000.0])
+    waves_max_ooo = np.array([4000.0, 5000.0, 7500.0, 6000.0])
+    with pytest.raises(ValueError):
+        _ = Spectrograph(waves_min_ooo, waves_max_ooo)
+
+
 def test_spectrograph_equals():
     """Test that we can compare two Spectrograph objects for equality."""
     spgraph1 = Spectrograph.from_regular_grid(wave_start=4000, wave_end=8000, bin_width=5.0)
@@ -207,11 +220,16 @@ def test_spectrograph_equals():
     spgraph3 = Spectrograph.from_regular_grid(wave_start=4000, wave_end=8000, bin_width=10.0)
     spgraph4 = Spectrograph.from_regular_grid(wave_start=3000, wave_end=8000, bin_width=5.0)
     spgraph5 = Spectrograph.from_regular_grid(wave_start=4000, wave_end=9000, bin_width=5.0)
+    spgraph6 = Spectrograph.from_regular_grid(
+        wave_start=4000, wave_end=8000, bin_width=5.0,
+        wavelength_resolution=np.full(spgraph1.num_bins, 10.0),
+    )
 
     assert spgraph1 == spgraph2
     assert spgraph1 != spgraph3
     assert spgraph1 != spgraph4
     assert spgraph1 != spgraph5
+    assert spgraph1 != spgraph6
 
 
 def test_create_spectrograph_with_scale():
@@ -452,6 +470,20 @@ def test_create_spectrograph_max_wave_step():
     assert np.allclose(results3, expected3)
     assert results3.shape == (2, 2, spgraph.num_bins)
 
+    # oversample_factor=1 one point per bin, but also and must
+    # include padding introduced by wavelength_resolution.
+    resolution = np.full(5, 30.0)
+    spgraph_padded = Spectrograph(
+        wave_min, wave_max, oversample_factor=1, wavelength_resolution=resolution
+    )
+    assert spgraph_padded.num_padded_bins > spgraph_padded.num_bins
+    assert len(spgraph_padded.query_waves) == spgraph_padded.num_padded_bins
+    assert np.allclose(
+        spgraph_padded.query_waves, (spgraph_padded.padded_min + spgraph_padded.padded_max) / 2
+    )
+    result = spgraph_padded.evaluate(np.random.random(spgraph_padded.query_waves.shape), smear=True)
+    assert result.shape == (spgraph_padded.num_bins,)
+
     # We fail to create a Spectrograph object with an invalid max_wave_step (<= 0.0).
     with pytest.raises(ValueError):
         _ = Spectrograph(wave_min, wave_max, max_wave_step=-50.0)
@@ -531,3 +563,79 @@ def test_create_spectrograph_max_wave_step_aggregates_subbins():
         ]
     )
     assert np.allclose(result, expected)
+
+def test_create_spectrograph_with_wavelength_resolution():
+    """Test that a Spectrograph with per-bin wavelength resolution pads its bins
+    on both sides to support smearing, and that no resolution means no padding."""
+    waves_min = np.array([4000.0, 4020.0, 4040.0])
+    waves_max = np.array([4020.0, 4040.0, 4060.0])
+    resolution = np.full(3, 10.0)
+    spgraph = Spectrograph(waves_min, waves_max, wavelength_resolution=resolution)
+
+    assert spgraph.num_padded_bins > spgraph.num_bins
+    assert np.sum(spgraph.is_padding) == spgraph.num_padded_bins - spgraph.num_bins
+    assert len(spgraph.padded_min) == spgraph.num_padded_bins
+    assert len(spgraph.padded_max) == spgraph.num_padded_bins
+    assert np.allclose(spgraph.waves_min, waves_min)
+    assert np.allclose(spgraph.waves_max, waves_max)
+
+    # With no resolution given, there is no padding at all.
+    spgraph_no_res = Spectrograph(waves_min, waves_max)
+    assert spgraph_no_res.num_padded_bins == spgraph_no_res.num_bins
+    assert not np.any(spgraph_no_res.is_padding)
+
+
+def test_spectrograph_smear_matrix_values():
+    """Test that the smear matrix redistributes flux using the expected Gaussian
+    fractions for a simple, hand-computable case."""
+    waves_min = np.array([4000.0, 4020.0, 4040.0])
+    waves_max = np.array([4020.0, 4040.0, 4060.0])
+    resolution = np.full(3, 10.0)  # sigma = bin_width / 2
+    spgraph = Spectrograph(waves_min, waves_max, wavelength_resolution=resolution)
+
+    # Index of the middle observed bin (center 4030) within the padded array.
+    middle = int(np.argmax(~spgraph.is_padding)) + 1
+
+    within_1_sigma = gaussian_integral(-1, 1)
+    between_1_and_3_sigma = gaussian_integral(1, 3)
+    assert spgraph.smear_matrix[middle, middle] == pytest.approx(within_1_sigma)
+    assert spgraph.smear_matrix[middle, middle - 1] == pytest.approx(between_1_and_3_sigma)
+    assert spgraph.smear_matrix[middle, middle + 1] == pytest.approx(between_1_and_3_sigma)
+
+    # Padding bins can never receive smeared flux.
+    assert np.all(spgraph.smear_matrix[:, spgraph.is_padding] == 0.0)
+
+    # With zero resolution the smear matrix is the identity (no cross-bin mixing).
+    spgraph_no_res = Spectrograph(waves_min, waves_max)
+    assert np.allclose(spgraph_no_res.smear_matrix, np.eye(spgraph_no_res.num_bins))
+
+
+def test_spectrograph_evaluate_with_smearing():
+    """Test that evaluate() smears flux across bins and that smear=False bypasses it."""
+    waves_min = np.arange(4000.0, 4400.0, 20.0)
+    waves_max = np.arange(4020.0, 4420.0, 20.0)
+    resolution = np.full(len(waves_min), 30.0)
+    spgraph = Spectrograph(waves_min, waves_max, wavelength_resolution=resolution)
+
+    # A flat flux density should stay (approximately) flat after smearing, since
+    # padding supplies the flux that would otherwise be lost at the edges.
+    flux_density = 3.7
+    flat_input = np.full(spgraph.query_waves.shape, flux_density)
+    expected = flux_density * spgraph.bin_widths
+
+    smeared = spgraph.evaluate(flat_input, smear=True)
+    assert smeared.shape == (spgraph.num_bins,)
+    assert np.allclose(smeared, expected, rtol=5e-3)
+
+    # With smear=False, there is no cross-bin mixing and the result is exact.
+    unsmeared = spgraph.evaluate(flat_input, smear=False)
+    assert np.allclose(unsmeared, expected)
+
+    # A single narrow spike of flux should spread into neighboring bins when smeared,
+    # while approximately conserving total flux.
+    spike_input = np.zeros_like(spgraph.query_waves)
+    spike_input[len(spike_input) // 2] = 100.0
+    spiked = spgraph.evaluate(spike_input, smear=True)
+    not_spiked = spgraph.evaluate(spike_input, smear=False)
+    assert np.sum(spiked > 0) > np.sum(not_spiked > 0)
+    assert np.sum(spiked) == pytest.approx(np.sum(not_spiked), rel=0.05)

--- a/tests/lightcurvelynx/astro_utils/test_spectrograph.py
+++ b/tests/lightcurvelynx/astro_utils/test_spectrograph.py
@@ -208,7 +208,9 @@ def test_spectrograph_equals():
     spgraph4 = Spectrograph.from_regular_grid(wave_start=3000, wave_end=8000, bin_width=5.0)
     spgraph5 = Spectrograph.from_regular_grid(wave_start=4000, wave_end=9000, bin_width=5.0)
     spgraph6 = Spectrograph.from_regular_grid(
-        wave_start=4000, wave_end=8000, bin_width=5.0,
+        wave_start=4000,
+        wave_end=8000,
+        bin_width=5.0,
         wavelength_resolution=np.full(spgraph1.num_bins, 10.0),
     )
 
@@ -459,9 +461,7 @@ def test_create_spectrograph_max_wave_step():
 
     # check padding introduced by wavelength_resolution.
     resolution = np.full(5, 30.0)
-    spgraph_padded = Spectrograph(
-        wave_min, wave_max, wavelength_resolution=resolution
-    )
+    spgraph_padded = Spectrograph(wave_min, wave_max, wavelength_resolution=resolution)
     assert spgraph_padded.num_padded_bins > spgraph_padded.num_bins
     assert len(spgraph_padded.query_waves) == spgraph_padded.num_padded_bins
     assert np.allclose(
@@ -550,6 +550,7 @@ def test_create_spectrograph_max_wave_step_aggregates_subbins():
     )
     assert np.allclose(result, expected)
 
+
 def test_create_spectrograph_with_wavelength_resolution():
     """Test that a Spectrograph with per-bin wavelength resolution pads its bins
     on both sides to support smearing, and that no resolution means no padding."""
@@ -593,7 +594,9 @@ def test_spectrograph_smear_matrix_values():
 
     # With zero resolution the smear matrix is the identity (no cross-bin mixing).
     zero_resolution = np.full(3, 0.0)
-    spgraph_no_res = Spectrograph(waves_min, waves_max, wavelength_resolution=zero_resolution, compute_smear=True)
+    spgraph_no_res = Spectrograph(
+        waves_min, waves_max, wavelength_resolution=zero_resolution, compute_smear=True
+    )
     assert np.allclose(spgraph_no_res.smear_matrix, np.eye(spgraph_no_res.num_bins))
 
 

--- a/tests/lightcurvelynx/astro_utils/test_spectrograph.py
+++ b/tests/lightcurvelynx/astro_utils/test_spectrograph.py
@@ -457,18 +457,17 @@ def test_create_spectrograph_max_wave_step():
     assert np.allclose(results3, expected3)
     assert results3.shape == (2, 2, spgraph.num_bins)
 
-    # oversample_factor=1 one point per bin, but also and must
-    # include padding introduced by wavelength_resolution.
+    # check padding introduced by wavelength_resolution.
     resolution = np.full(5, 30.0)
     spgraph_padded = Spectrograph(
-        wave_min, wave_max, oversample_factor=1, wavelength_resolution=resolution
+        wave_min, wave_max, wavelength_resolution=resolution
     )
     assert spgraph_padded.num_padded_bins > spgraph_padded.num_bins
     assert len(spgraph_padded.query_waves) == spgraph_padded.num_padded_bins
     assert np.allclose(
         spgraph_padded.query_waves, (spgraph_padded.padded_min + spgraph_padded.padded_max) / 2
     )
-    result = spgraph_padded.evaluate(np.random.random(spgraph_padded.query_waves.shape), smear=True)
+    result = spgraph_padded.evaluate(np.random.random(spgraph_padded.query_waves.shape))
     assert result.shape == (spgraph_padded.num_bins,)
 
     # We fail to create a Spectrograph object with an invalid max_wave_step (<= 0.0).
@@ -578,7 +577,7 @@ def test_spectrograph_smear_matrix_values():
     waves_min = np.array([4000.0, 4020.0, 4040.0])
     waves_max = np.array([4020.0, 4040.0, 4060.0])
     resolution = np.full(3, 10.0)  # sigma = bin_width / 2
-    spgraph = Spectrograph(waves_min, waves_max, wavelength_resolution=resolution)
+    spgraph = Spectrograph(waves_min, waves_max, wavelength_resolution=resolution, compute_smear=True)
 
     # Index of the middle observed bin (center 4030) within the padded array.
     middle = int(np.argmax(~spgraph.is_padding)) + 1
@@ -593,7 +592,8 @@ def test_spectrograph_smear_matrix_values():
     assert np.all(spgraph.smear_matrix[:, spgraph.is_padding] == 0.0)
 
     # With zero resolution the smear matrix is the identity (no cross-bin mixing).
-    spgraph_no_res = Spectrograph(waves_min, waves_max)
+    zero_resolution = np.full(3, 0.0)
+    spgraph_no_res = Spectrograph(waves_min, waves_max, wavelength_resolution=zero_resolution, compute_smear=True)
     assert np.allclose(spgraph_no_res.smear_matrix, np.eye(spgraph_no_res.num_bins))
 
 
@@ -602,14 +602,15 @@ def test_spectrograph_evaluate_with_smearing():
     waves_min = np.arange(4000.0, 4400.0, 20.0)
     waves_max = np.arange(4020.0, 4420.0, 20.0)
     resolution = np.full(len(waves_min), 30.0)
-    spgraph = Spectrograph(waves_min, waves_max, wavelength_resolution=resolution)
+    spgraph = Spectrograph(waves_min, waves_max, wavelength_resolution=resolution, compute_smear=True)
+    spgraph_unsmeared = Spectrograph(waves_min, waves_max, wavelength_resolution=resolution)
 
     # A flat flux density should stay (approximately) flat after smearing, since
     # padding supplies the flux that would otherwise be lost at the edges.
     flux_density = 3.7
     flat_input = np.full(spgraph.query_waves.shape, flux_density)
-    unsmeared = spgraph.evaluate(flat_input, smear=False)
-    smeared = spgraph.evaluate(flat_input, smear=True)
+    unsmeared = spgraph_unsmeared.evaluate(flat_input)
+    smeared = spgraph.evaluate(flat_input)
     assert smeared.shape == (spgraph.num_bins,)
     assert np.allclose(smeared, unsmeared, rtol=5e-3)
 
@@ -617,7 +618,7 @@ def test_spectrograph_evaluate_with_smearing():
     # while approximately conserving total flux.
     spike_input = np.zeros_like(spgraph.query_waves)
     spike_input[len(spike_input) // 2] = 100.0
-    spiked = spgraph.evaluate(spike_input, smear=True)
-    not_spiked = spgraph.evaluate(spike_input, smear=False)
+    spiked = spgraph.evaluate(spike_input)
+    not_spiked = spgraph_unsmeared.evaluate(spike_input)
     assert np.sum(spiked > 0) > np.sum(not_spiked > 0)
     assert np.sum(spiked) == pytest.approx(np.sum(not_spiked), rel=0.05)


### PR DESCRIPTION
## Change Description
Following the SNANA implementation, applies gaussian smearing to flux into neighboring spectrograph bins based on provided wavelength resolutions per bin.  Pads the edges of the bins to allow flux from beyond the bins to possible smear into the specified bins.

## Code Quality
- [ ] I have read the Contribution Guide and agree to the Code of Conduct
- [ ] My code follows the code style of this project
- [ ] My code builds (or compiles) cleanly without any errors or warnings
- [ ] My code contains relevant comments and necessary documentation
