### PR TITLE
Fix extrapolation edge cases

### DIFF
--- a/src/lightcurvelynx/models/physical_model.py
+++ b/src/lightcurvelynx/models/physical_model.py
@@ -543,12 +543,12 @@ class SEDModel(BasePhysicalModel):
         min_query_wave = np.min(wavelengths)
         min_valid_wave = self.minwave(graph_state=graph_state)
         if min_valid_wave is None:
-            min_valid_wave = min_query_wave
+            min_valid_wave = -np.inf
 
         max_query_wave = np.max(wavelengths)
         max_valid_wave = self.maxwave(graph_state=graph_state)
         if max_valid_wave is None:
-            max_valid_wave = max_query_wave
+            max_valid_wave = np.inf
 
         # We check if we can do extrapolation for before the first valid wavelength and, if so, modify
         # the queries and set up the data we need.
@@ -631,14 +631,14 @@ class SEDModel(BasePhysicalModel):
         min_query_time = np.min(times)
         min_valid_phase = self.minphase(graph_state=graph_state)
         if min_valid_phase is None:
-            min_valid_time = min_query_time
+            min_valid_time = -np.inf
         else:
             min_valid_time = min_valid_phase + t0
 
         max_query_time = np.max(times)
         max_valid_phase = self.maxphase(graph_state=graph_state)
         if max_valid_phase is None:
-            max_valid_time = max_query_time
+            max_valid_time = np.inf
         else:
             max_valid_time = max_valid_phase + t0
 
@@ -1098,14 +1098,14 @@ class BandfluxModel(BasePhysicalModel, ABC):
         min_query_time = np.min(times)
         min_valid_phase = self.minphase(filter=filter, graph_state=state)
         if min_valid_phase is None:
-            min_valid_time = min_query_time
+            min_valid_time = -np.inf
         else:
             min_valid_time = min_valid_phase + t0
 
         max_query_time = np.max(times)
         max_valid_phase = self.maxphase(filter=filter, graph_state=state)
         if max_valid_phase is None:
-            max_valid_time = max_query_time
+            max_valid_time = np.inf
         else:
             max_valid_time = max_valid_phase + t0
 

--- a/src/lightcurvelynx/models/physical_model.py
+++ b/src/lightcurvelynx/models/physical_model.py
@@ -539,13 +539,19 @@ class SEDModel(BasePhysicalModel):
         # Stage 1: ----- Determine which wavelengths require extrapolation -----
         # Updates query_waves and creates before_wave_queries and after_wave_queries for extrapolation.
 
-        # We check if we can do extrapolation for before the first valid wavelength and, if so, modify
-        # the queries and set up the data we need.
+        # Check the minimum and maximum query wavelengths against the valid wavelength range.
         min_query_wave = np.min(wavelengths)
         min_valid_wave = self.minwave(graph_state=graph_state)
         if min_valid_wave is None:
             min_valid_wave = min_query_wave
 
+        max_query_wave = np.max(wavelengths)
+        max_valid_wave = self.maxwave(graph_state=graph_state)
+        if max_valid_wave is None:
+            max_valid_wave = max_query_wave
+
+        # We check if we can do extrapolation for before the first valid wavelength and, if so, modify
+        # the queries and set up the data we need.
         before_wave_queries = None
         if min_query_wave < min_valid_wave:
             if self._wave_extrap_before is None:
@@ -564,13 +570,15 @@ class SEDModel(BasePhysicalModel):
                     (min_valid_wave + 10.0 * np.arange(n_added_wave_before), query_waves[valid_mask])
                 )
 
+                # Check that our added points didn't go past the maximum valid wavelength.
+                if min_valid_wave + 10.0 * n_added_wave_before > max_valid_wave:
+                    raise ValueError(
+                        f"Cannot add {n_added_wave_before} wave extrapolation points at the start of the "
+                        f"wavelength range: [{min_valid_wave}, {max_valid_wave}]."
+                    )
+
         # We check if we can do extrapolation for after the last valid wavelength and, if so, modify
         # the queries and set up the data we need.
-        max_query_wave = np.max(wavelengths)
-        max_valid_wave = self.maxwave(graph_state=graph_state)
-        if max_valid_wave is None:
-            max_valid_wave = max_query_wave
-
         after_wave_queries = None
         if max_query_wave > max_valid_wave:
             if self._wave_extrap_after is None:
@@ -592,6 +600,13 @@ class SEDModel(BasePhysicalModel):
                     )
                 )
 
+                # Check that our added points didn't go past the minimum valid wavelength.
+                if max_valid_wave - 10.0 * n_added_wave_after < min_valid_wave:
+                    raise ValueError(
+                        f"Cannot add {n_added_wave_after} wave extrapolation points at the end of the "
+                        f"wavelength range: [{min_valid_wave}, {max_valid_wave}]."
+                    )
+
         # Check if the wavelengths are sorted and, if not, create sorting indices. We do this AFTER we
         # augment the query waves in case the new boundary points interleave with the original queries.
         if len(query_waves) > 1 and not np.all(query_waves[:-1] <= query_waves[1:]):
@@ -610,8 +625,7 @@ class SEDModel(BasePhysicalModel):
         if t0 is None:
             t0 = 0.0
 
-        # We check if we can do extrapolation for times before the valid time range and, if so, modify
-        # the queries and set up the data we need.
+        # Check the minimum and maximum query times against the valid time range.
         min_query_time = np.min(times)
         min_valid_phase = self.minphase(graph_state=graph_state)
         if min_valid_phase is None:
@@ -619,6 +633,15 @@ class SEDModel(BasePhysicalModel):
         else:
             min_valid_time = min_valid_phase + t0
 
+        max_query_time = np.max(times)
+        max_valid_phase = self.maxphase(graph_state=graph_state)
+        if max_valid_phase is None:
+            max_valid_time = max_query_time
+        else:
+            max_valid_time = max_valid_phase + t0
+
+        # We check if we can do extrapolation for times before the valid time range and, if so, modify
+        # the queries and set up the data we need.
         before_time_queries = None
         if min_query_time < min_valid_time:
             if self._time_extrap_before is None:
@@ -637,15 +660,15 @@ class SEDModel(BasePhysicalModel):
                     (min_valid_time + np.arange(n_added_time_before), query_times[valid_mask])
                 )
 
+                # Check that our added points didn't go past the maximum valid time.
+                if min_valid_time + n_added_time_before > max_valid_time:
+                    raise ValueError(
+                        f"Cannot add {n_added_time_before} time extrapolation points at the start of the "
+                        f"time range: [{min_valid_time}, {max_valid_time}]."
+                    )
+
         # We check if we can do extrapolation for times after the valid time range and, if so, modify
         # the queries and set up the data we need.
-        max_query_time = np.max(times)
-        max_valid_phase = self.maxphase(graph_state=graph_state)
-        if max_valid_phase is None:
-            max_valid_time = max_query_time
-        else:
-            max_valid_time = max_valid_phase + t0
-
         after_time_queries = None
         if max_query_time > max_valid_time:
             if self._time_extrap_after is None:
@@ -663,6 +686,13 @@ class SEDModel(BasePhysicalModel):
                 query_times = np.concatenate(
                     (query_times[valid_mask], max_valid_time - np.arange(n_added_time_after - 1, -1, -1))
                 )
+
+                # Check that our added points didn't go past the minimum valid time.
+                if max_valid_time - n_added_time_after < min_valid_time:
+                    raise ValueError(
+                        f"Cannot add {n_added_time_after} time extrapolation points at the end of the "
+                        f"time range: [{min_valid_time}, {max_valid_time}]."
+                    )
 
         # Check if the times are sorted and, if not, create sorting indices. We do this AFTER we
         # augment the query times in case the new boundary points interleave with the original queries.
@@ -1220,7 +1250,7 @@ class BandfluxModel(BasePhysicalModel, ABC):
             )
         return bandfluxes
 
-    def evaluate_spectra(self, spectrograph, times, state, rng_info=None) -> np.ndarray:
+    def evaluate_spectra(self, times, spectrograph, state, rng_info=None):
         """Get the bin-integrated fluxes for each bin in a spectrograph in units of F_lambda (erg/s/cm²).
 
         Parameters

--- a/src/lightcurvelynx/models/physical_model.py
+++ b/src/lightcurvelynx/models/physical_model.py
@@ -571,7 +571,8 @@ class SEDModel(BasePhysicalModel):
                 )
 
                 # Check that our added points didn't go past the maximum valid wavelength.
-                if min_valid_wave + 10.0 * n_added_wave_before > max_valid_wave:
+                last_added_wave = min_valid_wave + 10.0 * (n_added_wave_before - 1)
+                if n_added_wave_before > 1 and last_added_wave > max_valid_wave:
                     raise ValueError(
                         f"Cannot add {n_added_wave_before} wave extrapolation points at the start of the "
                         f"wavelength range: [{min_valid_wave}, {max_valid_wave}]."
@@ -601,7 +602,8 @@ class SEDModel(BasePhysicalModel):
                 )
 
                 # Check that our added points didn't go past the minimum valid wavelength.
-                if max_valid_wave - 10.0 * n_added_wave_after < min_valid_wave:
+                first_added_wave = max_valid_wave - 10.0 * (n_added_wave_after - 1)
+                if n_added_wave_after > 1 and first_added_wave < min_valid_wave:
                     raise ValueError(
                         f"Cannot add {n_added_wave_after} wave extrapolation points at the end of the "
                         f"wavelength range: [{min_valid_wave}, {max_valid_wave}]."
@@ -661,7 +663,8 @@ class SEDModel(BasePhysicalModel):
                 )
 
                 # Check that our added points didn't go past the maximum valid time.
-                if min_valid_time + n_added_time_before > max_valid_time:
+                last_added_time = min_valid_time + (n_added_time_before - 1)
+                if n_added_time_before > 1 and last_added_time > max_valid_time:
                     raise ValueError(
                         f"Cannot add {n_added_time_before} time extrapolation points at the start of the "
                         f"time range: [{min_valid_time}, {max_valid_time}]."
@@ -688,7 +691,8 @@ class SEDModel(BasePhysicalModel):
                 )
 
                 # Check that our added points didn't go past the minimum valid time.
-                if max_valid_time - n_added_time_after < min_valid_time:
+                first_added_time = max_valid_time - (n_added_time_after - 1)
+                if n_added_time_after > 1 and first_added_time < min_valid_time:
                     raise ValueError(
                         f"Cannot add {n_added_time_after} time extrapolation points at the end of the "
                         f"time range: [{min_valid_time}, {max_valid_time}]."
@@ -1090,8 +1094,7 @@ class BandfluxModel(BasePhysicalModel, ABC):
         if t0 is None:
             t0 = 0.0
 
-        # We check if we can do extrapolation for times before the valid time range and, if so, modify
-        # the queries and set up the data we need.
+        # Determine the minimum and maximum valid times based on the model's phase bounds and t0.
         min_query_time = np.min(times)
         min_valid_phase = self.minphase(filter=filter, graph_state=state)
         if min_valid_phase is None:
@@ -1099,6 +1102,15 @@ class BandfluxModel(BasePhysicalModel, ABC):
         else:
             min_valid_time = min_valid_phase + t0
 
+        max_query_time = np.max(times)
+        max_valid_phase = self.maxphase(filter=filter, graph_state=state)
+        if max_valid_phase is None:
+            max_valid_time = max_query_time
+        else:
+            max_valid_time = max_valid_phase + t0
+
+        # We check if we can do extrapolation for times before the valid time range and, if so, modify
+        # the queries and set up the data we need.
         before_time_queries = None
         if min_query_time < min_valid_time:
             if self._time_extrap_before is None:
@@ -1117,15 +1129,16 @@ class BandfluxModel(BasePhysicalModel, ABC):
                     (min_valid_time + np.arange(n_added_time_before), query_times[valid_mask])
                 )
 
+                # Check that our added points didn't go past the maximum valid time.
+                last_added_time_before = min_valid_time + (n_added_time_before - 1)
+                if n_added_time_before > 1 and last_added_time_before > max_valid_time:
+                    raise ValueError(
+                        f"Cannot add {n_added_time_before} time extrapolation points at the start of the "
+                        f"time range: [{min_valid_time}, {max_valid_time}]."
+                    )
+
         # We check if we can do extrapolation for times after the valid time range and, if so, modify
         # the queries and set up the data we need.
-        max_query_time = np.max(times)
-        max_valid_phase = self.maxphase(filter=filter, graph_state=state)
-        if max_valid_phase is None:
-            max_valid_time = max_query_time
-        else:
-            max_valid_time = max_valid_phase + t0
-
         after_time_queries = None
         if max_query_time > max_valid_time:
             if self._time_extrap_after is None:
@@ -1143,6 +1156,14 @@ class BandfluxModel(BasePhysicalModel, ABC):
                 query_times = np.concatenate(
                     (query_times[valid_mask], max_valid_time - np.arange(n_added_time_after - 1, -1, -1))
                 )
+
+                # Check that our added points didn't go past the minimum valid time.
+                first_added_time_after = max_valid_time - (n_added_time_after - 1)
+                if n_added_time_after > 1 and first_added_time_after < min_valid_time:
+                    raise ValueError(
+                        f"Cannot add {n_added_time_after} time extrapolation points at the end of the "
+                        f"time range: [{min_valid_time}, {max_valid_time}]."
+                    )
 
         # Check if the times are sorted and, if not, create sorting indices. We do this AFTER we
         # augment the query times in case the new boundary points interleave with the original queries.
@@ -1250,7 +1271,7 @@ class BandfluxModel(BasePhysicalModel, ABC):
             )
         return bandfluxes
 
-    def evaluate_spectra(self, times, spectrograph, state, rng_info=None):
+    def evaluate_spectra(self, times, spectrograph, state, rng_info=None) -> np.ndarray:
         """Get the bin-integrated fluxes for each bin in a spectrograph in units of F_lambda (erg/s/cm²).
 
         Parameters

--- a/tests/lightcurvelynx/models/test_model_extrapolation.py
+++ b/tests/lightcurvelynx/models/test_model_extrapolation.py
@@ -272,6 +272,52 @@ def test_linear_linear_model_extrapolators() -> None:
         _ = _LinearLinearTestModel(time_extrapolation="not an extrapolator", t0=0.0)
 
 
+def test_linear_linear_model_extrapolators_time_too_small() -> None:
+    """Test that we correctly fail when the model does not have a large enough
+    time range to add the needed extrapolation points.
+    """
+    wave_extrapolator = LinearDecay(decay_width=500.0)  # 500 angstroms to zero
+    time_extrapolator = LinearDecay(decay_width=100.0)  # 100 days to zero
+    model_wave = _LinearLinearTestModel(
+        wave_extrapolation=wave_extrapolator,
+        time_extrapolation=time_extrapolator,
+        t0=0.0,
+        min_phase=0.0,
+        max_phase=0.1,  # Less than a day away.
+    )
+
+    # Trying to add points after min_phase for extrapolation before min_phase.
+    with pytest.raises(ValueError):
+        _ = model_wave.evaluate_sed(np.array([-1.0, 0.0]), np.array([5000.0]))
+
+    # Trying to add points before max_phase for extrapolation after max_phase.
+    with pytest.raises(ValueError):
+        _ = model_wave.evaluate_sed(np.array([0.0, 1.0]), np.array([5000.0]))
+
+
+def test_linear_linear_model_extrapolators_wave_too_small() -> None:
+    """Test that we correctly fail when the model does not have a large enough
+    wavelength range to add the needed extrapolation points.
+    """
+    wave_extrapolator = LinearDecay(decay_width=500.0)  # 500 angstroms to zero
+    time_extrapolator = LinearDecay(decay_width=100.0)  # 100 days to zero
+    model_wave = _LinearLinearTestModel(
+        wave_extrapolation=wave_extrapolator,
+        time_extrapolation=time_extrapolator,
+        t0=0.0,
+        min_wave=5000.0,
+        max_wave=5005.0,  # Less then 10.0 A away
+    )
+
+    # Trying to add points after min_wave for extrapolation before min_wave.
+    with pytest.raises(ValueError):
+        _ = model_wave.evaluate_sed(np.array([0.0]), np.array([4950.0, 5001.0]))
+
+    # Trying to add points before max_wave for extrapolation after max_wave.
+    with pytest.raises(ValueError):
+        _ = model_wave.evaluate_sed(np.array([0.0]), np.array([5001.0, 5050.0]))
+
+
 def test_linear_linear_model_diff_extrapolators() -> None:
     """Test the _LinearLinearTestModel with different extrapolators each
     each direction (above/below) for times and wavelengths.

--- a/tests/lightcurvelynx/models/test_model_extrapolation.py
+++ b/tests/lightcurvelynx/models/test_model_extrapolation.py
@@ -277,8 +277,8 @@ def test_linear_linear_model_extrapolators_time_too_small() -> None:
     time range to add the needed extrapolation points.
     """
     wave_extrapolator = LinearDecay(decay_width=500.0)  # 500 angstroms to zero
-    time_extrapolator = LinearDecay(decay_width=100.0)  # 100 days to zero
-    model_wave = _LinearLinearTestModel(
+    time_extrapolator = LinearFit(nfit=2)  # Fit from 2 points
+    model_time = _LinearLinearTestModel(
         wave_extrapolation=wave_extrapolator,
         time_extrapolation=time_extrapolator,
         t0=0.0,
@@ -288,25 +288,25 @@ def test_linear_linear_model_extrapolators_time_too_small() -> None:
 
     # Trying to add points after min_phase for extrapolation before min_phase.
     with pytest.raises(ValueError):
-        _ = model_wave.evaluate_sed(np.array([-1.0, 0.0]), np.array([5000.0]))
+        _ = model_time.evaluate_sed(np.array([-1.0, 0.0]), np.array([5000.0]))
 
     # Trying to add points before max_phase for extrapolation after max_phase.
     with pytest.raises(ValueError):
-        _ = model_wave.evaluate_sed(np.array([0.0, 1.0]), np.array([5000.0]))
+        _ = model_time.evaluate_sed(np.array([0.0, 1.0]), np.array([5000.0]))
 
 
 def test_linear_linear_model_extrapolators_wave_too_small() -> None:
     """Test that we correctly fail when the model does not have a large enough
     wavelength range to add the needed extrapolation points.
     """
-    wave_extrapolator = LinearDecay(decay_width=500.0)  # 500 angstroms to zero
+    wave_extrapolator = LinearFit(nfit=2)  # Fit from 2 points
     time_extrapolator = LinearDecay(decay_width=100.0)  # 100 days to zero
     model_wave = _LinearLinearTestModel(
         wave_extrapolation=wave_extrapolator,
         time_extrapolation=time_extrapolator,
         t0=0.0,
         min_wave=5000.0,
-        max_wave=5005.0,  # Less then 10.0 A away
+        max_wave=5005.0,  # Less than 10.0 A away
     )
 
     # Trying to add points after min_wave for extrapolation before min_wave.
@@ -621,6 +621,27 @@ def test_linear_bandflux_model_ooo_time():
     values5 = model5.compute_bandflux_with_extrapolation(query_times, "r", state5)
     expected5 = np.array([80.0, 90.0, 75.0, 120.0, 127.5, 145.0, 132.5, 135.0])
     assert np.allclose(values5, expected5)
+
+
+def test_linear_bandflux_model_time_too_small() -> None:
+    """Test that we correctly fail when the model does not have a large enough
+    time range to add the needed extrapolation points.
+    """
+    model_time = _LinearBandfluxTestModel(
+        time_extrapolation=LinearFit(nfit=2),
+        t0=0.0,
+        min_phase=0.0,
+        max_phase=0.1,  # Less than a day away.
+    )
+    state = model_time.sample_parameters(num_samples=1)
+
+    # Trying to add points after min_phase for extrapolation before min_phase.
+    with pytest.raises(ValueError):
+        _ = model_time.compute_bandflux_with_extrapolation(np.array([-1.0, 0.0]), "r", state)
+
+    # Trying to add points before max_phase for extrapolation after max_phase.
+    with pytest.raises(ValueError):
+        _ = model_time.compute_bandflux_with_extrapolation(np.array([0.0, 1.0]), "r", state)
 
 
 def test_linear_fit_extrapolation():


### PR DESCRIPTION
A slight modification to the model extrapolation code to handle the case where the extrapolator needs to add so many points that it extends beyond the model's bounds on the other side. This can happen because if we are using N points for extrapolation we:
- Add them every +1.0 day starting at `min_phase` to model all times before `min_phase`
- Add them every -1.0 day starting at `max_phase` to model all times before `max_phase`
- Add them every +10.0 A starting at `min_wave` to model all wavelengths before `min_wave` 
- Add them every -10.0 A starting at `max_wave` to model all wavelengths after `max_wave`
If N is high and the bounds are close, we can over shoot. This is very unlikely, but requires only a simple check to prevent.

We also update the method signature of the band-flux only's `evaluate_spectra` method to match the signature of the SED-model's `evaluate_spectra` method.