### PR TITLE
Break out the evaluation of a single model on a single survey

### DIFF
--- a/src/lightcurvelynx/models/basic_models.py
+++ b/src/lightcurvelynx/models/basic_models.py
@@ -306,7 +306,7 @@ class LinearTimeModel(SEDModel):
     """A model that emits flux as a linear function of time
     (that is constant over wavelengths)::
 
-        f(t, w) = max(0.0, scale * t - t0) + base
+        f(t, w) = max(0.0, scale * (t - t0)) + base
 
     Parameterized values include:
 

--- a/src/lightcurvelynx/models/basic_models.py
+++ b/src/lightcurvelynx/models/basic_models.py
@@ -70,6 +70,10 @@ class StepModel(ConstantSEDModel):
     * t0 - The time the step function starts, in MJD.
     * t1- The time the step function ends, in MJD.
 
+    Note
+    ----
+    This model is provided for testing.
+
     Parameters
     ----------
     brightness : float
@@ -129,6 +133,10 @@ class SinWaveModel(SEDModel):
     * ra - The object's right ascension in degrees. [from BasePhysicalModel]
     * redshift - The object's redshift. [from BasePhysicalModel]
     * t0 - The start of the sine wave's period. [from BasePhysicalModel]
+
+    Note
+    ----
+    This model is provided for testing.
 
     Parameters
     ----------
@@ -199,6 +207,10 @@ class LinearWavelengthModel(SEDModel):
     * ra - The object's right ascension in degrees. [from BasePhysicalModel]
     * redshift - The object's redshift. [from BasePhysicalModel]
     * t0 - No effect for static model. [from BasePhysicalModel]
+
+    Note
+    ----
+    This model is provided for testing.
 
     Attributes
     ----------
@@ -288,3 +300,63 @@ class LinearWavelengthModel(SEDModel):
         params = self.get_local_params(graph_state)
         single_wave = params["linear_base"] + params["linear_scale"] * wavelengths
         return np.tile(single_wave[np.newaxis, :], (len(times), 1))
+
+
+class LinearTimeModel(SEDModel):
+    """A model that emits flux as a linear function of time
+    (that is constant over wavelengths)::
+
+        f(t, w) = max(0.0, scale * t - t0) + base
+
+    Parameterized values include:
+
+    * linear_base - The base brightness in nJy.
+    * linear_scale - The slope of the linear function in nJy/day.
+    * dec - The object's declination in degrees. [from BasePhysicalModel]
+    * distance - The object's luminosity distance in pc. [from BasePhysicalModel]
+    * ra - The object's right ascension in degrees. [from BasePhysicalModel]
+    * redshift - The object's redshift. [from BasePhysicalModel]
+    * t0 - Time offset before the linear ramp begins. [from BasePhysicalModel]
+
+    Note
+    ----
+    This model is provided for testing.
+
+    Parameters
+    ----------
+    linear_base : parameter
+        The base brightness in nJy.
+    linear_scale : parameter
+        The slope of the linear function in nJy/day.
+    **kwargs : dict, optional
+        Any additional keyword arguments.
+    """
+
+    def __init__(self, linear_base, linear_scale, **kwargs):
+        super().__init__(**kwargs)
+        self.add_parameter("linear_base", linear_base, **kwargs)
+        self.add_parameter("linear_scale", linear_scale, **kwargs)
+
+    def compute_sed(self, times, wavelengths, graph_state, **kwargs):
+        """Draw effect-free observations for this object.
+
+        Parameters
+        ----------
+        times : numpy.ndarray
+            A length T array of rest frame timestamps.
+        wavelengths : numpy.ndarray, optional
+            A length N array of wavelengths (in angstroms).
+        graph_state : GraphState
+            An object mapping graph parameters to their values.
+        **kwargs : dict, optional
+            Any additional keyword arguments.
+
+        Returns
+        -------
+        flux_density : numpy.ndarray
+            A length T x N matrix of SED values (in nJy).
+        """
+        params = self.get_local_params(graph_state)
+        time_after_t0 = np.maximum(0.0, times - params["t0"])
+        single_wave = time_after_t0 * params["linear_scale"] + params["linear_base"]
+        return np.tile(single_wave[:, np.newaxis], (1, len(wavelengths)))

--- a/src/lightcurvelynx/simulate.py
+++ b/src/lightcurvelynx/simulate.py
@@ -291,6 +291,117 @@ def get_time_windows(t0, z, obs_time_window_offset, rest_time_window_offset):
     return start_times, end_times
 
 
+def simulate_single_bandflux_sample(
+    model,
+    survey_info,
+    state,
+    *,
+    indices=None,
+    rng_info=None,
+    apply_saturation=False,
+    obs_time_window_offset=None,
+    rest_time_window_offset=None,
+):
+    """Simulate a single sample (object) for a single bandflux survey. This function is
+    called by the core loop, but broken out so that it can be called from external
+    code as well.
+
+    Parameters
+    ----------
+    model : object
+        The lightcurve model to simulate.
+    survey_info : object
+        Information about the survey, including the observation table, passbands,
+        and noise model.
+    state : GraphState
+        Pre-sampled state of the model parameters.
+    indices : array-like, optional
+        Precomputed indices for the observations to use. If these are provided all spatial
+        matching is skipped and the passbands will be evaluated at these indices directly.
+        If not provided, the spatial matching and time filtering will be performed to determine
+        the relevant  observation indices.
+    rng_info : object, optional
+        Random number generator information.
+    apply_saturation : bool, default False
+        Whether to apply saturation thresholds.
+    obs_time_window_offset : tuple, optional
+        Observer-frame time window offset (before, after) in days. Ignored if indices are
+        passed since we do not do matching.
+    rest_time_window_offset : tuple, optional
+        Rest-frame time window offset (before, after) in days. Ignored if indices are
+        passed since we do not do matching.
+
+    Returns
+    -------
+    dict
+        A dictionary containing the simulated bandfluxes and associated information. Keys include:
+        - "flux_perfect": The noise-free bandfluxes in nJy.
+        - "flux": The noisy bandfluxes in nJy.
+        - "fluxerr": The errors on the noisy bandfluxes.
+        - "is_saturated": Boolean array indicating which observations are saturated.
+    """
+    if state is None or state.num_samples != 1:
+        raise ValueError("The pre-sampled state must contain exactly one sample.")
+
+    # If we have not done the spatial matching, do that now.
+    if indices is None:
+        start_times, end_times = get_time_windows(
+            model.get_param(state, "t0"),
+            model.get_param(state, "redshift"),
+            obs_time_window_offset,
+            rest_time_window_offset,
+        )
+        indices = survey_info.obstable.range_search(
+            model.get_param(state, "ra"),
+            model.get_param(state, "dec"),
+            t_min=start_times,
+            t_max=end_times,
+        )
+
+    # Compute the bandfluxes for the lightcurves column.
+    obs_times = survey_info.obstable["time"].iloc[indices]
+    obs_filters = survey_info.obstable["filter"].iloc[indices]
+    bandfluxes_perfect = model.evaluate_bandfluxes(
+        survey_info.passbands,
+        obs_times,
+        obs_filters,
+        state,
+        rng_info=rng_info,
+    )
+
+    # Simulate bandflux noise.
+    noise_model = survey_info.noise_model
+    if noise_model is None:
+        bandfluxes = np.copy(bandfluxes_perfect)
+        bandfluxes_error = np.zeros_like(bandfluxes_perfect)
+    else:
+        bandfluxes, bandfluxes_error = noise_model.apply_noise(
+            bandfluxes_perfect,
+            obs_table=survey_info.obstable,
+            indices=indices,
+            rng=rng_info,
+        )
+
+    # Apply saturation thresholds from the ObsTable if they are requested.
+    if apply_saturation:
+        bandfluxes, bandfluxes_error, saturation_flags = survey_info.obstable.compute_saturation(
+            bandfluxes,
+            bandfluxes_error,
+            indices,
+        )
+    else:
+        saturation_flags = [False] * len(indices)
+
+    # Compile the results into a dictionary.
+    results = {
+        "flux_perfect": bandfluxes_perfect,
+        "flux": bandfluxes,
+        "fluxerr": bandfluxes_error,
+        "is_saturated": saturation_flags,
+    }
+    return results
+
+
 def _simulate_lightcurves_batch(simulation_info):
     """Generate a number of simulations of the given model and information
     from one or more surveys.
@@ -483,46 +594,27 @@ def _simulate_lightcurves_batch(simulation_info):
                 # Add the new entries to the spectra_index.
                 spectra_index.extend([idx] * nobs)
             else:
-                # This is a PassbandGroup integrator, so we compute the bandfluxes for the lightcurves column.
-                # Compute the bandfluxes and errors over just the given filters.
-                bandfluxes_perfect = model.evaluate_bandfluxes(
-                    passbands[survey_idx],
-                    obs_times,
-                    obs_filters,
-                    state,
+                # Compute the bandfluxes for this model and survey combination. Note that we
+                # do not need to pass information such as the time windows because we have
+                # already done those computations in a batch above.
+                results = simulate_single_bandflux_sample(
+                    model,
+                    simulation_info.survey_info[survey_idx],
+                    indices=obs_index,  # We have done spatial matching already.
+                    state=state,  # Single state
                     rng_info=rng,
+                    apply_saturation=simulation_info.apply_saturation,
                 )
-
-                # Simulate bandflux noise.
-                noise_model = simulation_info.survey_info[survey_idx].noise_model
-                if noise_model is None:
-                    bandfluxes = np.copy(bandfluxes_perfect)
-                    bandfluxes_error = np.zeros_like(bandfluxes_perfect)
-                else:
-                    bandfluxes, bandfluxes_error = noise_model.apply_noise(
-                        bandfluxes_perfect,
-                        obs_table=obstable[survey_idx],
-                        indices=obs_index,
-                        rng=rng,
-                    )
-
-                # Apply saturation thresholds from the ObsTable if they are requested.
-                if simulation_info.apply_saturation:
-                    bandfluxes, bandfluxes_error, saturation_flags = obstable[survey_idx].compute_saturation(
-                        bandfluxes, bandfluxes_error, obs_index
-                    )
-                else:
-                    saturation_flags = [False] * nobs
 
                 # Append the per-observation data to the nested dictionary, including
                 # any needed ObsTable columns. These are appended
                 object_nested_dict["mjd"].append(obs_times)
                 object_nested_dict["filter"].append(obs_filters)
-                object_nested_dict["flux_perfect"].append(bandfluxes_perfect)
-                object_nested_dict["flux"].append(bandfluxes)
-                object_nested_dict["fluxerr"].append(bandfluxes_error)
+                object_nested_dict["flux_perfect"].append(results["flux_perfect"])
+                object_nested_dict["flux"].append(results["flux"])
+                object_nested_dict["fluxerr"].append(results["fluxerr"])
                 object_nested_dict["survey_idx"].append([survey_idx] * nobs)
-                object_nested_dict["is_saturated"].append(saturation_flags)
+                object_nested_dict["is_saturated"].append(results["is_saturated"])
                 object_nested_dict["obs_idx"].append(obs_index)
                 for col in obstable_save_cols:
                     if len(obs_index) > 0:

--- a/src/lightcurvelynx/simulate.py
+++ b/src/lightcurvelynx/simulate.py
@@ -392,7 +392,7 @@ def simulate_single_bandflux_sample(
             indices,
         )
     else:
-        saturation_flags = [False] * len(indices)
+        saturation_flags = np.zeros_like(bandfluxes_perfect, dtype=bool)
 
     # Compile the results into a dictionary.
     results = {

--- a/src/lightcurvelynx/simulate.py
+++ b/src/lightcurvelynx/simulate.py
@@ -335,6 +335,8 @@ def simulate_single_bandflux_sample(
     -------
     dict
         A dictionary containing the simulated bandfluxes and associated information. Keys include:
+        - "mjd": The Modified Julian Dates of the observations.
+        - "filter": The filters corresponding to each observation.
         - "flux_perfect": The noise-free bandfluxes in nJy.
         - "flux": The noisy bandfluxes in nJy.
         - "fluxerr": The errors on the noisy bandfluxes.
@@ -359,8 +361,8 @@ def simulate_single_bandflux_sample(
         )
 
     # Compute the bandfluxes for the lightcurves column.
-    obs_times = survey_info.obstable["time"].iloc[indices]
-    obs_filters = survey_info.obstable["filter"].iloc[indices]
+    obs_times = survey_info.obstable["time"].to_numpy()[indices]
+    obs_filters = survey_info.obstable["filter"].to_numpy()[indices]
     bandfluxes_perfect = model.evaluate_bandfluxes(
         survey_info.passbands,
         obs_times,
@@ -394,6 +396,8 @@ def simulate_single_bandflux_sample(
 
     # Compile the results into a dictionary.
     results = {
+        "mjd": obs_times,
+        "filter": obs_filters,
         "flux_perfect": bandfluxes_perfect,
         "flux": bandfluxes,
         "fluxerr": bandfluxes_error,
@@ -521,9 +525,8 @@ def _simulate_lightcurves_batch(simulation_info):
         obstable[i].range_search(ra, dec, t_min=start_times, t_max=end_times) for i in range(num_surveys)
     ]
 
-    # Get all times and all filters as numpy arrays so we can do easy subsets.
-    all_times = [np.asarray(obstable[i]["time"].values, dtype=float) for i in range(num_surveys)]
-    all_filters = [np.asarray(obstable[i]["filter"].values, dtype=str) for i in range(num_surveys)]
+    # Get all times as a numpy array so we can do easy subsets.
+    all_times = [np.asarray(obstable[i]["time"].to_numpy(), dtype=float) for i in range(num_surveys)]
 
     # We loop over objects first, then surveys. This allows us to generate a single block
     # of data for the object over all surveys.
@@ -550,7 +553,6 @@ def _simulate_lightcurves_batch(simulation_info):
             if len(obs_index) == 0:
                 continue
             obs_times = all_times[survey_idx][obs_index]
-            obs_filters = all_filters[survey_idx][obs_index]
 
             # Check for duplicate observation times in the same survey.
             nobs = len(obs_times)
@@ -608,13 +610,13 @@ def _simulate_lightcurves_batch(simulation_info):
 
                 # Append the per-observation data to the nested dictionary, including
                 # any needed ObsTable columns. These are appended
-                object_nested_dict["mjd"].append(obs_times)
-                object_nested_dict["filter"].append(obs_filters)
+                object_nested_dict["mjd"].append(results["mjd"])
+                object_nested_dict["filter"].append(results["filter"])
                 object_nested_dict["flux_perfect"].append(results["flux_perfect"])
                 object_nested_dict["flux"].append(results["flux"])
                 object_nested_dict["fluxerr"].append(results["fluxerr"])
-                object_nested_dict["survey_idx"].append([survey_idx] * nobs)
                 object_nested_dict["is_saturated"].append(results["is_saturated"])
+                object_nested_dict["survey_idx"].append([survey_idx] * nobs)
                 object_nested_dict["obs_idx"].append(obs_index)
                 for col in obstable_save_cols:
                     if len(obs_index) > 0:
@@ -628,7 +630,7 @@ def _simulate_lightcurves_batch(simulation_info):
 
                 # Add the survey name from the integrator information if we chose to save it.
                 if simulation_info.save_full_filter_names:
-                    obs_filters = np.asarray(obs_filters)
+                    obs_filters = results["filter"]
                     full_filter_names = np.empty_like(obs_filters, dtype=object)
                     for filter_name in np.unique(obs_filters):
                         pb_obj = passbands[survey_idx][filter_name]

--- a/src/lightcurvelynx/simulate.py
+++ b/src/lightcurvelynx/simulate.py
@@ -291,20 +291,18 @@ def get_time_windows(t0, z, obs_time_window_offset, rest_time_window_offset):
     return start_times, end_times
 
 
-def simulate_single_bandflux_sample(
+def evaluate_single_bandflux_given_indices(
     model,
     survey_info,
     state,
+    indices,
     *,
-    indices=None,
     rng_info=None,
     apply_saturation=False,
-    obs_time_window_offset=None,
-    rest_time_window_offset=None,
 ):
-    """Simulate a single sample (object) for a single bandflux survey. This function is
-    called by the core loop, but broken out so that it can be called from external
-    code as well.
+    """Simulate a single sample (object) for given indices in the ObsTable. This is
+    used both in the core loop and also in cases where the spatial matching has
+    been done externally.
 
     Parameters
     ----------
@@ -314,22 +312,13 @@ def simulate_single_bandflux_sample(
         Information about the survey, including the observation table, passbands,
         and noise model.
     state : GraphState
-        Pre-sampled state of the model parameters.
-    indices : array-like, optional
-        Precomputed indices for the observations to use. If these are provided all spatial
-        matching is skipped and the passbands will be evaluated at these indices directly.
-        If not provided, the spatial matching and time filtering will be performed to determine
-        the relevant  observation indices.
+        Pre-sampled state of the model parameters. Must contain a single sample.
+    indices : array-like
+        Precomputed indices for the observations to use from the given observation table.
     rng_info : object, optional
         Random number generator information.
     apply_saturation : bool, default False
         Whether to apply saturation thresholds.
-    obs_time_window_offset : tuple, optional
-        Observer-frame time window offset (before, after) in days. Ignored if indices are
-        passed since we do not do matching.
-    rest_time_window_offset : tuple, optional
-        Rest-frame time window offset (before, after) in days. Ignored if indices are
-        passed since we do not do matching.
 
     Returns
     -------
@@ -344,21 +333,8 @@ def simulate_single_bandflux_sample(
     """
     if state is None or state.num_samples != 1:
         raise ValueError("The pre-sampled state must contain exactly one sample.")
-
-    # If we have not done the spatial matching, do that now.
-    if indices is None:
-        start_times, end_times = get_time_windows(
-            model.get_param(state, "t0"),
-            model.get_param(state, "redshift"),
-            obs_time_window_offset,
-            rest_time_window_offset,
-        )
-        indices = survey_info.obstable.range_search(
-            model.get_param(state, "ra"),
-            model.get_param(state, "dec"),
-            t_min=start_times,
-            t_max=end_times,
-        )
+    if indices is None or len(indices) == 0:
+        raise ValueError("No observation indices provided.")
 
     # Compute the bandfluxes for the lightcurves column.
     obs_times = survey_info.obstable["time"].to_numpy()[indices]
@@ -596,14 +572,13 @@ def _simulate_lightcurves_batch(simulation_info):
                 # Add the new entries to the spectra_index.
                 spectra_index.extend([idx] * nobs)
             else:
-                # Compute the bandfluxes for this model and survey combination. Note that we
-                # do not need to pass information such as the time windows because we have
-                # already done those computations in a batch above.
-                results = simulate_single_bandflux_sample(
+                # Compute the bandfluxes for the indices in the ObsTable where
+                # the object was observed.
+                results = evaluate_single_bandflux_given_indices(
                     model,
                     simulation_info.survey_info[survey_idx],
-                    indices=obs_index,  # We have done spatial matching already.
-                    state=state,  # Single state
+                    state,
+                    obs_index,
                     rng_info=rng,
                     apply_saturation=simulation_info.apply_saturation,
                 )

--- a/tests/lightcurvelynx/models/test_basic_models.py
+++ b/tests/lightcurvelynx/models/test_basic_models.py
@@ -8,6 +8,7 @@ from lightcurvelynx.astro_utils.unit_utils import fnu_to_flam
 from lightcurvelynx.base_models import FunctionNode
 from lightcurvelynx.models.basic_models import (
     ConstantSEDModel,
+    LinearTimeModel,
     LinearWavelengthModel,
     SinWaveModel,
     StepModel,
@@ -296,3 +297,19 @@ def test_linear_wavelength_model_bounds() -> None:
     values3 = model3.evaluate_sed(times, wavelengths3, state3)
     expected3 = np.tile(np.array([0.0, 50.5, 101.0, 151.0, 201.0, 100.5, 0.0]), (len(times), 1))
     assert np.allclose(values3, expected3)
+
+
+def test_linear_time_model() -> None:
+    """Test that we can create and query a LinearTimeModel."""
+    model = LinearTimeModel(linear_base=3.0, linear_scale=0.1, t0=10.0)
+    state = model.sample_parameters()
+
+    times = np.arange(0.0, 50.0, 0.5)
+    wavelengths = np.array([500.0, 1000.0, 1500.0, 2000.0, 2500.0])
+    values = model.evaluate_sed(times, wavelengths, state)
+
+    # Check that we are getting a linear increase in flux after t0 and only
+    # the baseline before that.
+    expected_per_wave = np.maximum(0.0, 0.1 * (times - 10.0)) + 3.0
+    expected = np.tile(expected_per_wave[:, np.newaxis], (1, len(wavelengths)))
+    assert np.allclose(values, expected)

--- a/tests/lightcurvelynx/test_simulate.py
+++ b/tests/lightcurvelynx/test_simulate.py
@@ -20,7 +20,12 @@ from lightcurvelynx.math_nodes.given_sampler import (
 )
 from lightcurvelynx.math_nodes.np_random import NumpyRandomFunc
 from lightcurvelynx.math_nodes.state_expansion_node import StateExpansionNode
-from lightcurvelynx.models.basic_models import ConstantSEDModel, SinWaveModel, StepModel
+from lightcurvelynx.models.basic_models import (
+    ConstantSEDModel,
+    LinearTimeModel,
+    SinWaveModel,
+    StepModel,
+)
 from lightcurvelynx.models.physical_model import SEDModel
 from lightcurvelynx.models.static_sed_model import StaticBandfluxModel
 from lightcurvelynx.noise_models.base_noise_models import GivenNoiseModel
@@ -35,6 +40,7 @@ from lightcurvelynx.simulate import (
     compute_single_noise_free_lightcurve,
     get_time_windows,
     simulate_lightcurves,
+    simulate_single_bandflux_sample,
 )
 from lightcurvelynx.survey_info import SurveyInfo
 from nested_pandas import NestedFrame, read_parquet
@@ -363,6 +369,132 @@ def test_simulation_info_graph_state():
             rng=np.random.default_rng(12345),
             graph_state=state,
         )
+
+
+def test_simulate_single_bandflux_sample_indices(test_data_dir):
+    """Test that we can simulate a single model sample with given indices."""
+    # Load the OpSim data.
+    opsim_db = OpSim.from_db(test_data_dir / "opsim_small.db")
+
+    # Load the passband data for the griz filters only.
+    passband_group = PassbandGroup.from_preset(
+        preset="LSST",
+        table_dir=test_data_dir / "passbands",
+        filters=["g", "r", "i", "z"],
+    )
+
+    # Use the default noise model.
+    survey_info = SurveyInfo(obstable=opsim_db, passbands=passband_group)
+
+    # Create a constant SED model with known brightnesses and RA, dec
+    # values that match the opsim.
+    given_brightness = [1000.0, 2000.0, 5000.0, 1000.0, 100.0]
+    source = ConstantSEDModel(
+        brightness=GivenValueList(given_brightness),
+        t0=0.0,
+        ra=GivenValueList(opsim_db["ra"].values[0:5]),
+        dec=GivenValueList(opsim_db["dec"].values[0:5]),
+        redshift=0.0,
+        node_label="source",
+    )
+
+    # Do a single sample.
+    rng = np.random.default_rng(12345)
+    state = source.sample_parameters(num_samples=1)
+    results = simulate_single_bandflux_sample(source, survey_info, state, rng_info=rng)
+    assert len(results["flux_perfect"]) > 1
+    assert "flux" in results
+    assert "fluxerr" in results
+    assert "is_saturated" in results
+
+    # Do a second sample with the same state, but a different random number state.
+    # The flux_perfect and noise should be the same, but the noisy flux should be different.
+    rng2 = np.random.default_rng(67890)
+    results2 = simulate_single_bandflux_sample(source, survey_info, state, rng_info=rng2)
+    assert np.allclose(results["flux_perfect"], results2["flux_perfect"])
+    assert np.allclose(results["fluxerr"], results2["fluxerr"])
+    assert not np.allclose(results["flux"], results2["flux"])
+
+    # But we can get the same everything if we use the same random number generator.
+    rng3 = np.random.default_rng(12345)
+    results3 = simulate_single_bandflux_sample(source, survey_info, state, rng_info=rng3)
+    assert np.allclose(results["flux_perfect"], results3["flux_perfect"])
+    assert np.allclose(results["fluxerr"], results3["fluxerr"])
+    assert np.allclose(results["flux"], results3["flux"])
+
+    # We can limit the time window to just the first observation.
+    first_time = np.min(opsim_db["time"].values)
+    rng4 = np.random.default_rng(12345)
+    results4 = simulate_single_bandflux_sample(
+        source,
+        survey_info,
+        state,
+        rng_info=rng4,
+        obs_time_window_offset=(first_time - 0.01, first_time + 0.01),
+    )
+    assert len(results4["flux_perfect"]) == 1
+    assert np.allclose(results4["flux_perfect"], results["flux_perfect"][0])
+
+    # We fail if we have more than one sample.
+    state_bad = source.sample_parameters(num_samples=2)
+    with pytest.raises(ValueError):
+        _ = simulate_single_bandflux_sample(source, survey_info, state_bad)
+
+
+def test_simulate_single_bandflux_sample(test_data_dir):
+    """Test that we can simulate a single model sample."""
+    # Load the OpSim data.
+    opsim_db = OpSim.from_db(test_data_dir / "opsim_small.db")
+
+    # Choose the first point for our query ra and dec. Check that not all of the
+    # early entries in the table use this location (would pass a spatial filter).
+    query_ra = opsim_db["ra"].values[0]
+    query_dec = opsim_db["dec"].values[0]
+    ra_delta = np.abs(opsim_db["ra"].values[1:10] - query_ra)
+    dec_delta = np.abs(opsim_db["dec"].values[1:10] - query_dec)
+    assert np.all((ra_delta > 0) | (dec_delta > 0))
+
+    # Load the passband data for the griz filters only.
+    passband_group = PassbandGroup.from_preset(
+        preset="LSST",
+        table_dir=test_data_dir / "passbands",
+        filters=["g", "r", "i", "z"],
+    )
+
+    # Use the default noise model.
+    survey_info = SurveyInfo(obstable=opsim_db, passbands=passband_group)
+
+    # Create a linearly increasing source model.
+    t0 = np.min(opsim_db["time"])
+    source = LinearTimeModel(
+        linear_base=3.0,
+        linear_scale=0.1,
+        t0=t0,
+        ra=query_ra,
+        dec=query_dec,
+        redshift=0.0,
+        node_label="source",
+    )
+
+    # Do a single sample without indices. Only the first observation should spatially match.
+    rng1 = np.random.default_rng(12345)
+    state1 = source.sample_parameters(num_samples=1, rng_info=rng1)
+    results1 = simulate_single_bandflux_sample(source, survey_info, state1, rng_info=rng1)
+    assert len(results1["flux"]) != 10
+
+    # Do a sample with the first 10 indices.
+    rng2 = np.random.default_rng(12345)
+    state2 = source.sample_parameters(num_samples=1, rng_info=rng2)
+    assert state1 == state2
+    results2 = simulate_single_bandflux_sample(
+        source, survey_info, state2, rng_info=rng2, indices=np.arange(10)
+    )
+    assert len(results2["flux"]) == 10
+
+    # Check that we evaluated the model on the first 10 times regardless of spatial matching.
+    all_times = np.sort(opsim_db["time"].values)
+    expected_flux = 3.0 + 0.1 * (all_times[:10] - t0)
+    assert np.allclose(results2["flux_perfect"], expected_flux)
 
 
 def test_simulate_lightcurves(test_data_dir):

--- a/tests/lightcurvelynx/test_simulate.py
+++ b/tests/lightcurvelynx/test_simulate.py
@@ -38,9 +38,9 @@ from lightcurvelynx.simulate import (
     SimulationInfo,
     compute_noise_free_lightcurves,
     compute_single_noise_free_lightcurve,
+    evaluate_single_bandflux_given_indices,
     get_time_windows,
     simulate_lightcurves,
-    simulate_single_bandflux_sample,
 )
 from lightcurvelynx.survey_info import SurveyInfo
 from nested_pandas import NestedFrame, read_parquet
@@ -371,80 +371,7 @@ def test_simulation_info_graph_state():
         )
 
 
-def test_simulate_single_bandflux_sample_indices(test_data_dir):
-    """Test that we can simulate a single model sample with given indices."""
-    # Load the OpSim data.
-    opsim_db = OpSim.from_db(test_data_dir / "opsim_small.db")
-
-    # Load the passband data for the griz filters only.
-    passband_group = PassbandGroup.from_preset(
-        preset="LSST",
-        table_dir=test_data_dir / "passbands",
-        filters=["g", "r", "i", "z"],
-    )
-
-    # Use the default noise model.
-    survey_info = SurveyInfo(obstable=opsim_db, passbands=passband_group)
-
-    # Create a constant SED model with known brightnesses and RA, dec
-    # values that match the opsim.
-    given_brightness = [1000.0, 2000.0, 5000.0, 1000.0, 100.0]
-    source = ConstantSEDModel(
-        brightness=GivenValueList(given_brightness),
-        t0=0.0,
-        ra=GivenValueList(opsim_db["ra"].values[0:5]),
-        dec=GivenValueList(opsim_db["dec"].values[0:5]),
-        redshift=0.0,
-        node_label="source",
-    )
-
-    # Do a single sample.
-    rng = np.random.default_rng(12345)
-    state = source.sample_parameters(num_samples=1)
-    results = simulate_single_bandflux_sample(source, survey_info, state, rng_info=rng)
-    assert len(results["flux_perfect"]) > 1
-    assert "flux" in results
-    assert "fluxerr" in results
-    assert "is_saturated" in results
-    assert "mjd" in results
-    assert "filter" in results
-
-    # Do a second sample with the same state, but a different random number state.
-    # The flux_perfect and noise should be the same, but the noisy flux should be different.
-    rng2 = np.random.default_rng(67890)
-    results2 = simulate_single_bandflux_sample(source, survey_info, state, rng_info=rng2)
-    assert np.allclose(results["flux_perfect"], results2["flux_perfect"])
-    assert np.allclose(results["fluxerr"], results2["fluxerr"])
-    assert not np.allclose(results["flux"], results2["flux"])
-
-    # But we can get the same everything if we use the same random number generator.
-    rng3 = np.random.default_rng(12345)
-    results3 = simulate_single_bandflux_sample(source, survey_info, state, rng_info=rng3)
-    assert np.allclose(results["flux_perfect"], results3["flux_perfect"])
-    assert np.allclose(results["fluxerr"], results3["fluxerr"])
-    assert np.allclose(results["flux"], results3["flux"])
-
-    # We can limit the time window to just the first observation.
-    first_time = np.min(opsim_db["time"].values)
-    rng4 = np.random.default_rng(12345)
-    results4 = simulate_single_bandflux_sample(
-        source,
-        survey_info,
-        state,
-        rng_info=rng4,
-        obs_time_window_offset=(first_time - 0.01, first_time + 0.01),
-    )
-    assert len(results4["flux_perfect"]) == 1
-    assert np.allclose(results4["flux_perfect"], results["flux_perfect"][0])
-    assert np.allclose(results4["mjd"], first_time)
-
-    # We fail if we have more than one sample.
-    state_bad = source.sample_parameters(num_samples=2)
-    with pytest.raises(ValueError):
-        _ = simulate_single_bandflux_sample(source, survey_info, state_bad)
-
-
-def test_simulate_single_bandflux_sample(test_data_dir):
+def test_evaluate_single_bandflux_given_indices(test_data_dir):
     """Test that we can simulate a single model sample."""
     # Load the OpSim data.
     opsim_db = OpSim.from_db(test_data_dir / "opsim_small.db")
@@ -478,28 +405,40 @@ def test_simulate_single_bandflux_sample(test_data_dir):
         redshift=0.0,
         node_label="source",
     )
+    state = source.sample_parameters(num_samples=1)
+    inds = np.arange(10)
 
-    # Do a single sample without indices. Only the first observation should spatially match.
-    rng1 = np.random.default_rng(12345)
-    state1 = source.sample_parameters(num_samples=1, rng_info=rng1)
-    results1 = simulate_single_bandflux_sample(source, survey_info, state1, rng_info=rng1)
-    assert len(results1["flux"]) != 10
-
-    # Do a sample with the first 10 indices.
-    rng2 = np.random.default_rng(12345)
-    state2 = source.sample_parameters(num_samples=1, rng_info=rng2)
-    assert state1 == state2
-    results2 = simulate_single_bandflux_sample(
-        source, survey_info, state2, rng_info=rng2, indices=np.arange(10)
-    )
-    assert len(results2["flux"]) == 10
+    # Do a single sample with given indices.
+    rng = np.random.default_rng(12345)
+    results = evaluate_single_bandflux_given_indices(source, survey_info, state, inds, rng_info=rng)
+    assert len(results["mjd"]) == 10
+    assert len(results["filter"]) == 10
+    assert len(results["flux_perfect"]) == 10
+    assert len(results["fluxerr"]) == 10
+    assert len(results["flux"]) == 10
+    assert len(results["is_saturated"]) == 10
 
     # Check that we evaluated the model on the first 10 times regardless of spatial matching.
     all_times = opsim_db["time"].to_numpy()
     expected_flux = 3.0 + 0.1 * (all_times[:10] - t0)
-    assert np.allclose(results2["flux_perfect"], expected_flux)
-    assert np.allclose(results2["mjd"], all_times[:10])
-    assert np.array_equal(results2["filter"], opsim_db["filter"].values[:10])
+    assert np.allclose(results["flux_perfect"], expected_flux)
+    assert np.allclose(results["mjd"], all_times[:10])
+    assert np.array_equal(results["filter"], opsim_db["filter"].values[:10])
+    assert not np.any(results["is_saturated"])
+
+    # If we use the same state and random number generator, we get the same result.
+    rng2 = np.random.default_rng(12345)
+    results2 = evaluate_single_bandflux_given_indices(source, survey_info, state, inds, rng_info=rng2)
+    assert np.allclose(results["flux_perfect"], results2["flux_perfect"])
+    assert np.allclose(results["fluxerr"], results2["fluxerr"])
+    assert np.allclose(results["flux"], results2["flux"])
+
+    # If we use a different random number generator, we get the same perfect flux_perfect
+    # (because we are using the same state) but different flux.
+    rng3 = np.random.default_rng(67890)
+    results3 = evaluate_single_bandflux_given_indices(source, survey_info, state, inds, rng_info=rng3)
+    assert np.allclose(results["flux_perfect"], results3["flux_perfect"])
+    assert not np.allclose(results["flux"], results3["flux"])
 
 
 def test_simulate_lightcurves(test_data_dir):

--- a/tests/lightcurvelynx/test_simulate.py
+++ b/tests/lightcurvelynx/test_simulate.py
@@ -406,6 +406,8 @@ def test_simulate_single_bandflux_sample_indices(test_data_dir):
     assert "flux" in results
     assert "fluxerr" in results
     assert "is_saturated" in results
+    assert "mjd" in results
+    assert "filter" in results
 
     # Do a second sample with the same state, but a different random number state.
     # The flux_perfect and noise should be the same, but the noisy flux should be different.
@@ -434,6 +436,7 @@ def test_simulate_single_bandflux_sample_indices(test_data_dir):
     )
     assert len(results4["flux_perfect"]) == 1
     assert np.allclose(results4["flux_perfect"], results["flux_perfect"][0])
+    assert np.allclose(results4["mjd"], first_time)
 
     # We fail if we have more than one sample.
     state_bad = source.sample_parameters(num_samples=2)
@@ -492,9 +495,11 @@ def test_simulate_single_bandflux_sample(test_data_dir):
     assert len(results2["flux"]) == 10
 
     # Check that we evaluated the model on the first 10 times regardless of spatial matching.
-    all_times = np.sort(opsim_db["time"].values)
+    all_times = opsim_db["time"].to_numpy()
     expected_flux = 3.0 + 0.1 * (all_times[:10] - t0)
     assert np.allclose(results2["flux_perfect"], expected_flux)
+    assert np.allclose(results2["mjd"], all_times[:10])
+    assert np.array_equal(results2["filter"], opsim_db["filter"].values[:10])
 
 
 def test_simulate_lightcurves(test_data_dir):


### PR DESCRIPTION
Break out the core evaluation step of computing bandfluxes for a single sample of a single survey. This allows the possibility of calling just the evaluation from other code (specifically Rubin's metric analysis framework). The functionality of the current workflow is unchanged.