### PR TITLE
Fix Notebook Headings

### DIFF
--- a/docs/notebooks/pre_executed/modeldag_sampling.ipynb
+++ b/docs/notebooks/pre_executed/modeldag_sampling.ipynb
@@ -195,7 +195,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# The ModelDAGNode\n",
+    "## The ModelDAGNode\n",
     "\n",
     "LightCurveLynx provides a `ModelDAGNode` node to wrap `modeldag.ModelDAG`. Sampling this node samples all the parameters at once and makes them available via LightCurveLynx's dot notation."
    ]

--- a/docs/notebooks/pre_executed/snana_example.ipynb
+++ b/docs/notebooks/pre_executed/snana_example.ipynb
@@ -277,7 +277,7 @@
    "id": "993bfaab",
    "metadata": {},
    "source": [
-    "# More Realistic OpSim\n",
+    "## More Realistic OpSim\n",
     "\n",
     "Let's repeat the simulation using a real Rubin OpSim to get more realistic cadence and noise. We filter the time range to the same three month coverage as the above. We also remove the filters that we will not use."
    ]

--- a/docs/notebooks/sampling_positions.ipynb
+++ b/docs/notebooks/sampling_positions.ipynb
@@ -334,7 +334,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Sampling from a Model Distribution\n",
+    "## Sampling from a Model Distribution\n",
     "\n",
     "We can use built-in or custom defined distribution models for more specific sampling cases. As one example, consider the `MilkyWayCoordSampler` which samples from density distribution of the milky way. Below we use the density model defined in [Juric et al., 2008](https://iopscience.iop.org/article/10.1086/523619/pdf), but users can also define their own models."
    ]

--- a/docs/notebooks/saturation.ipynb
+++ b/docs/notebooks/saturation.ipynb
@@ -160,7 +160,7 @@
    "id": "deb8763c",
    "metadata": {},
    "source": [
-    "# Running the Simulation\n",
+    "## Running the Simulation\n",
     "\n",
     "We start by running the simulation for the model with no saturation. Since the `OpSim` has saturation thresholds provided, we control this by using the `apply_saturation` flag in simulation function."
    ]


### PR DESCRIPTION
The notebook headings with a single `#` get picked up a top-level notebooks in the https://lightcurvelynx.readthedocs.io/en/latest/notebooks.html page. This fixes that by using `##` level headings where those are more appropriate.