### PR TITLE
Fix part 1 of issue 955

### DIFF
--- a/src/lightcurvelynx/effects/extinction.py
+++ b/src/lightcurvelynx/effects/extinction.py
@@ -253,9 +253,9 @@ class ExtinctionEffect(EffectModel):
         The setter (function) for the extinction parameter E(B-V).
     r_v : float, optional
         The value for the extinction parameter R(V) if needed by the backend model.
-    frame : str, optional
+    frame : str
         The frame for extinction. 'rest' or 'observer'.
-    backend : str, optional
+    backend : str
         The backend extinction library to use. One of 'dust_extinction' or 'extinction'.
     ebv_param_name : str, optional
         The name of the ebv parameter. If the user wants to chain multiple extinction models,
@@ -340,7 +340,7 @@ class ExtinctionEffect(EffectModel):
 
         self._extinction_wrapper = self._BACKEND_TO_WRAPPER[self.backend](self.model_name, r_v=self.r_v)
 
-    def apply(self, flux_density, times=None, wavelengths=None, **kwargs):
+    def apply(self, flux_density, times=None, wavelengths=None, ebv=None, **kwargs):
         """Apply the extinction effect to the flux density.
 
         Parameters
@@ -352,17 +352,19 @@ class ExtinctionEffect(EffectModel):
         wavelengths : numpy.ndarray, optional
             A length N array of wavelengths (in angstroms).
         ebv : float, optional
-            The extinction parameter E(B-V). Raises an error if None is provided.
+            The extinction parameter E(B-V). This is not used if ebv_param_name
+            is set to something other than "ebv".
         **kwargs : `dict`, optional
-           Any additional keyword arguments. This must include the ebv parameter,
-           which has the name listed in ebv_param_name.
+           Any additional keyword arguments. If ebv_param_name is not "ebv" then,
+           this must include a value for parameter ebv_param_name.
 
         Returns
         -------
         flux_density : numpy.ndarray
             A length T x N matrix of flux densities after the effect is applied (in nJy).
         """
-        ebv = kwargs.pop(self.ebv_param_name, None)
+        if self.ebv_param_name != "ebv":
+            ebv = kwargs.pop(self.ebv_param_name, None)
         if ebv is None:
             raise ValueError(f"Invalid value for parameter {self.ebv_param_name} provided: {ebv}")
 

--- a/src/lightcurvelynx/effects/extinction.py
+++ b/src/lightcurvelynx/effects/extinction.py
@@ -249,14 +249,17 @@ class ExtinctionEffect(EffectModel):
     ----------
     extinction_model : str
         The name of the extinction model to use.
-    ebv : parameter
+    ebv : parameter, optional
         The setter (function) for the extinction parameter E(B-V).
     r_v : float, optional
         The value for the extinction parameter R(V) if needed by the backend model.
-    frame : str
+    frame : str, optional
         The frame for extinction. 'rest' or 'observer'.
-    backend : str
+    backend : str, optional
         The backend extinction library to use. One of 'dust_extinction' or 'extinction'.
+    ebv_param_name : str, optional
+        The name of the ebv parameter. If the user wants to chain multiple extinction models,
+        each model will need a unique ebv parameter name. Default: "ebv"
     **kwargs : `dict`, optional
         Any additional keyword arguments.
     """
@@ -274,6 +277,7 @@ class ExtinctionEffect(EffectModel):
         frame=None,
         r_v=None,
         backend=None,
+        ebv_param_name="ebv",
         **kwargs,
     ):
         self.model_name = extinction_model
@@ -282,7 +286,8 @@ class ExtinctionEffect(EffectModel):
 
         # Set up the effect parameters (ebv).
         super().__init__(**kwargs)
-        self.add_effect_parameter("ebv", ebv)
+        self.ebv_param_name = ebv_param_name
+        self.add_effect_parameter(ebv_param_name, ebv)
 
         # Set the frame.
         if frame == "observer":
@@ -335,7 +340,7 @@ class ExtinctionEffect(EffectModel):
 
         self._extinction_wrapper = self._BACKEND_TO_WRAPPER[self.backend](self.model_name, r_v=self.r_v)
 
-    def apply(self, flux_density, times=None, wavelengths=None, ebv=None, **kwargs):
+    def apply(self, flux_density, times=None, wavelengths=None, **kwargs):
         """Apply the extinction effect to the flux density.
 
         Parameters
@@ -349,14 +354,18 @@ class ExtinctionEffect(EffectModel):
         ebv : float, optional
             The extinction parameter E(B-V). Raises an error if None is provided.
         **kwargs : `dict`, optional
-           Any additional keyword arguments, including any additional
-           parameters needed to apply the effect.
+           Any additional keyword arguments. This must include the ebv parameter,
+           which has the name listed in ebv_param_name.
 
         Returns
         -------
         flux_density : numpy.ndarray
             A length T x N matrix of flux densities after the effect is applied (in nJy).
         """
+        ebv = kwargs.pop(self.ebv_param_name, None)
+        if ebv is None:
+            raise ValueError(f"Invalid value for parameter {self.ebv_param_name} provided: {ebv}")
+
         return self._extinction_wrapper.apply(
             flux_density,
             times=times,

--- a/src/lightcurvelynx/models/physical_model.py
+++ b/src/lightcurvelynx/models/physical_model.py
@@ -466,7 +466,8 @@ class SEDModel(BasePhysicalModel):
             Most users should NOT change this setting.
             Default: False
         """
-        # Add any effect parameters that are not already in the model.
+        # Add any effect parameters that are not already in the model. We can use None
+        # if the parameter already exists in the model.
         if not skip_params:
             for param_name, setter in effect.parameters.items():
                 if param_name not in self.setters:
@@ -476,6 +477,8 @@ class SEDModel(BasePhysicalModel):
                         description=f"Added parameter by effect {effect}",
                         allow_gradient=False,
                     )
+                elif setter is not None:
+                    raise ValueError(f"Tried to add duplicate parameter {param_name} to model.")
 
         # Add the effect to the appropriate list.
         if effect.rest_frame:

--- a/tests/lightcurvelynx/effects/test_effect_model.py
+++ b/tests/lightcurvelynx/effects/test_effect_model.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 from lightcurvelynx.effects.effect_model import EffectModel
+from lightcurvelynx.models.basic_models import ConstantSEDModel
 
 
 def test_effect_model() -> None:
@@ -22,3 +23,31 @@ def test_effect_model() -> None:
     # We cannot call apply on the base EffectModel
     with pytest.raises(NotImplementedError):
         _ = model.apply(np.zeros((5, 3)))
+
+
+def test_add_effect_model() -> None:
+    """The test that we can add an effect model."""
+    basic_model = ConstantSEDModel(brightness=1000.0, ra=15.0, dec=-10.0, node_label="test")
+    effect_model1 = EffectModel(param1=1.0, param2=2.0)
+    basic_model.add_effect(effect_model1)
+    state = basic_model.sample_parameters(num_samples=1)
+    assert state["test"]["brightness"] == 1000.0
+    assert state["test"]["ra"] == 15.0
+    assert state["test"]["dec"] == -10.0
+    assert state["test"]["param1"] == 1.0
+    assert state["test"]["param2"] == 2.0
+
+    # We fail if we try to add a parameter that is already in the model.
+    effect_model2 = EffectModel(brightness=25.0)
+    with pytest.raises(ValueError):
+        basic_model.add_effect(effect_model2)
+
+    # However if we set it the parameter's value to None, then it will reuse the model's value.
+    effect_model3 = EffectModel(brightness=None)
+    basic_model.add_effect(effect_model3)
+    state = basic_model.sample_parameters(num_samples=1)
+    assert state["test"]["brightness"] == 1000.0
+    assert state["test"]["ra"] == 15.0
+    assert state["test"]["dec"] == -10.0
+    assert state["test"]["param1"] == 1.0
+    assert state["test"]["param2"] == 2.0

--- a/tests/lightcurvelynx/effects/test_extinction.py
+++ b/tests/lightcurvelynx/effects/test_extinction.py
@@ -130,6 +130,9 @@ def test_extinction_effect_chain():
     assert state["test"]["ebv"] == pytest.approx(0.1)
     assert state["test"]["galaxy_ebv"] == pytest.approx(0.15)
 
+    # We can apply the extinction effect to a set of fluxes.
+    _ = model.evaluate_sed(np.array([1.0]), np.array([7000.0, 5200.0, 4800.0]), state)
+
 
 def test_pickle_extinction_models(subtests):
     """Test that we can pickle and unpickle extinction effects regardless of backend."""

--- a/tests/lightcurvelynx/effects/test_extinction.py
+++ b/tests/lightcurvelynx/effects/test_extinction.py
@@ -97,7 +97,7 @@ def test_set_frame():
 
 def test_extinction_effect_chain():
     """Test that we can chain two ExtinctionEffects."""
-    pytest.importorskip("dust_extinction")
+    pytest.importorskip("extinction")
     model = ConstantSEDModel(brightness=1000.0, ra=15.0, dec=-10.0, node_label="test")
 
     dust_effect = ExtinctionEffect(

--- a/tests/lightcurvelynx/effects/test_extinction.py
+++ b/tests/lightcurvelynx/effects/test_extinction.py
@@ -95,6 +95,42 @@ def test_set_frame():
         ExtinctionEffect("G23", ebv=0.1, r_v=3.1, frame="InvalidFrame", backend="dust_extinction")
 
 
+def test_extinction_effect_chain():
+    """Test that we can chain two ExtinctionEffects."""
+    pytest.importorskip("dust_extinction")
+    model = ConstantSEDModel(brightness=1000.0, ra=15.0, dec=-10.0, node_label="test")
+
+    dust_effect = ExtinctionEffect(
+        "odonnell94",
+        ebv=0.1,
+        r_v=3.1,
+        frame="rest",
+        backend="extinction",
+    )
+    model.add_effect(dust_effect)
+
+    # We fail if we try to add another dust effect that uses the same EBV name.
+    with pytest.raises(ValueError):
+        model.add_effect(dust_effect)
+
+    # Not really a galaxy effect, but we just need to test that we can handle the
+    # duplicate ebv parameter, using a different name.
+    galaxy_effect = ExtinctionEffect(
+        "odonnell94",
+        ebv=0.15,
+        r_v=3.1,
+        frame="rest",
+        backend="extinction",
+        ebv_param_name="galaxy_ebv",
+    )
+    model.add_effect(galaxy_effect)
+
+    # If we sample the model, we can see both ebv values (correctly named).
+    state = model.sample_parameters(num_samples=1)
+    assert state["test"]["ebv"] == pytest.approx(0.1)
+    assert state["test"]["galaxy_ebv"] == pytest.approx(0.15)
+
+
 def test_pickle_extinction_models(subtests):
     """Test that we can pickle and unpickle extinction effects regardless of backend."""
     pytest.importorskip("dust_extinction")

--- a/tests/lightcurvelynx/effects/test_extinction.py
+++ b/tests/lightcurvelynx/effects/test_extinction.py
@@ -131,7 +131,8 @@ def test_extinction_effect_chain():
     assert state["test"]["galaxy_ebv"] == pytest.approx(0.15)
 
     # We can apply the extinction effect to a set of fluxes.
-    _ = model.evaluate_sed(np.array([1.0]), np.array([7000.0, 5200.0, 4800.0]), state)
+    fluxes = model.evaluate_sed(np.array([1.0]), np.array([7000.0, 5200.0, 4800.0]), state)
+    assert np.all(np.isfinite(fluxes))
 
 
 def test_pickle_extinction_models(subtests):


### PR DESCRIPTION
## Change Description
Addresses the first part of #955 where `add_effect` is silently dropping parameters. This PR adds a check that the parameter name does not exist already OR that the new setter value is `None` (which means use the existing value). This later condition is needed to allow effects to access existing model parameters such as ra and dec.

Since this was discovered when chaining extinction models, we also add a path for extinction models to rename their ebv parameter. This allows users to apply multiple extinction models as long as they explicitly override the parameter names. 