### PR TITLE
Fix part 3 of issue 955

### DIFF
--- a/src/lightcurvelynx/models/lightcurve_template_model.py
+++ b/src/lightcurvelynx/models/lightcurve_template_model.py
@@ -946,7 +946,7 @@ class MultiLightcurveTemplateModel(BaseLightcurveBandTemplateModel):
             raise ValueError("Filter must be provided to compute minphase.")
         if graph_state is None:
             raise ValueError("Graph state must be provided to compute minphase.")
-        if graph_state.num_samples > 1:
+        if graph_state.num_samples != 1:
             raise ValueError("Graph state must have num_samples=1 to compute maxphase.")
 
         model_ind = self.get_param(graph_state, "selected_lightcurve")
@@ -979,7 +979,7 @@ class MultiLightcurveTemplateModel(BaseLightcurveBandTemplateModel):
             raise ValueError("Filter must be provided to compute maxphase.")
         if graph_state is None:
             raise ValueError("Graph state must be provided to compute maxphase.")
-        if graph_state.num_samples > 1:
+        if graph_state.num_samples != 1:
             raise ValueError("Graph state must have num_samples=1 to compute maxphase.")
 
         model_ind = self.get_param(graph_state, "selected_lightcurve")

--- a/src/lightcurvelynx/models/lightcurve_template_model.py
+++ b/src/lightcurvelynx/models/lightcurve_template_model.py
@@ -947,7 +947,7 @@ class MultiLightcurveTemplateModel(BaseLightcurveBandTemplateModel):
         if graph_state is None:
             raise ValueError("Graph state must be provided to compute minphase.")
         if graph_state.num_samples != 1:
-            raise ValueError("Graph state must have num_samples=1 to compute maxphase.")
+            raise ValueError("Graph state must have num_samples=1 to compute minphase.")
 
         model_ind = self.get_param(graph_state, "selected_lightcurve")
         lc_model = self.lightcurves[model_ind]

--- a/src/lightcurvelynx/models/multi_object_model.py
+++ b/src/lightcurvelynx/models/multi_object_model.py
@@ -485,7 +485,7 @@ class RandomMultiObjectModel(MultiObjectModel):
             if the model does not have a defined maximum phase.
         """
         if graph_state is None or graph_state.num_samples != 1:
-            raise ValueError("A 1 sample graph_state must be provided to determine wavelength bounds.")
+            raise ValueError("A 1 sample graph_state must be provided to determine time bounds.")
         name = self.get_param(graph_state, "selected_object")
         return self.object_map[name].maxphase(graph_state=graph_state)
 

--- a/src/lightcurvelynx/models/multi_object_model.py
+++ b/src/lightcurvelynx/models/multi_object_model.py
@@ -217,8 +217,10 @@ class AdditiveMultiObjectModel(MultiObjectModel):
 
     Note
     ----
-    Each model may have its own sampled (RA, dec) position, which are not
+    * Each model may have its own sampled (RA, dec) position, which are not
     required to align.
+    * Bounds checking and extrapolation is performed on each submodel independently, allowing
+    them to have different wavelength ranges.
 
     Attributes
     ----------
@@ -255,94 +257,6 @@ class AdditiveMultiObjectModel(MultiObjectModel):
             raise ValueError("Length of weights must match length of objects.")
         else:
             self.weights = weights
-
-    def minwave(self, graph_state=None):
-        """Get the minimum wavelength of the model. For additive models, this is
-        a list of minimums for each object.
-
-        Note
-        ----
-        Wavelength extrapolation is handled by each object. So the actual wavelength's
-        can be evaluated outside the range of each object.
-
-        Parameters
-        ----------
-        graph_state : GraphState, optional
-            An object mapping graph parameters to their values. If provided,
-            the function will use the graph state to compute the minimum wavelength.
-
-        Returns
-        -------
-        minwave : list of float or None
-            The minimum wavelength of the each object (in angstroms) or None
-        """
-        return [object.minwave(graph_state=graph_state) for object in self.objects]
-
-    def maxwave(self, graph_state=None):
-        """Get the maximum wavelength of the model. For additive models, this is
-        a list of maximums for each object.
-
-        Note
-        ----
-        Wavelength extrapolation is handled by each object. So the actual wavelength's
-        can be evaluated outside the range of each object.
-
-        Parameters
-        ----------
-        graph_state : GraphState, optional
-            An object mapping graph parameters to their values. If provided,
-            the function will use the graph state to compute the maximum wavelength.
-
-        Returns
-        -------
-        maxwave : list of float or None
-            The maximum wavelength of the each object (in angstroms) or None
-        """
-        return [object.maxwave(graph_state=graph_state) for object in self.objects]
-
-    def minphase(self, graph_state=None):
-        """Get the minimum phase of the model. For additive models, this is
-        a list of minimums for each object.
-
-        Note
-        ----
-        Phase extrapolation is handled by each object. So the actual phase's
-        can be evaluated outside the range of each object.
-
-        Parameters
-        ----------
-        graph_state : GraphState, optional
-            An object mapping graph parameters to their values. If provided,
-            the function will use the graph state to compute the minimum phase.
-
-        Returns
-        -------
-        minphase : list of float or None
-            The minimum phase of the each object (in days) or None
-        """
-        return [object.minphase(graph_state=graph_state) for object in self.objects]
-
-    def maxphase(self, graph_state=None):
-        """Get the maximum phase of the model. For additive models, this is
-        a list of maximums for each object.
-
-        Note
-        ----
-        Phase extrapolation is handled by each object. So the actual phase's
-        can be evaluated outside the range of each object.
-
-        Parameters
-        ----------
-        graph_state : GraphState, optional
-            An object mapping graph parameters to their values. If provided,
-            the function will use the graph state to compute the maximum phase.
-
-        Returns
-        -------
-        maxphase : list of float or None
-            The maximum phase of the each object (in days) or None
-        """
-        return [object.maxphase(graph_state=graph_state) for object in self.objects]
 
     def _evaluate_single(self, times, wavelengths, state, **kwargs):
         """Evaluate the model and apply the effects for a single, given graph state.

--- a/src/lightcurvelynx/models/multi_object_model.py
+++ b/src/lightcurvelynx/models/multi_object_model.py
@@ -300,6 +300,50 @@ class AdditiveMultiObjectModel(MultiObjectModel):
         """
         return [object.maxwave(graph_state=graph_state) for object in self.objects]
 
+    def minphase(self, graph_state=None):
+        """Get the minimum phase of the model. For additive models, this is
+        a list of minimums for each object.
+
+        Note
+        ----
+        Phase extrapolation is handled by each object. So the actual phase's
+        can be evaluated outside the range of each object.
+
+        Parameters
+        ----------
+        graph_state : GraphState, optional
+            An object mapping graph parameters to their values. If provided,
+            the function will use the graph state to compute the minimum phase.
+
+        Returns
+        -------
+        minphase : list of float or None
+            The minimum phase of the each object (in days) or None
+        """
+        return [object.minphase(graph_state=graph_state) for object in self.objects]
+
+    def maxphase(self, graph_state=None):
+        """Get the maximum phase of the model. For additive models, this is
+        a list of maximums for each object.
+
+        Note
+        ----
+        Phase extrapolation is handled by each object. So the actual phase's
+        can be evaluated outside the range of each object.
+
+        Parameters
+        ----------
+        graph_state : GraphState, optional
+            An object mapping graph parameters to their values. If provided,
+            the function will use the graph state to compute the maximum phase.
+
+        Returns
+        -------
+        maxphase : list of float or None
+            The maximum phase of the each object (in days) or None
+        """
+        return [object.maxphase(graph_state=graph_state) for object in self.objects]
+
     def _evaluate_single(self, times, wavelengths, state, **kwargs):
         """Evaluate the model and apply the effects for a single, given graph state.
         This function applies redshift, computes the flux density for the object,
@@ -466,6 +510,8 @@ class RandomMultiObjectModel(MultiObjectModel):
             The minimum wavelength of the model (in angstroms) or None
             if the model does not have a defined minimum wavelength.
         """
+        if graph_state is None or graph_state.num_samples != 1:
+            raise ValueError("A 1 sample graph_state must be provided to determine wavelength bounds.")
         name = self.get_param(graph_state, "selected_object")
         return self.object_map[name].minwave(graph_state=graph_state)
 
@@ -484,8 +530,50 @@ class RandomMultiObjectModel(MultiObjectModel):
             The maximum wavelength of the model (in angstroms) or None
             if the model does not have a defined maximum wavelength.
         """
+        if graph_state is None or graph_state.num_samples != 1:
+            raise ValueError("A 1 sample graph_state must be provided to determine wavelength bounds.")
         name = self.get_param(graph_state, "selected_object")
         return self.object_map[name].maxwave(graph_state=graph_state)
+
+    def minphase(self, graph_state=None):
+        """Get the minimum supported phase of the model in days.
+
+        Parameters
+        ----------
+        graph_state : GraphState, optional
+            An object mapping graph parameters to their values. If provided,
+            the function will use the graph state to compute the minimum phase.
+
+        Returns
+        -------
+        minphase : float or None
+            The minimum phase of the model (in days) or None
+            if the model does not have a defined minimum phase.
+        """
+        if graph_state is None or graph_state.num_samples != 1:
+            raise ValueError("A 1 sample graph_state must be provided to determine time bounds.")
+        name = self.get_param(graph_state, "selected_object")
+        return self.object_map[name].minphase(graph_state=graph_state)
+
+    def maxphase(self, graph_state=None):
+        """Get the maximum supported phase of the model in days.
+
+        Parameters
+        ----------
+        graph_state : GraphState, optional
+            An object mapping graph parameters to their values. If provided,
+            the function will use the graph state to compute the maximum phase.
+
+        Returns
+        -------
+        maxphase : float or None
+            The maximum phase of the model (in days) or None
+            if the model does not have a defined maximum phase.
+        """
+        if graph_state is None or graph_state.num_samples != 1:
+            raise ValueError("A 1 sample graph_state must be provided to determine wavelength bounds.")
+        name = self.get_param(graph_state, "selected_object")
+        return self.object_map[name].maxphase(graph_state=graph_state)
 
     def _evaluate_single(self, times, wavelengths, state, **kwargs):
         """Evaluate the model and apply the effects for a single, given graph state.

--- a/src/lightcurvelynx/models/sed_template_model.py
+++ b/src/lightcurvelynx/models/sed_template_model.py
@@ -14,7 +14,7 @@ import astropy.units as u
 import numpy as np
 import yaml
 from citation_compass import cite_inline
-from scipy.interpolate import RectBivariateSpline
+from scipy.interpolate import RectBivariateSpline, interp1d
 from tqdm import tqdm
 
 from lightcurvelynx.astro_utils.unit_utils import flam_to_fnu
@@ -36,6 +36,8 @@ class SEDTemplate:
         A length T array of the times for the SED relative to the reference epoch.
     interp : scipy.interpolate object
         The type of interpolation to use. One of 'linear' or 'spline'.
+    baseline_interp : scipy.interpolate object or None
+        The interpolation object for the baseline SED values, if provided. None if no baseline is used.
     period : float or None
         The period of this data, if it is periodic. Default is None.
 
@@ -75,6 +77,16 @@ class SEDTemplate:
             )
         self.phases, self.wavelengths, sed_values = SEDTemplate._three_column_to_matrix(grid_data)
 
+        # Check that the data is not empty and sorted.
+        if len(self.phases) == 0:
+            raise ValueError("Phases array is empty.")  # pragma: no cover
+        if len(self.wavelengths) == 0:
+            raise ValueError("Wavelengths array is empty.")  # pragma: no cover
+        if not np.all(np.diff(self.phases) >= 0):
+            raise ValueError("Phases must be sorted in ascending order.")  # pragma: no cover
+        if not np.all(np.diff(self.wavelengths) >= 0):
+            raise ValueError("Wavelengths must be sorted in ascending order.")  # pragma: no cover
+
         # Apply the sed_data_t0 offset to the phases to get the times.
         self.times = self.phases - sed_data_t0
 
@@ -103,6 +115,7 @@ class SEDTemplate:
             self.period = None
 
         # Set up the interpolation object for this SED.
+        self._interpolation_type = interpolation_type
         interp_degree = 3 if interpolation_type == "cubic" else 1
         self.interp = RectBivariateSpline(
             self.times,
@@ -111,6 +124,15 @@ class SEDTemplate:
             kx=interp_degree,
             ky=interp_degree,
         )
+
+        if self.baseline is not None:
+            self.baseline_interp = interp1d(
+                self.wavelengths,
+                self.baseline,
+                kind=self._interpolation_type,
+                bounds_error=False,
+                fill_value=0.0,
+            )
 
     @property
     def is_periodic(self):
@@ -195,14 +217,22 @@ class SEDTemplate:
         sed_values : np.ndarray
             A (T x W) matrix of SED values (in the given units) at the given times and wavelengths.
         """
+        sed_values = np.zeros((len(times), len(wavelengths)))
+
         if self.period is None:
-            sed_values = np.zeros((len(times), len(wavelengths)))
+            # Check which times and wavelengths are in range and only evaluate those.
+            time_in_range = (times >= self.times[0]) & (times <= self.times[-1])
+            wave_in_range = (wavelengths >= self.wavelengths[0]) & (wavelengths <= self.wavelengths[-1])
+            query_waves = wavelengths[wave_in_range]
 
-            in_range = (times >= self.times[0]) & (times <= self.times[-1])
-            sed_values[in_range, :] = self.interp(times[in_range], wavelengths, grid=True)
+            sed_values[np.ix_(time_in_range, wave_in_range)] = self.interp(
+                times[time_in_range], query_waves, grid=True
+            )
 
+            # Outside the time tange use the (wavelength-interpolated) baseline value.
             if self.baseline is not None:
-                sed_values[~in_range, :] = self.baseline[np.newaxis, :]
+                baseline_values = self.baseline_interp(query_waves)
+                sed_values[np.ix_(~time_in_range, wave_in_range)] = baseline_values
         else:
             # Create the modulo times for periodic evaluation and an inverse mapping to original order.
             times = np.mod(times, self.period)
@@ -210,8 +240,12 @@ class SEDTemplate:
             inv_idx = np.empty_like(argsort_idx)
             inv_idx[argsort_idx] = np.arange(len(times))
 
-            sed_values = self.interp(times[argsort_idx], wavelengths, grid=True)
-            sed_values = sed_values[inv_idx, :]
+            # Check which wavelengths are in range and only evaluate those.
+            wave_in_range = (wavelengths >= self.wavelengths[0]) & (wavelengths <= self.wavelengths[-1])
+            query_waves = wavelengths[wave_in_range]
+
+            partial_sed_values = self.interp(times[argsort_idx], query_waves, grid=True)
+            sed_values[np.ix_(np.arange(len(times)), wave_in_range)] = partial_sed_values[inv_idx, :]
         return sed_values
 
     @staticmethod
@@ -258,6 +292,8 @@ class SEDTemplateModel(SEDModel):
     is not periodic then the given values will be interpolated during the time range
     of the template. Values outside the time range (before and after) will be set to
     the baseline value for that wavelength (0.0 by default).
+
+    The values for all wavelengths outside the range of the data will be zero.
 
     Parameterized values include:
 
@@ -355,6 +391,74 @@ class SEDTemplateModel(SEDModel):
     def wavelengths(self):
         """The wavelengths of the template data (in Angstroms)."""
         return self.template.wavelengths
+
+    def minwave(self, **kwargs):
+        """Get the minimum supported wavelength of the model.
+
+        Parameters
+        ----------
+        **kwargs : dict
+            Additional keyword arguments, not used in this method.
+
+        Returns
+        -------
+        minwave : float or None
+            The minimum wavelength of the model (in angstroms) or None
+            if the model does not have a defined minimum wavelength.
+        """
+        return self.wavelengths[0]
+
+    def maxwave(self, **kwargs):
+        """Get the maximum supported wavelength of the model.
+
+        Parameters
+        ----------
+        **kwargs : dict
+            Additional keyword arguments, not used in this method.
+
+        Returns
+        -------
+        maximum : float or None
+            The maximum wavelength of the model (in angstroms) or None
+            if the model does not have a defined maximum wavelength.
+        """
+        return self.wavelengths[-1]
+
+    def minphase(self, **kwargs):
+        """Get the minimum supported phase of the model in days.
+
+        Parameters
+        ----------
+        **kwargs : dict
+            Additional keyword arguments, not used in this method.
+
+        Returns
+        -------
+        minphase : float or None
+            The minimum phase of the model (in days) or None
+            if the model does not have a defined minimum phase.
+        """
+        if self.template.is_periodic:
+            return None
+        return self.times[0]
+
+    def maxphase(self, **kwargs):
+        """Get the maximum supported phase of the model in days.
+
+        Parameters
+        ----------
+        **kwargs : dict
+            Additional keyword arguments, not used in this method.
+
+        Returns
+        -------
+        maximum : float or None
+            The maximum phase of the model (in days) or None
+            if the model does not have a defined maximum phase.
+        """
+        if self.template.is_periodic:
+            return None
+        return self.times[-1]
 
     def compute_sed(self, times, wavelengths, graph_state):
         """Draw effect-free observer frame flux densities.

--- a/src/lightcurvelynx/models/sed_template_model.py
+++ b/src/lightcurvelynx/models/sed_template_model.py
@@ -35,7 +35,7 @@ class SEDTemplate:
     times : np.ndarray
         A length T array of the times for the SED relative to the reference epoch.
     interp : scipy.interpolate object
-        The type of interpolation to use. One of 'linear' or 'spline'.
+        The type of interpolation to use. One of 'linear' or 'cubic'.
     baseline_interp : scipy.interpolate object or None
         The interpolation object for the baseline SED values, if provided. None if no baseline is used.
     period : float or None
@@ -229,7 +229,7 @@ class SEDTemplate:
                 times[time_in_range], query_waves, grid=True
             )
 
-            # Outside the time tange use the (wavelength-interpolated) baseline value.
+            # Outside the time range use the (wavelength-interpolated) baseline value.
             if self.baseline is not None:
                 baseline_values = self.baseline_interp(query_waves)
                 sed_values[np.ix_(~time_in_range, wave_in_range)] = baseline_values

--- a/src/lightcurvelynx/models/sed_template_model.py
+++ b/src/lightcurvelynx/models/sed_template_model.py
@@ -438,7 +438,7 @@ class SEDTemplateModel(SEDModel):
             The minimum phase of the model (in days) or None
             if the model does not have a defined minimum phase.
         """
-        if self.template.is_periodic:
+        if self.template.is_periodic or self.template.baseline is not None:
             return None
         return self.times[0]
 
@@ -456,7 +456,7 @@ class SEDTemplateModel(SEDModel):
             The maximum phase of the model (in days) or None
             if the model does not have a defined maximum phase.
         """
-        if self.template.is_periodic:
+        if self.template.is_periodic or self.template.baseline is not None:
             return None
         return self.times[-1]
 

--- a/src/lightcurvelynx/models/sed_template_model.py
+++ b/src/lightcurvelynx/models/sed_template_model.py
@@ -536,6 +536,92 @@ class MultiSEDTemplateModel(SEDModel):
         """Get the number of SED templates."""
         return len(self.templates)
 
+    def minwave(self, graph_state=None):
+        """Get the minimum wavelength of the model.
+
+        Parameters
+        ----------
+        graph_state : GraphState, optional
+            An object mapping graph parameters to their values. If provided,
+            the function will use the graph state to compute the minimum wavelength.
+
+        Returns
+        -------
+        minwave : float, list of float, or None
+            The minimum wavelength of the model (in angstroms) or None
+            if the model does not have a defined minimum wavelength.
+        """
+        if graph_state is None or graph_state.num_samples != 1:
+            raise ValueError("A 1 sample graph_state must be provided to determine wavelength bounds.")
+        template_id = self.get_param(graph_state, "selected_template")
+        return self.templates[template_id].wavelengths[0]
+
+    def maxwave(self, graph_state=None):
+        """Get the maximum wavelength of the model.
+
+        Parameters
+        ----------
+        graph_state : GraphState, optional
+            An object mapping graph parameters to their values. If provided,
+            the function will use the graph state to compute the maximum wavelength.
+
+        Returns
+        -------
+        maxwave : float or None
+            The maximum wavelength of the model (in angstroms) or None
+            if the model does not have a defined maximum wavelength.
+        """
+        if graph_state is None or graph_state.num_samples != 1:
+            raise ValueError("A 1 sample graph_state must be provided to determine wavelength bounds.")
+        template_id = self.get_param(graph_state, "selected_template")
+        return self.templates[template_id].wavelengths[-1]
+
+    def minphase(self, graph_state=None):
+        """Get the minimum phase of the model in days.
+
+        Parameters
+        ----------
+        graph_state : GraphState, optional
+            An object mapping graph parameters to their values. If provided,
+            the function will use the graph state to compute the minimum phase.
+
+        Returns
+        -------
+        minphase : float or None
+            The minimum phase of the model (in days) or None
+            if the model does not have a defined minimum phase.
+        """
+        if graph_state is None or graph_state.num_samples != 1:
+            raise ValueError("A 1 sample graph_state must be provided to determine time bounds.")
+        template_id = self.get_param(graph_state, "selected_template")
+        template = self.templates[template_id]
+        if template.is_periodic or template.baseline is not None:
+            return None
+        return template.times[0]
+
+    def maxphase(self, graph_state=None):
+        """Get the maximum phase of the model in days.
+
+        Parameters
+        ----------
+        graph_state : GraphState, optional
+            An object mapping graph parameters to their values. If provided,
+            the function will use the graph state to compute the maximum phase.
+
+        Returns
+        -------
+        maxphase : float or None
+            The maximum phase of the model (in days) or None
+            if the model does not have a defined maximum phase.
+        """
+        if graph_state is None or graph_state.num_samples != 1:
+            raise ValueError("A 1 sample graph_state must be provided to determine time bounds.")
+        template_id = self.get_param(graph_state, "selected_template")
+        template = self.templates[template_id]
+        if template.is_periodic or template.baseline is not None:
+            return None
+        return template.times[-1]
+
     def compute_sed(self, times, wavelengths, graph_state):
         """Draw effect-free observer frame flux densities.
 

--- a/tests/lightcurvelynx/astro_utils/test_passband_groups.py
+++ b/tests/lightcurvelynx/astro_utils/test_passband_groups.py
@@ -10,6 +10,7 @@ from astropy import units as u
 from astropy.table import Table
 from lightcurvelynx.astro_utils.passbands import Passband, PassbandGroup
 from lightcurvelynx.models.sed_template_model import SEDTemplateModel
+from lightcurvelynx.utils.extrapolate import ZeroPadding
 
 
 def create_lsst_passband_group(passbands_dir, delta_wave=5.0, trim_quantile=None):
@@ -620,21 +621,28 @@ def test_passband_group_wrapped_from_physical_source(passbands_dir, tmp_path):
     # Set up physical model
     sed_values = np.array(
         [
-            [1.0, 10.0, 1.0],
-            [1.0, 20.0, 5.0],
-            [1.0, 30.0, 1.0],
-            [2.0, 10.0, 5.0],
-            [2.0, 20.0, 10.0],
-            [2.0, 30.0, 5.0],
-            [3.0, 10.0, 1.0],
-            [3.0, 20.0, 5.0],
-            [3.0, 30.0, 3.0],
+            [1.0, 1000.0, 1.0],
+            [1.0, 2000.0, 5.0],
+            [1.0, 3000.0, 1.0],
+            [2.0, 1000.0, 5.0],
+            [2.0, 2000.0, 10.0],
+            [2.0, 3000.0, 5.0],
+            [3.0, 1000.0, 1.0],
+            [3.0, 2000.0, 5.0],
+            [3.0, 3000.0, 3.0],
         ]
     )
-    model = SEDTemplateModel(sed_values, sed_data_t0=0.0, t0=0.0, interpolation_type="linear")
+    model = SEDTemplateModel(
+        sed_values,
+        sed_data_t0=0.0,
+        t0=0.0,
+        interpolation_type="linear",
+        time_extrapolation=ZeroPadding(),
+        wave_extrapolation=ZeroPadding(),
+    )
     state = model.sample_parameters()
 
-    test_times = np.array([1.0, 1.5, 2.0, 2.5, 3.0, 3.5])
+    test_times = np.array([1.0, 1.5, 2.0, 2.5, 3.0])
 
     # Test wrapper with a PassbandGroup as input (see Passband tests for single-band tests)
     # Using LSST passband group:

--- a/tests/lightcurvelynx/astro_utils/test_passbands.py
+++ b/tests/lightcurvelynx/astro_utils/test_passbands.py
@@ -13,6 +13,7 @@ from astropy import units as u
 from astropy.table import Table
 from lightcurvelynx.astro_utils.passbands import Passband
 from lightcurvelynx.models.sed_template_model import SEDTemplateModel
+from lightcurvelynx.utils.extrapolate import ZeroPadding
 
 
 def create_lsst_passband(path, filter_name, **kwargs):
@@ -661,18 +662,25 @@ def test_passband_wrapped_from_physical_source(passbands_dir, tmp_path):
     # Set up physical model
     sed_values = np.array(
         [
-            [1.0, 10.0, 1.0],
-            [1.0, 20.0, 5.0],
-            [1.0, 30.0, 1.0],
-            [2.0, 10.0, 5.0],
-            [2.0, 20.0, 10.0],
-            [2.0, 30.0, 5.0],
-            [3.0, 10.0, 1.0],
-            [3.0, 20.0, 5.0],
-            [3.0, 30.0, 3.0],
+            [1.0, 1000.0, 1.0],
+            [1.0, 2000.0, 5.0],
+            [1.0, 3000.0, 1.0],
+            [2.0, 1000.0, 5.0],
+            [2.0, 2000.0, 10.0],
+            [2.0, 3000.0, 5.0],
+            [3.0, 1000.0, 1.0],
+            [3.0, 2000.0, 5.0],
+            [3.0, 3000.0, 3.0],
         ]
     )
-    model = SEDTemplateModel(sed_values, sed_data_t0=0.0, interpolation_type="linear", t0=0.0)
+    model = SEDTemplateModel(
+        sed_values,
+        sed_data_t0=0.0,
+        interpolation_type="linear",
+        t0=0.0,
+        time_extrapolation=ZeroPadding(),
+        wave_extrapolation=ZeroPadding(),
+    )
     state = model.sample_parameters()
 
     test_times = np.array([1.0, 1.5, 2.0, 2.5, 3.0, 3.5])

--- a/tests/lightcurvelynx/models/test_multi_object_models.py
+++ b/tests/lightcurvelynx/models/test_multi_object_models.py
@@ -242,34 +242,6 @@ def test_additive_multi_object_node_effects_obs_frame() -> None:
     assert np.allclose(values, contrib1 + contrib2)
 
 
-def test_additive_multi_object_node_min_max() -> None:
-    """Test that we can get the correct wavelength limits for a AdditiveMultiObjectModel."""
-    sed0 = np.array(
-        [
-            [100.0, 200.0, 300.0, 400.0],  # Wavelengths
-            [10.0, 20.0, 20.0, 10.0],  # fluxes
-        ]
-    )
-    model0 = StaticSEDModel([sed0], node_label="sed0")
-
-    sed1 = np.array(
-        [
-            [200.0, 300.0, 400.0, 500.0],  # Wavelengths
-            [20.0, 40.0, 40.0, 20.0],  # fluxes
-        ]
-    )
-    model1 = StaticSEDModel([sed1], node_label="sed1")
-
-    # The reported min/max wavelengths are the overlap of the objects.
-    model = AdditiveMultiObjectModel(
-        [model0, model1],
-        node_label="test",
-    )
-    states = model.sample_parameters(num_samples=1)
-    assert np.array_equal(model.minwave(states), [100.0, 200.0])
-    assert np.array_equal(model.maxwave(states), [400.0, 500.0])
-
-
 def test_additive_multi_object_node_bandflux() -> None:
     """Test that we can create and evaluate an AdditiveMultiObjectModel with Bandflux models."""
     object1 = StaticBandfluxModel({"a": 1.0, "b": 2.0, "c": 0.0}, node_label="object1")

--- a/tests/lightcurvelynx/models/test_multi_object_models.py
+++ b/tests/lightcurvelynx/models/test_multi_object_models.py
@@ -447,14 +447,33 @@ def test_random_multi_object_node_min_max() -> None:
     states.set("test", "selected_object", "sed0")
     assert model.minwave(states) == 100.0
     assert model.maxwave(states) == 400.0
+    assert model.minphase(states) is None
+    assert model.maxphase(states) is None
 
     # Force the selected_object to be 1 for the test.
     states.set("test", "selected_object", "sed1")
     assert model.minwave(states) == 200.0
     assert model.maxwave(states) == 500.0
+    assert model.minphase(states) is None
+    assert model.maxphase(states) is None
 
     # We fail if we do not pass in the states.
     with pytest.raises(ValueError):
         _ = model.minwave()
     with pytest.raises(ValueError):
         _ = model.maxwave()
+    with pytest.raises(ValueError):
+        _ = model.minphase()
+    with pytest.raises(ValueError):
+        _ = model.maxphase()
+
+    # We fail if we pass states with more than one sample.
+    states2 = model.sample_parameters(num_samples=10)
+    with pytest.raises(ValueError):
+        _ = model.minwave(graph_state=states2)
+    with pytest.raises(ValueError):
+        _ = model.maxwave(graph_state=states2)
+    with pytest.raises(ValueError):
+        _ = model.minphase(graph_state=states2)
+    with pytest.raises(ValueError):
+        _ = model.maxphase(graph_state=states2)

--- a/tests/lightcurvelynx/models/test_sed_template_model.py
+++ b/tests/lightcurvelynx/models/test_sed_template_model.py
@@ -49,7 +49,7 @@ def test_linear_sed_template_data() -> None:
     expected_values = np.array([[0.0], [12.5], [17.5], [0.0]])
     assert np.allclose(sed_values, expected_values)
 
-    # That that we correct for sed_data_t0.
+    # Note that we correct for sed_data_t0.
     data_obj2 = SEDTemplate(
         data,
         interpolation_type="linear",
@@ -447,9 +447,9 @@ def test_create_multi_sed_template_model() -> None:
     assert np.allclose(sed_values[~chose_first, 0, 0], 22.5)
 
 
-def test_create_multi_sed_template_model_counds() -> None:
-    """Test that we can create a MultiSEDTemplateModel objects from templates
-    with different time and waavelenght bounds."""
+def test_create_multi_sed_template_model_bounds() -> None:
+    """Test that we can create a MultiSEDTemplateModel object from templates
+    with different time and wavelength bounds."""
     data1 = np.array(
         [
             [0.0, 1000.0, 5.0],

--- a/tests/lightcurvelynx/models/test_sed_template_model.py
+++ b/tests/lightcurvelynx/models/test_sed_template_model.py
@@ -39,7 +39,17 @@ def test_linear_sed_template_data() -> None:
     )
     assert np.allclose(sed_values, expected_values)
 
-    # We correct for sed_data_t0.
+    # Test that we correctly broadcast everything when we only have
+    # a single query time or wavelength.
+    sed_values = data_obj.evaluate_sed(np.array([1.5]), eval_waves)
+    expected_values = np.array([[12.5, 22.5]])
+    assert np.allclose(sed_values, expected_values)
+
+    sed_values = data_obj.evaluate_sed(eval_times, np.array([1000.0]))
+    expected_values = np.array([[0.0], [12.5], [17.5], [0.0]])
+    assert np.allclose(sed_values, expected_values)
+
+    # That that we correct for sed_data_t0.
     data_obj2 = SEDTemplate(
         data,
         interpolation_type="linear",
@@ -92,6 +102,69 @@ def test_linear_sed_template_data() -> None:
             periodic=False,
             baseline=np.array([1.0, 2.0, 3.0]),
         )
+
+
+def test_linear_sed_template_data_wavelength_bounds() -> None:
+    """Test that we can create a SEDTemplate object and handle queries with
+    wavelengths outside the range of the data. The flux for those wavelengths
+    should be zero.
+    """
+    data = np.array(
+        [
+            [1.0, 1000.0, 10.0],
+            [1.0, 2000.0, 20.0],
+            [2.0, 1000.0, 15.0],
+            [2.0, 2000.0, 25.0],
+            [3.0, 1000.0, 20.0],
+            [3.0, 2000.0, 30.0],
+        ]
+    )
+    baseline = np.array([1.0, 2.0])
+    data_obj = SEDTemplate(data, interpolation_type="linear", periodic=False, baseline=baseline)
+
+    eval_times = np.array([0.5, 1.5, 2.5, 3.5])
+    eval_waves = np.array([500.0, 1000.0, 1500.0, 2000.0, 2500.0])
+    sed_values = data_obj.evaluate_sed(eval_times, eval_waves)
+    expected_values = np.array(
+        [
+            [0.0, 1.0, 1.5, 2.0, 0.0],  # T before uses baseline.
+            [0.0, 12.5, 17.5, 22.5, 0.0],
+            [0.0, 17.5, 22.5, 27.5, 0.0],
+            [0.0, 1.0, 1.5, 2.0, 0.0],  # T after uses baseline.
+        ]
+    )
+    assert np.allclose(sed_values, expected_values)
+
+    # Check that we correctly handle the periodic case.
+    data2 = np.array(
+        [
+            [0.0, 1000.0, 10.0],
+            [0.0, 2000.0, 20.0],
+            [1.0, 1000.0, 15.0],
+            [1.0, 2000.0, 25.0],
+            [2.0, 1000.0, 20.0],
+            [2.0, 2000.0, 30.0],
+            [3.0, 1000.0, 10.0],
+            [3.0, 2000.0, 20.0],
+        ]
+    )
+    data_obj2 = SEDTemplate(data2, interpolation_type="linear", periodic=True)
+    eval_times = np.array([-0.5, 0.0, 0.5, 1.0, 1.5, 2.0, 2.5, 3.0, 3.5])
+    sed_values2 = data_obj2.evaluate_sed(eval_times, eval_waves)
+    expected_values2 = np.array(
+        [
+            [0.0, 15.0, 20.0, 25.0, 0.0],  # -0.5 wraps to 2.5
+            [0.0, 10.0, 15.0, 20.0, 0.0],  # 0.0
+            [0.0, 12.5, 17.5, 22.5, 0.0],  # Halfway between 0.0 and 1.0
+            [0.0, 15.0, 20.0, 25.0, 0.0],  # 1.0
+            [0.0, 17.5, 22.5, 27.5, 0.0],  # Halfway between 1.0 and 2.0
+            [0.0, 20.0, 25.0, 30.0, 0.0],  # 2.0
+            [0.0, 15.0, 20.0, 25.0, 0.0],  # Halfway between 2.0 and 3.0
+            [0.0, 10.0, 15.0, 20.0, 0.0],  # 3.0
+            [0.0, 12.5, 17.5, 22.5, 0.0],  # 3.5 wraps to 0.5
+        ]
+    )
+    assert np.allclose(sed_values2, expected_values2)
 
 
 def test_linear_sed_template_unsorted_data() -> None:
@@ -244,6 +317,10 @@ def test_create_sed_template_model() -> None:
     model = SEDTemplateModel(data, sed_data_t0=0.0, interpolation_type="linear", periodic=False, t0=0.0)
     assert len(model.times) == 4
     assert len(model.wavelengths) == 3
+    assert model.minwave() == 1000.0
+    assert model.maxwave() == 3000.0
+    assert model.minphase() == 0.0
+    assert model.maxphase() == 3.0
 
     # Evaluate the model at some times and wavelengths.
     eval_times = np.array([1.5, 2.5, 3.5])
@@ -264,15 +341,20 @@ def test_create_sed_template_model() -> None:
     with pytest.raises(ValueError):
         _ = SEDTemplateModel(data, interpolation_type="linear", periodic=False, t0=0.0)
 
-    # Set a non-zero t0. An evaluation time of 2.0 now corresponds to phase 0.0 in the curve.
+    # Set a non-zero t0. An evaluation time of 2.0 now corresponds to phase 0.0 in the
+    # curve. We should get a warning, because the first and last points are outside the
+    # range of the data.
     model2 = SEDTemplateModel(data, sed_data_t0=0.0, interpolation_type="linear", periodic=False, t0=2.0)
     state2 = model2.sample_parameters(num_samples=1)
-    sed_values2 = model2.evaluate_sed(eval_times, eval_waves, graph_state=state2)
+    eval_times = np.array([1.5, 2.5, 3.5, 5.5])
+    with pytest.warns(UserWarning):
+        sed_values2 = model2.evaluate_sed(eval_times, eval_waves, graph_state=state2)
     expected_values2 = np.array(
         [
             [0.0, 0.0, 0.0],
             [7.5, 17.5, 11.25],
             [12.5, 22.5, 13.75],
+            [0.0, 0.0, 0.0],
         ]
     )
     assert np.allclose(sed_values2, expected_values2)
@@ -296,6 +378,10 @@ def test_create_sed_template_model_from_template() -> None:
     assert len(model.wavelengths) == 2
     assert model.template.is_periodic
     assert model.template.period == 2.0
+    assert model.minwave() == 1000.0
+    assert model.maxwave() == 2000.0
+    assert model.minphase() is None
+    assert model.maxphase() is None
 
 
 def test_sed_model_data_from_file(test_data_dir):

--- a/tests/lightcurvelynx/models/test_sed_template_model.py
+++ b/tests/lightcurvelynx/models/test_sed_template_model.py
@@ -447,6 +447,68 @@ def test_create_multi_sed_template_model() -> None:
     assert np.allclose(sed_values[~chose_first, 0, 0], 22.5)
 
 
+def test_create_multi_sed_template_model_counds() -> None:
+    """Test that we can create a MultiSEDTemplateModel objects from templates
+    with different time and waavelenght bounds."""
+    data1 = np.array(
+        [
+            [0.0, 1000.0, 5.0],
+            [0.0, 2000.0, 15.0],
+            [1.0, 1000.0, 10.0],
+            [1.0, 2000.0, 20.0],
+            [2.0, 1000.0, 10.0],
+            [2.0, 2000.0, 20.0],
+        ]
+    )
+    lc1 = SEDTemplate(data1, interpolation_type="linear", periodic=False)
+
+    data2 = np.array(
+        [
+            [0.0, 3000.0, 20.0],
+            [0.0, 4000.0, 30.0],
+            [1.0, 3000.0, 25.0],
+            [1.0, 4000.0, 35.0],
+        ]
+    )
+    lc2 = SEDTemplate(data2, interpolation_type="linear", periodic=False)
+    model = MultiSEDTemplateModel([lc1, lc2], t0=0.0, node_label="model")
+    state = model.sample_parameters(num_samples=1)
+
+    # Overwrite the sampled template selection to test the bounds.
+    state["model"]["selected_template"] = 0
+    assert model.minphase(graph_state=state) == 0.0
+    assert model.maxphase(graph_state=state) == 2.0
+    assert model.minwave(graph_state=state) == 1000.0
+    assert model.maxwave(graph_state=state) == 2000.0
+
+    state["model"]["selected_template"] = 1
+    assert model.minphase(graph_state=state) == 0.0
+    assert model.maxphase(graph_state=state) == 1.0
+    assert model.minwave(graph_state=state) == 3000.0
+    assert model.maxwave(graph_state=state) == 4000.0
+
+    # We fail with no state.
+    with pytest.raises(ValueError):
+        _ = model.minphase()
+    with pytest.raises(ValueError):
+        _ = model.maxphase()
+    with pytest.raises(ValueError):
+        _ = model.minwave()
+    with pytest.raises(ValueError):
+        _ = model.maxwave()
+
+    # We fail when we have more than one sample.
+    states = model.sample_parameters(num_samples=10)
+    with pytest.raises(ValueError):
+        _ = model.minphase(graph_state=states)
+    with pytest.raises(ValueError):
+        _ = model.maxphase(graph_state=states)
+    with pytest.raises(ValueError):
+        _ = model.minwave(graph_state=states)
+    with pytest.raises(ValueError):
+        _ = model.maxwave(graph_state=states)
+
+
 def test_simsed_model_compute_sed(test_data_dir) -> None:
     """Test that we can load and compute SEDs from a SIMSEDModel."""
     model = SIMSEDModel.from_dir(test_data_dir / "fake_simsed", t0=0.0, distance=10.0, node_label="model")

--- a/tests/lightcurvelynx/models/test_sed_template_model.py
+++ b/tests/lightcurvelynx/models/test_sed_template_model.py
@@ -325,9 +325,11 @@ def test_create_sed_template_model() -> None:
     # Evaluate the model at some times and wavelengths.
     eval_times = np.array([1.5, 2.5, 3.5])
     eval_waves = np.array([1000.0, 2000.0, 2500.0])
-
     state = model.sample_parameters(num_samples=1)
-    sed_values = model.evaluate_sed(eval_times, eval_waves, graph_state=state)
+
+    # We should get a warning, because the last point is outside the range of the data.
+    with pytest.warns(UserWarning):
+        sed_values = model.evaluate_sed(eval_times, eval_waves, graph_state=state)
     expected_values = np.array(
         [
             [12.5, 22.5, 13.75],
@@ -358,6 +360,19 @@ def test_create_sed_template_model() -> None:
         ]
     )
     assert np.allclose(sed_values2, expected_values2)
+
+    # Test that if we create a model with a baseline, the time bounds are None.
+    baseline = np.array([1.0, 2.0, 3.0])
+    model3 = SEDTemplateModel(
+        data,
+        sed_data_t0=0.0,
+        interpolation_type="linear",
+        periodic=False,
+        t0=0.0,
+        baseline=baseline,
+    )
+    assert model3.minphase() is None
+    assert model3.maxphase() is None
 
 
 def test_create_sed_template_model_from_template() -> None:


### PR DESCRIPTION
Addresses the third part of #955 where the `SEDTemplate.evaluate_sed()` method returns the last valid flux value for all wavelengths outside the SED's native wavelength range. This PR changes it to use zero instead (and updates the documentation).

In the process of fixing this, I found a bunch of other small fixes. Most significantly is that the lack of `minphase`, `maxphase`, `minwave`, and `maxwave` methods meant that the out of bounds was not causing a warning or using extrapolation.

Changes:
- `evaluate_sed` returns 0 outside of range
- `SEDTemplate` implements `minphase`, `maxphase`, `minwave`, and `maxwave` so it produces warnings and uses extrapolation.
- Fix the corresponding `minphase`, etc. implementations in the `RandomMultiObjectModel `minphase`, etc. implementations for the `AdditiveMultiObjectModel` as the sub-models are evaluated independently and the approach of returning a list wasn't needed.
- Baselines were not being interpolated for actual query wavelengths in `SEDTemplate`. Fix that.
