### PR TITLE
Add documentation on randomness

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -180,6 +180,7 @@ This project is supported by Schmidt Sciences.
    Custom Models and Effects <custom_models>
    Noise Models <noise_models>
    Results and Output <results_and_output>
+   Randomness <randomness>
    Notebooks <notebooks>
    API Reference <autoapi/index>
    Glossary <glossary>

--- a/docs/randomness.rst
+++ b/docs/randomness.rst
@@ -1,0 +1,46 @@
+Randomness
+========================================================================================
+
+LightCurveLynx is designed to run statistically meaningful simulations, which means dealing with randomness. The code provides several different mechanisms for controlling randomness.
+
+
+Default Behavior
+-------------------------------------------------------------------------------
+
+By default, LightCurveLynx uses per-node random number generators (RNGs) that are initialized with a random seed (via `urandom` or the default numpy behavior):
+
+.. code-block:: python
+    
+    from os import urandom
+    from numpy.random import default_rng
+
+    seed = int.from_bytes(urandom(4), "big")
+    rng = default_rng(seed)
+
+This means that if you run a simulation multiple times, you will get independent simulations and can use the results for statistical analysis.
+
+
+Global Random Number Generator
+-------------------------------------------------------------------------------
+
+If users want to have reproducible simulations, they can provide a (seeded) global random number generator (RNG) to the ``simulate_lightcurves()`` function. This RNG will be used to initialize the per-node RNGs, noise RNGs, etc. The use of a global RNG will override any per-node seeds provided. If no global RNG is provided, the default behavior described above will be used.
+
+**Passing a global RNG is the recommended way to control randomness for testing or reproducibility.**
+
+
+Per-Node Seeds
+-------------------------------------------------------------------------------
+
+Many of the `ParameterizedNode` classes that use randomness have a ``seed`` parameter. If a seed is provided, the node will use it to initialize its **default** random number generator. A user provided (global) random number generator will override the per-node seeds.
+
+These per-node seeds are provided for two reasons (both related to debugging only):
+1. They allow deterministic node specifications for unit testing.
+2. They allow the users to shut off the randomness to just a specific node (when no global RNG is provided).
+
+As noted below, the per-node seeds are **always overridden** when running in parallel model to prevent correlations between the batches.
+
+
+Parallelism and Randomness
+-------------------------------------------------------------------------------
+
+If provided a global RNG in parallel mode, LightCurveLynx will create a unique RNG for each batch of samples. This is done to avoid correlations between the batches. **Note that this will always override the per-node seeds.** If you need to control randomness while running in parallel, you should provide a global RNG to the ``simulate_lightcurves()`` function.

--- a/src/lightcurvelynx/math_nodes/bilby_priors.py
+++ b/src/lightcurvelynx/math_nodes/bilby_priors.py
@@ -18,7 +18,9 @@ class BilbyPriorNode(FunctionNode, CiteClass):
     prior : dict or bilby.prior.PriorDict
         A dictionary mapping the names of the parameters to their prior distributions.
     seed : int, optional
-        The seed to use.
+        The seed to set the node's default random number generator. If None, then a random seed is used.
+        This parameter is for testing and has no effect when a user-provided random number generator is
+        used during simulation. Default: None
 
     Note
     ----

--- a/src/lightcurvelynx/math_nodes/given_sampler.py
+++ b/src/lightcurvelynx/math_nodes/given_sampler.py
@@ -23,6 +23,15 @@ class BinarySampler(NumpyRandomFunc):
     ----------
     probability : float
         The probability of returning True.
+
+    Parameters
+    ----------
+    probability : float
+        The probability of returning True.
+    seed : int, optional
+        The seed to set the node's default random number generator. If None, then a random seed is used.
+        This parameter is for testing and has no effect when a user-provided random number generator is
+        used during simulation. Default: None
     """
 
     def __init__(self, probability, seed=None, **kwargs):
@@ -178,6 +187,18 @@ class GivenValueSampler(NumpyRandomFunc):
         The number of values that can be sampled.
     _weights : numpy.ndarray, optional
         The weights for each value, if provided. If None, all values are equally likely.
+
+    Parameters
+    ----------
+    values : int, list, or numpy.ndarray
+        The values to select from. If an integer is provided, it is treated as a range
+        from 0 to that value - 1.
+    weights : list or numpy.ndarray, optional
+        The weights for each value. If None, all values are equally likely.
+    seed : int, optional
+        The seed to set the node's default random number generator. If None, then a random seed is used.
+        This parameter is for testing and has no effect when a user-provided random number generator is
+        used during simulation. Default: None
     """
 
     def __init__(self, values, weights=None, seed=None, **kwargs):

--- a/src/lightcurvelynx/math_nodes/np_random.py
+++ b/src/lightcurvelynx/math_nodes/np_random.py
@@ -29,7 +29,9 @@ class NumpyRandomFunc(FunctionNode):
         returned value will be ``(num_samples, *size)``.
         Default: None (single values for each sample)
     seed : int, optional
-        The seed to use.
+        The seed to set the node's default random number generator. If None, then a random seed is used.
+        This parameter is for testing and has no effect when a user-provided random number generator is
+        used during simulation. Default: None
 
     Note
     ----
@@ -181,7 +183,9 @@ class NumpyMultivariateNormalFunc(FunctionNode):
     cov : array-like
         A D x D array with the covariance matrix of the distribution for each sample.
     seed : int, optional
-        The seed to use.
+        The seed to set the node's default random number generator. If None, then a random seed is used.
+        This parameter is for testing and has no effect when a user-provided random number generator is
+        used during simulation. Default: None
 
     Examples
     --------

--- a/src/lightcurvelynx/math_nodes/ra_dec_sampler.py
+++ b/src/lightcurvelynx/math_nodes/ra_dec_sampler.py
@@ -26,9 +26,19 @@ class UniformRADEC(NumpyRandomFunc):
     use_degrees : bool
         The default return unit. If True returns samples in degrees.
         Otherwise, if False, returns samples in radians.
+
+    Parameters
+    ----------
+    seed : int, optional
+        The seed to set the node's default random number generator. If None, then a random seed is used.
+        This parameter is for testing and has no effect when a user-provided random number generator is
+        used during simulation. Default: None
+    use_degrees : bool
+        The default return unit. If True returns samples in degrees.
+        Otherwise, if False, returns samples in radians.
     """
 
-    def __init__(self, outputs=None, seed=None, use_degrees=True, **kwargs):
+    def __init__(self, seed=None, use_degrees=True, **kwargs):
         self.use_degrees = use_degrees
 
         # Override key arguments. We create a uniform sampler function, but
@@ -293,7 +303,9 @@ class ObsTableUniformRADECSampler(NumpyRandomFunc):
     outputs : list of str, optional
         The list of output names. Default: ["ra", "dec"]
     seed : int, optional
-        The random seed to use for the internal random number generator. Default: None
+        The seed to set the node's default random number generator. If None, then a random seed is used.
+        This parameter is for testing and has no effect when a user-provided random number generator is
+        used during simulation. Default: None
     max_iterations : int, optional
         The maximum number of iterations to perform. Default: 1000
     **kwargs : dict, optional
@@ -403,9 +415,22 @@ class ApproximateMOCSampler(NumpyRandomFunc, CiteClass):
         The list of healpix pixel IDs that cover the MOC at the given depth.
     depth : int
         The healpix depth to use as an approximation. Must be [2, 29].
+
+    Parameters
+    ----------
+    moc : mocpy.MOC
+        The MOC object to sample from.
+    seed : int, optional
+        The seed to set the node's default random number generator. If None, then a random seed is used.
+        This parameter is for testing and has no effect when a user-provided random number generator is
+        used during simulation. Default: None
+    depth : int
+        The healpix depth to use as an approximation. Must be [2, 29]. Default: 12
+    **kwargs : dict, optional
+        Additional keyword arguments to pass to the parent class constructor.
     """
 
-    def __init__(self, moc, *, outputs=None, seed=None, depth=12, **kwargs):
+    def __init__(self, moc, *, seed=None, depth=12, **kwargs):
         if depth < 2 or depth > 29:
             raise ValueError(f"Depth must be [2, 29]. Received {depth}")
         self.depth = depth
@@ -746,15 +771,19 @@ class CatalogRADECSampler(ObsTableRADECSampler):
         The deduplication threshold in degrees. If two rows have RA and dec values that
         are within this threshold, only one of them will be kept for sampling. Use 0.0 to
         keep all rows. Default: 0.0
+    seed : int, optional
+            The seed to set the node's default random number generator. If None, then a random seed is used.
+            This parameter is for testing and has no effect when a user-provided random number generator is
+            used during simulation. Default: None
     **kwargs : dict, optional
         Additional keyword arguments to pass to the parent class constructor.
     """
 
-    def __init__(self, data, *, dedup_threshold=0.0, **kwargs):
+    def __init__(self, data, *, dedup_threshold=0.0, seed=None, **kwargs):
         # Always default to a radius of 0.0.
         if "radius" not in kwargs or kwargs["radius"] is None:
             kwargs["radius"] = 0.0
-        super().__init__(data, dedup_threshold=dedup_threshold, **kwargs)
+        super().__init__(data, dedup_threshold=dedup_threshold, seed=seed, **kwargs)
 
 
 class MilkyWayCoordSampler(NumpyRandomFunc):
@@ -782,8 +811,10 @@ class MilkyWayCoordSampler(NumpyRandomFunc):
         The Milky Way stellar density model to use for sampling.  If *None*
         a :class:`~lightcurvelynx.astro_utils.milky_way_density.MilkyWayDensityJuric2008`
         instance with default parameters is created.  Default: None
-    seed : int or None, optional
-        Seed for the internal random number generator. Default: None
+    seed : int, optional
+        The seed to set the node's default random number generator. If None, then a random seed is used.
+        This parameter is for testing and has no effect when a user-provided random number generator is
+        used during simulation. Default: None
     **kwargs : dict, optional
         Additional keyword arguments passed to the parent class.
 

--- a/src/lightcurvelynx/math_nodes/random_choice.py
+++ b/src/lightcurvelynx/math_nodes/random_choice.py
@@ -22,9 +22,9 @@ class RandomChoiceNode(FunctionNode):
         are equally likely.
         Default: None
     seed : int, optional
-        The seed for the random number generator. If not provided, the node will
-        use a random seed.
-        Default: None
+        The seed to set the node's default random number generator. If None, then a random seed is used.
+        This parameter is for testing and has no effect when a user-provided random number generator is
+        used during simulation. Default: None
     """
 
     def __init__(self, values, *, weights=None, seed=None, **kwargs):

--- a/src/lightcurvelynx/math_nodes/scipy_random.py
+++ b/src/lightcurvelynx/math_nodes/scipy_random.py
@@ -68,7 +68,9 @@ class NumericalInversePolynomialFunc(FunctionNode):
         A tuple of (min, max) values to use as bounds for the sampling. If
         not provided, scipy will try to infer the domain.
     seed : int, optional
-        The seed to use.
+            The seed to set the node's default random number generator. If None, then a random seed is used.
+            This parameter is for testing and has no effect when a user-provided random number generator is
+            used during simulation. Default: None
     """
 
     def __init__(self, dist=None, *, domain=None, seed=None, **kwargs):

--- a/src/lightcurvelynx/models/agn.py
+++ b/src/lightcurvelynx/models/agn.py
@@ -101,8 +101,9 @@ class AGN(SEDModel):
         The label for the node in the model graph.
         Default: None
     seed : int, optional
-        The seed to use for the random number generator.
-        Default: None
+        The seed to set the node's default random number generator. If None, then a random seed is used.
+        This parameter is for testing and has no effect when a user-provided random number generator is
+        used during simulation. Default: None
     **kwargs : dict
         Additional keyword arguments.
     """

--- a/src/lightcurvelynx/models/physical_model.py
+++ b/src/lightcurvelynx/models/physical_model.py
@@ -58,7 +58,9 @@ class BasePhysicalModel(ParameterizedNode, ABC):
     node_label : str, optional
         The label for the node in the model graph.
     seed : int, optional
-        The seed for a random number generator.
+        The seed to set the node's default random number generator. If None, then a random seed is used.
+        This parameter is for testing and has no effect when a user-provided random number generator is
+        used during simulation. Default: None
     **kwargs : dict, optional
         Any additional keyword arguments.
     """

--- a/src/lightcurvelynx/models/sncosmo_models.py
+++ b/src/lightcurvelynx/models/sncosmo_models.py
@@ -57,7 +57,9 @@ class SncosmoWrapperModel(SEDModel, CiteClass):
         the model for after the last valid time. If None is provided the model will not try to
         extrapolate, but rather call compute_sed() for all times.
     seed : int, optional
-        The seed for a random number generator.
+        The seed to set the node's default random number generator. If None, then a random seed is used.
+        This parameter is for testing and has no effect when a user-provided random number generator is
+        used during simulation. Default: None
     **kwargs : dict, optional
         Any additional keyword arguments.
     """

--- a/tests/lightcurvelynx/math_nodes/test_given_sampler.py
+++ b/tests/lightcurvelynx/math_nodes/test_given_sampler.py
@@ -256,6 +256,39 @@ def test_given_value_sampler_weighted():
     assert len(results[results == 7]) > 500
 
 
+def test_given_value_sampler_weighted_seeded():
+    """Test that we can retrieve numbers from a GivenValueSampler
+    with a weighted distribution."""
+    # Same seed should produce the same results.
+    given_node1 = GivenValueSampler([1, 3, 5, 7], [0.1, 0.5, 0.3, 0.1], seed=123)
+    state1 = GraphState(num_samples=10_000)
+    results1 = given_node1.compute(state1)
+
+    given_node2 = GivenValueSampler([1, 3, 5, 7], [0.1, 0.5, 0.3, 0.1], seed=123)
+    state2 = GraphState(num_samples=10_000)
+    results2 = given_node2.compute(state2)
+    assert np.array_equal(results1, results2)
+
+    # Different seeds should produce different results.
+    given_node3 = GivenValueSampler([1, 3, 5, 7], [0.1, 0.5, 0.3, 0.1], seed=124)
+    state3 = GraphState(num_samples=10_000)
+    results3 = given_node3.compute(state3)
+    assert not np.array_equal(results1, results3)
+
+    # We can override the seed with a given random number generator. Different
+    # seeds do not matter if we provide the same random number generator to the compute() method.
+    rng1 = np.random.default_rng(seed=456)
+    given_node4 = GivenValueSampler([1, 3, 5, 7], [0.1, 0.5, 0.3, 0.1], seed=123)
+    state4 = GraphState(num_samples=10_000)
+    results4 = given_node4.compute(state4, rng_info=rng1)
+
+    rng2 = np.random.default_rng(seed=456)
+    given_node5 = GivenValueSampler([1, 3, 5, 7], [0.1, 0.5, 0.3, 0.1], seed=124)
+    state5 = GraphState(num_samples=10_000)
+    results5 = given_node5.compute(state5, rng_info=rng2)
+    assert np.allclose(results4, results5)
+
+
 @pytest.mark.parametrize("bad_weights", [[-0.1, 0.6, 0.5], [0.2, -0.2, 1.0]])
 def test_given_value_sampler_negative_weights_fail(bad_weights):
     """Test that negative weights are rejected."""

--- a/tests/lightcurvelynx/math_nodes/test_np_random.py
+++ b/tests/lightcurvelynx/math_nodes/test_np_random.py
@@ -52,6 +52,26 @@ def test_numpy_random_uniform():
         NumpyRandomFunc("uniform", size=())
 
 
+def test_numpy_random_uniform_seed_override():
+    """Test that we can generate numbers from a uniform distribution where we
+    override the given seed with a given random number generator."""
+    np_node1 = NumpyRandomFunc("uniform", seed=100)
+    used_rng1 = np.random.default_rng(100)
+    values1 = np.array([np_node1.generate(rng_info=used_rng1) for _ in range(10_000)])
+
+    # Different seed, but overridden by given random number generator.
+    np_node2 = NumpyRandomFunc("uniform", seed=101)
+    used_rng2 = np.random.default_rng(100)
+    values2 = np.array([np_node2.generate(rng_info=used_rng2) for _ in range(10_000)])
+    assert np.allclose(values1, values2)
+
+    # Same seed, but overridden by different random number generator.
+    np_node3 = NumpyRandomFunc("uniform", seed=100)
+    used_rng3 = np.random.default_rng(101)
+    values3 = np.array([np_node3.generate(rng_info=used_rng3) for _ in range(10_000)])
+    assert not np.allclose(values1, values3)
+
+
 def test_numpy_random_uniform_multi_samples():
     """Test that we can generate many numbers at once from a uniform distribution."""
     np_node = NumpyRandomFunc("uniform", seed=100)


### PR DESCRIPTION
As I was addressing #955, I realized that the precedence of randomness operations is not clear (namely that per-node seeds are not used if a per-simulation random number generator is given). This adds explicit documentation and tests.
