### PR TITLE
Fix typos in the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ conda install conda-forge::lightcurvelynx
 ```
 
 Since LightCurveLynx relies on a large number of existing packages, not all of the packages
-are installed in the default configuration. You can install most of the optional depenencies
+are installed in the default configuration. You can install most of the optional dependencies
 with the "dev" or "all" extras:
 
 ```

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -82,7 +82,7 @@ How Do I Use an External Simulation Package?
 LightCurveLynx is designed to be modular and extensible, allowing users to wrap external
 simulation packages for use within the LightCurveLynx framework. How you wrap the package will
 depend largely on the specifics of the package you are trying to wrap. We have provided
-a few demo notebooks to illustrate various approachs, including:
+a few demo notebooks to illustrate various approaches, including:
 
   * :doc:`Wrapping Bagle Models <notebooks/pre_executed/wrapping_bagle>`
   * :doc:`Wrapping Redback Models <notebooks/pre_executed/wrapping_redback>`
@@ -134,7 +134,7 @@ It is possible to change the values within the ``GraphState`` object before pass
 Can I Simulate Spectra?
 --------------------------------------------------------------------------------
 
-Yes with some caveats. LightCurveLynx has built-in support for simulating spectrographs. The measurements returned are bin-integrated fluxes for each bin in the spectrograph in units of erg/s/cm². This feature is currently in an early stage of development and does not yet add noise to the measurements. In addition, spectra simulation is **only** compaible with models that generate data on the spectral level (not bandflux-only models).  For more detail see :doc:`the spectrograph demo notebook <notebooks/spectrograph_demo>`.
+Yes with some caveats. LightCurveLynx has built-in support for simulating spectrographs. The measurements returned are bin-integrated fluxes for each bin in the spectrograph in units of erg/s/cm². This feature is currently in an early stage of development and does not yet add noise to the measurements. In addition, spectra simulation is **only** compatible with models that generate data on the spectral level (not bandflux-only models).  For more detail see :doc:`the spectrograph demo notebook <notebooks/spectrograph_demo>`.
 
 
 Can I Generate Points from a Catalog?
@@ -153,4 +153,4 @@ for a detailed description of how to sample (RA, dec) positions.
 Why does my light curve have multiple points at the same time?
 --------------------------------------------------------------------------------
 
-While this can legitimately happen if multiple surveys have the exact same MJD for an observations, this is more likely an artifact of per-CCD level information. If the survey data is provided at the CCD-level (such as with Rubin's DP1 CCD visit table) **and** no detector footprint is set, the code will estimate a circular footprint per-CCD. Points that lie near the edge of one CCD may also be picked up by another CCD. This can often be solved by setting the detector footprint for each CCD. See the :doc:`ccd-level obstable <notebooks/ccd_obstables>` for more information.
+While this can legitimately happen if multiple surveys have the exact same MJD for an observations, this is more likely an artifact of per-CCD level information. If the survey data is provided at the CCD-level (such as with Rubin's DP1 CCD visit table) **and** no detector footprint is set, the code will estimate a circular footprint per-CCD. Points that lie near the edge of one CCD may also be picked up by another CCD. This can often be solved by setting the detector footprint for each CCD. See the :doc:`ccd-level obstacle <notebooks/ccd_obstables>` for more information.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -98,7 +98,7 @@ You can install LightCurveLynx from PyPI with pip or from conda-forge with conda
 Since LightCurveLynx relies on a large number of existing packages, not all of the packages
 are installed in the default configuration. For example the microlensing (`VBMicrolensing`),
 pzflow (`pzflow`), and sncosmo (`sncosmo`) packages are not included by default. You can
-install most of the optional depenencies with the "all" extra:
+install most of the optional dependencies with the "all" extra:
 
 .. tab-set::
    :sync-group: packagemanager

--- a/docs/results_and_output.rst
+++ b/docs/results_and_output.rst
@@ -109,7 +109,7 @@ If users have already run a simulation and want to include specific columns from
 
 The data will be stored in the ``test_col`` column in the nested light curve DataFrame.
 
-Note that if the simulation was run with mutiple surveys, the function matches observations to each observation based on the ``survey_idx`` and ``obs_idx`` columns in the nested light curve DataFrame.  In this case, users will need to pass in a list of ObsTable in the same order as the original simulation.
+Note that if the simulation was run with multiple surveys, the function matches observations to each observation based on the ``survey_idx`` and ``obs_idx`` columns in the nested light curve DataFrame.  In this case, users will need to pass in a list of ObsTable in the same order as the original simulation.
 
 
 Plotting Results


### PR DESCRIPTION
Fixes 6 spelling mistakes in the docs, found with `codespell`.

Prose only. No code identifiers, module paths, package names or proper nouns changed, and anything that was a valid word rather than a misspelling was left alone.