### PR TITLE
Small Graph State Fixes

### DIFF
--- a/src/lightcurvelynx/graph_state.py
+++ b/src/lightcurvelynx/graph_state.py
@@ -76,9 +76,6 @@ class GraphState:
     def __len__(self):
         return self.num_parameters
 
-    def __next__(self):
-        return next(self._iterate())
-
     def __iter__(self):
         return self._iterate()
 
@@ -217,7 +214,7 @@ class GraphState:
             new_state.states[node_name] = {}
             for var_name, var_value in node_vars.items():
                 if self.num_samples == 1:
-                    new_state.states[node_name][var_name] = var_value
+                    new_state.states[node_name][var_name] = copy.deepcopy(var_value)
                 else:
                     new_state.states[node_name][var_name] = var_value.copy()
 

--- a/tests/lightcurvelynx/test_graph_state.py
+++ b/tests/lightcurvelynx/test_graph_state.py
@@ -408,6 +408,12 @@ def test_graph_state_copy():
     assert state2["a"]["v2"] == 20.0
     assert state2["b"]["v1"] == 3.0  # No effect since this variable is fixed.
 
+    # Mutable single-sample values must not be shared with the copy.
+    state.set("a", "metadata", {"flags": ["original"]})
+    state2 = state.copy()
+    state2["a"]["metadata"]["flags"].append("copied")
+    assert state["a"]["metadata"] == {"flags": ["original"]}
+
     # Test with arrays.
     state = GraphState(3, sample_offset=2)
     state.set("a", "v1", np.array([1.0, 2.0, 3.0]))


### PR DESCRIPTION
Two small errors found and fixed by copilot:
- Make sure copy does a deep copy then there is only a single sample in `GraphState`
- The `next()` method was always returning a new iterator and thus sample 0. Since it isn't being used, we can just remove it.